### PR TITLE
Prevent using fallocate on platforms other than linux

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,15 +11,17 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v2
       - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-07-01-x86_64-unknown-linux-gnu
+          toolchain: nightly-2020-07-01
           override: true
           components: clippy
       - name: Clippy

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -7,7 +7,9 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::{cmp, u64};
 
 use nix::errno::Errno;
-use nix::fcntl::{self, fallocate, OFlag};
+#[cfg(target_os = "linux")]
+use nix::fcntl::fallocate;
+use nix::fcntl::{self, OFlag};
 use nix::sys::stat::Mode;
 use nix::sys::uio::{pread, pwrite};
 use nix::unistd::{close, fsync, ftruncate, lseek, Whence};
@@ -34,14 +36,17 @@ const INIT_FILE_NUM: u64 = 1;
 pub const FILE_MAGIC_HEADER: &[u8] = b"RAFT-LOG-FILE-HEADER-9986AB3E47F320B394C8E84916EB0ED5";
 pub const VERSION: &[u8] = b"v1.0.0";
 const DEFAULT_FILES_COUNT: usize = 32;
+#[cfg(target_os = "linux")]
 const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
 
 struct LogFd(RawFd);
+
 impl LogFd {
     fn close(&self) -> Result<()> {
         close(self.0).map_err(|e| parse_nix_error(e, "close"))
     }
 }
+
 impl Drop for LogFd {
     fn drop(&mut self) {
         if let Err(e) = self.close() {
@@ -190,6 +195,8 @@ impl LogManager {
         let fd = self.get_active_fd().unwrap();
 
         self.active_log_size += content_len;
+
+        #[cfg(target_os = "linux")]
         if self.active_log_size > self.active_log_capacity {
             // Use fallocate to pre-allocate disk space for active file.
             let reserve = self.active_log_size - self.active_log_capacity;

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -7,8 +7,6 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use std::{cmp, u64};
 
 use nix::errno::Errno;
-#[cfg(target_os = "linux")]
-use nix::fcntl::fallocate;
 use nix::fcntl::{self, OFlag};
 use nix::sys::stat::Mode;
 use nix::sys::uio::{pread, pwrite};
@@ -201,7 +199,7 @@ impl LogManager {
             // Use fallocate to pre-allocate disk space for active file.
             let reserve = self.active_log_size - self.active_log_capacity;
             let alloc_size = cmp::max(reserve, FILE_ALLOCATE_SIZE);
-            fallocate(
+            fcntl::fallocate(
                 fd.0,
                 fcntl::FallocateFlags::FALLOC_FL_KEEP_SIZE,
                 self.active_log_capacity as _,


### PR DESCRIPTION
`fallocate` works only under linux, and many of our developers are not using linux.
Currently `fallocate` is always on, which prevent raft-engine and crates depends on it from building, eg. [tikv#8570](https://github.com/tikv/tikv/issues/8570).

This pr and `cfg`s to enable fallocate only on linux.

This should close #34.