### PR TITLE
clean regions from rewrite queue

### DIFF
--- a/src/cache_evict.rs
+++ b/src/cache_evict.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 use crossbeam::channel::{bounded, Sender};
 use protobuf::Message;
 
-use crate::engine::{MemTableAccessor};
-use crate::GlobalStats;
+use crate::engine::MemTableAccessor;
 use crate::log_batch::{EntryExt, LogBatch, LogItemContent};
 use crate::pipe_log::{GenericPipeLog, LogQueue};
 use crate::util::{HandyRwLock, Runnable, Scheduler};
+use crate::GlobalStats;
 
 pub const DEFAULT_CACHE_CHUNK_SIZE: usize = 4 * 1024 * 1024;
 

--- a/src/cache_evict.rs
+++ b/src/cache_evict.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use crossbeam::channel::{bounded, Sender};
 use protobuf::Message;
 
-use crate::engine::{MemTableAccessor, SharedCacheStats};
+use crate::engine::{MemTableAccessor};
+use crate::GlobalStats;
 use crate::log_batch::{EntryExt, LogBatch, LogItemContent};
 use crate::pipe_log::{GenericPipeLog, LogQueue};
 use crate::util::{HandyRwLock, Runnable, Scheduler};
@@ -30,7 +31,7 @@ pub struct CacheSubmitor {
     scheduler: Scheduler<CacheTask>,
     cache_limit: usize,
     chunk_limit: usize,
-    cache_stats: Arc<SharedCacheStats>,
+    global_stats: Arc<GlobalStats>,
     block_on_full: bool,
 }
 
