### PR TITLE
*: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ protobuf = "=2.8.0"
 quick-error = "1.2.2"
 serde = "1.0"
 serde_derive = "1.0"
-crc32c = "0.4.0"
-log = { version = "0.3", features = ["max_level_trace", "release_max_level_debug"] }
+crc32fast = "1.2"
+log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 compress = "0.1"
 byteorder = "1.2"
 errno = "0.2.4"
@@ -25,7 +25,7 @@ lazy_static = "1.3"
 fxhash = "0.2"
 
 [dependencies.prometheus]
-version = "0.4.2"
+version = "0.9"
 default-features = false
 features = ["nightly", "push", "process"]
 
@@ -37,6 +37,3 @@ default-features = false
 git = "https://github.com/pingcap/raft-rs"
 branch = "master"
 default-features = false
-
-[dependencies.prometheus-static-metric]
-version = "0.1.4"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -102,7 +102,7 @@ impl FileEngineInner {
                 match LogBatch::from_bytes(&mut buf, current_read_file, offset) {
                     Ok(Some(log_batch)) => {
                         self.apply_to_memtable(log_batch, current_read_file);
-                        offset = unsafe { buf.as_ptr().offset_from(start_ptr) as u64 };
+                        offset = (buf.as_ptr() as usize - start_ptr as usize) as u64;
                     }
                     Ok(None) => {
                         info!("Recovered raft log file {}.", current_read_file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(ptr_offset_from)]
 #![allow(clippy::missing_safety_doc)]
 
 #[macro_use]


### PR DESCRIPTION
- get rid of old version of spin, which is vulnerable
- use the same crc library as TiKV
- make it compile and test using stable rust
