### PR TITLE
prometheus: remove unnecessary features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ fxhash = "0.2"
 [dependencies.prometheus]
 version = "0.8"
 default-features = false
-features = ["nightly", "push", "process"]
+features = ["nightly"]
 
 [dependencies.kvproto]
 git = "https://github.com/pingcap/kvproto.git"


### PR DESCRIPTION
All those features are not used and can make TiKV fail to compile.