@@ -39,7 +40,7 @@ impl CacheSubmitor {
         cache_limit: usize,
         chunk_limit: usize,
         scheduler: Scheduler<CacheTask>,
-        cache_stats: Arc<SharedCacheStats>,
+        global_stats: Arc<GlobalStats>,
     ) -> Self {
         CacheSubmitor {
             file_num: 0,
@@ -49,7 +50,7 @@ impl CacheSubmitor {
             scheduler,
             cache_limit,
             chunk_limit,
-            cache_stats,
+            global_stats,
             block_on_full: false,
         }
     }
@@ -96,7 +97,7 @@ impl CacheSubmitor {
         }
 
         if self.block_on_full {
-            let cache_size = self.cache_stats.cache_size();
+            let cache_size = self.global_stats.cache_size();
             if cache_size > self.cache_limit {
                 let (tx, rx) = bounded(1);
                 if self.scheduler.schedule(CacheTask::EvictOldest(tx)).is_ok() {
@@ -107,7 +108,7 @@ impl CacheSubmitor {
 
         self.chunk_size += size;
         self.size_tracker.fetch_add(size, Ordering::Release);
-        self.cache_stats.add_mem_change(size);
+        self.global_stats.add_mem_change(size);
         Some(self.size_tracker.clone())
     }
 
@@ -126,7 +127,7 @@ where
     P: GenericPipeLog,
 {
     cache_limit: usize,
-    cache_stats: Arc<SharedCacheStats>,
+    global_stats: Arc<GlobalStats>,
     chunk_limit: usize,
     valid_cache_chunks: VecDeque<CacheChunk>,
     memtables: MemTableAccessor<E, W>,
@@ -141,14 +142,14 @@ where
 {
     pub fn new(
         cache_limit: usize,
-        cache_stats: Arc<SharedCacheStats>,
+        global_stats: Arc<GlobalStats>,
         chunk_limit: usize,
         memtables: MemTableAccessor<E, W>,
         pipe_log: P,
     ) -> Runner<E, W, P> {
         Runner {
             cache_limit,
-            cache_stats,
+            global_stats,
             chunk_limit,
             valid_cache_chunks: Default::default(),
             memtables,
@@ -157,7 +158,7 @@ where
     }
 
     fn retain_valid_cache(&mut self) {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         if self.valid_cache_chunks.len() * self.chunk_limit >= cache_size * 3 {
             // There could be many empty chunks.
             self.valid_cache_chunks
@@ -169,12 +170,12 @@ where
     }
 
     fn cache_reach_high_water(&self) -> bool {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         cache_size > (self.cache_limit as f64 * HIGH_WATER_RATIO) as usize
     }
 
     fn cache_reach_low_water(&self) -> bool {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         cache_size <= (self.cache_limit as f64 * LOW_WATER_RATIO) as usize
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -18,7 +18,7 @@ use crate::memtable::{EntryIndex, MemTable};
 use crate::pipe_log::{GenericPipeLog, LogQueue, PipeLog, FILE_MAGIC_HEADER, VERSION};
 use crate::purge::PurgeManager;
 use crate::util::{HandyRwLock, HashMap, Worker};
-use crate::{codec, GlobalStats, CacheStats, Result};
+use crate::{codec, CacheStats, GlobalStats, Result};
 
 const SLOTS_COUNT: usize = 128;
 
@@ -285,14 +285,13 @@ where
         );
         cache_evict_worker.start(cache_evict_runner, Some(Duration::from_secs(1)));
 
-        let recovery_mode = cfg.recovery_mode;
         Engine::recover(
             LogQueue::Rewrite,
             &pipe_log,
             &memtables,
             RecoveryMode::TolerateCorruptedTailRecords,
         )?;
-        Engine::recover(LogQueue::Append, &pipe_log, &memtables, recovery_mode)?;
+        Engine::recover(LogQueue::Append, &pipe_log, &memtables, cfg.recovery_mode)?;
         pipe_log.cache_submitor().nonblock_on_full();
 
         let cfg = Arc::new(cfg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,15 @@ impl GlobalStats {
         self.cache_size.store(0, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::log_batch::EntryExt;
+    use raft::eraftpb::Entry;
+
+    impl EntryExt<Entry> for Entry {
+        fn index(e: &Entry) -> u64 {
+            e.get_index()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,11 @@ pub struct GlobalStats {
     cache_hit: AtomicUsize,
     cache_miss: AtomicUsize,
     cache_size: AtomicUsize,
+
+    // How many operations in the rewrite queue.
+    rewrite_operations: AtomicUsize,
+    // How many compacted operations in the rewrite queue.
+    compacted_rewrite_operations: AtomicUsize,
 }
 
 impl GlobalStats {
@@ -77,6 +82,20 @@ impl GlobalStats {
             miss: self.cache_miss.swap(0, Ordering::SeqCst),
             cache_size: self.cache_size.load(Ordering::SeqCst),
         }
+    }
+
+    pub fn add_rewrite(&self, count: usize) {
+        self.rewrite_operations.fetch_add(count, Ordering::Release);
+    }
+    pub fn add_compacted_rewrite(&self, count: usize) {
+        self.compacted_rewrite_operations
+            .fetch_add(count, Ordering::Release);
+    }
+    pub fn rewrite_operations(&self) -> usize {
+        self.rewrite_operations.load(Ordering::Acquire)
+    }
+    pub fn compacted_rewrite_operations(&self) -> usize {
+        self.compacted_rewrite_operations.load(Ordering::Acquire)
     }
 
     #[cfg(test)]

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -669,8 +669,8 @@ mod tests {
 
     use super::*;
     use crate::cache_evict::{CacheSubmitor, CacheTask};
-    use crate::GlobalStats;
     use crate::util::{ReadableSize, Worker};
+    use crate::GlobalStats;
 
     fn new_test_pipe_log(
         path: &str,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -669,7 +669,7 @@ mod tests {
 
     use super::*;
     use crate::cache_evict::{CacheSubmitor, CacheTask};
-    use crate::engine::SharedCacheStats;
+    use crate::GlobalStats;
     use crate::util::{ReadableSize, Worker};
 
     fn new_test_pipe_log(
@@ -683,7 +683,7 @@ mod tests {
         cfg.target_file_size = ReadableSize(rotate_size as u64);
 
         let mut worker = Worker::new("test".to_owned(), None);
-        let stats = Arc::new(SharedCacheStats::default());
+        let stats = Arc::new(GlobalStats::default());
         let submitor = CacheSubmitor::new(usize::MAX, 4096, worker.scheduler(), stats);
         let log = PipeLog::open(&cfg, submitor).unwrap();
         (log, worker.take_receiver())


### PR DESCRIPTION
It's possible for a region:
1. rewrite some entries and kvs into the rewrite queue
2. then the region has been removed from the engine
3. The log contains the `Command::Clean` for the region has been purged.
4. The regine restarts, the removed region appears again because there are some entires in the rewrite queue.

This PR resolves it. The `Command::Clean` will be written into the rewrite queue before the append queue has been purged.