### PR TITLE
make pipe_log.rs more simple and clear

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -65,10 +65,4 @@ impl From<Error> for raft::Error {
     }
 }
 
-impl From<nix::Error> for Error {
-    fn from(err: nix::Error) -> Error {
-        raft::StorageError::Other(err.into()).into()
-    }
-}
-
 pub type Result<T> = ::std::result::Result<T, Error>;


### PR DESCRIPTION
This PR trys to simplify `pipe_log.rs` and make it more clear. So that we can introduce other improvements easilier.