### PR TITLE
clean regions from rewrite queue

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -145,7 +145,10 @@ where
                     }
                 }
                 LogItemContent::Command(Command::Clean) => {
-                    if self.memtables.remove(item.raft_group_id).is_some() {}
+                    if self.memtables.remove(item.raft_group_id).is_some() {
+                        self.purge_manager
+                            .remove_memtable(file_num, item.raft_group_id);
+                    }
                 }
                 LogItemContent::Command(Command::Compact { index }) => {
                     memtable.wl().compact_to(index);
@@ -545,6 +548,17 @@ mod tests {
     use crate::util::ReadableSize;
     use raft::eraftpb::Entry;
 
+    impl<E, W, P> Engine<E, W, P>
+    where
+        E: Message + Clone,
+        W: EntryExt<E> + 'static,
+        P: GenericPipeLog,
+    {
+        pub fn purge_manager(&self) -> &PurgeManager<E, W, P> {
+            &self.purge_manager
+        }
+    }
+
     type RaftLogEngine = Engine<Entry, Entry, PipeLog>;
     impl RaftLogEngine {
         fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize> {
@@ -810,5 +824,65 @@ mod tests {
             new_active_num > active_num
                 || (new_active_num == active_num && new_active_len > active_len)
         );
+    }
+
+    // Raft groups can be removed when they only have entries in the rewrite queue.
+    // We need to ensure that these raft groups won't appear again after recover.
+    #[test]
+    fn test_clean_raft_with_rewrite() {
+        let dir = tempfile::Builder::new()
+            .prefix("test_clean_raft_with_rewrite")
+            .tempdir()
+            .unwrap();
+
+        let mut cfg = Config::default();
+        cfg.dir = dir.path().to_str().unwrap().to_owned();
+        cfg.target_file_size = ReadableSize::kb(5);
+        cfg.purge_threshold = ReadableSize::kb(80);
+        let engine = RaftLogEngine::new(cfg.clone());
+
+        // Put 100 entries into 10 regions.
+        let mut entry = Entry::new();
+        entry.set_data(vec![b'x'; 1024]);
+        for i in 1..=10 {
+            for j in 1..=10 {
+                entry.set_index(j);
+                append_log(&engine, i, &entry);
+            }
+        }
+
+        // The engine needs purge, and all old entries should be rewritten.
+        assert!(engine.purge_manager.needs_purge_log_files());
+        assert!(engine.purge_expired_files().unwrap().is_empty());
+        assert!(engine.pipe_log.first_file_num(LogQueue::Append) > 1);
+
+        // All entries of region 1 has been rewritten.
+        let memtable_1 = engine.memtables.get(1).unwrap();
+        assert!(memtable_1.rl().max_file_num(LogQueue::Append).is_none());
+        assert!(memtable_1.rl().kvs_max_file_num(LogQueue::Append).is_none());
+
+        // Clean a raft group.
+        let mut log_batch = LogBatch::with_capacity(1);
+        log_batch.clean_region(1);
+        engine.write(&mut log_batch, false).unwrap();
+        assert!(engine.memtables.get(1).is_none());
+
+        // Put 100 entries into another 10 regions, and then purge again.
+        let active_file_num = engine.pipe_log.active_file_num(LogQueue::Append);
+        let mut entry = Entry::new();
+        entry.set_data(vec![b'x'; 1024]);
+        for i in 10..=20 {
+            for j in 10..=20 {
+                entry.set_index(j);
+                append_log(&engine, i, &entry);
+            }
+        }
+        assert!(engine.purge_expired_files().unwrap().is_empty());
+        assert!(engine.pipe_log.first_file_num(LogQueue::Append) > active_file_num);
+
+        // After the engine recovers, the removed raft group shouldn't appear again.
+        drop(engine);
+        let engine = RaftLogEngine::new(cfg.clone());
+        assert!(engine.memtables.get(1).is_none());
     }
 }

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -1,12 +1,13 @@
-use std::cmp;
-use std::sync::Arc;
+use std::cmp::{self, Reverse};
+use std::collections::BinaryHeap;
+use std::sync::{Arc, Mutex};
 
 use log::info;
 use protobuf::Message;
 
 use crate::config::Config;
 use crate::engine::{fetch_entries, MemTableAccessor};
-use crate::log_batch::{EntryExt, LogBatch, LogItemContent, OpType};
+use crate::log_batch::{Command, EntryExt, LogBatch, LogItemContent, OpType};
 use crate::pipe_log::{GenericPipeLog, LogQueue};
 use crate::util::HandyRwLock;
 use crate::Result;
@@ -27,6 +28,10 @@ where
     cfg: Arc<Config>,
     memtables: MemTableAccessor<E, W>,
     pipe_log: P,
+
+    // Vector of (file_num, raft_group_id).
+    #[allow(clippy::type_complexity)]
+    removed_memtables: Arc<Mutex<BinaryHeap<(Reverse<u64>, u64)>>>,
 }
 
 impl<E, W, P> PurgeManager<E, W, P>
@@ -44,6 +49,7 @@ where
             cfg,
             memtables,
             pipe_log,
+            removed_memtables: Default::default(),
         }
     }
 
@@ -75,6 +81,11 @@ where
         total_size > purge_threshold
     }
 
+    pub fn remove_memtable(&self, file_num: u64, raft_group_id: u64) {
+        let mut tables = self.removed_memtables.lock().unwrap();
+        tables.push((Reverse(file_num), raft_group_id));
+    }
+
     // Returns (`latest_needs_rewrite`, `latest_needs_force_compact`).
     fn latest_inactive_file_num(&self) -> (u64, u64) {
         let queue = LogQueue::Append;
@@ -96,6 +107,8 @@ where
         (latest_needs_rewrite, latest_needs_compact)
     }
 
+    // FIXME: We need to ensure that all operations before `latest_rewrite` (included) are written
+    // into memtables.
     fn regions_rewrite_or_force_compact(
         &self,
         latest_rewrite: u64,
@@ -103,6 +116,17 @@ where
         will_force_compact: &mut Vec<u64>,
     ) {
         assert!(latest_compact <= latest_rewrite);
+        let mut log_batch = LogBatch::<E, W>::new();
+
+        while let Some(item) = self.removed_memtables.lock().unwrap().pop() {
+            let (file_num, raft_id) = ((item.0).0, item.1);
+            if file_num > latest_rewrite {
+                self.removed_memtables.lock().unwrap().push(item);
+                break;
+            }
+            log_batch.clean_region(raft_id);
+        }
+
         let memtables = self.memtables.collect(|t| {
             let min_file_num = t.min_file_num(LogQueue::Append).unwrap_or(u64::MAX);
             let count = t.entries_count();
@@ -126,18 +150,15 @@ where
                 |t, ents, ents_idx| t.fetch_rewrite_entries(latest_rewrite, ents, ents_idx),
             )
             .unwrap();
+            log_batch.add_entries(region_id, entries);
 
             let mut kvs = Vec::new();
             memtable.rl().fetch_rewrite_kvs(latest_rewrite, &mut kvs);
-
-            let mut log_batch = LogBatch::<E, W>::new();
-            log_batch.add_entries(region_id, entries);
             for (k, v) in kvs {
                 log_batch.put(region_id, k, v);
             }
-
-            self.rewrite_impl(&mut log_batch, latest_rewrite).unwrap();
         }
+        self.rewrite_impl(&mut log_batch, latest_rewrite).unwrap();
     }
 
     fn rewrite_impl(&self, log_batch: &mut LogBatch<E, W>, latest_rewrite: u64) -> Result<()> {
@@ -166,8 +187,47 @@ where
                     OpType::Put => memtable.wl().rewrite_key(kv.key, latest_rewrite, file_num),
                     _ => unreachable!(),
                 },
+                LogItemContent::Command(Command::Clean) => {
+                    // Nothing need to do.
+                }
                 _ => unreachable!(),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::Engine;
+    use crate::pipe_log::PipeLog;
+    use raft::eraftpb::Entry;
+
+    type RaftLogEngine = Engine<Entry, Entry, PipeLog>;
+
+    #[test]
+    fn test_remove_memtable() {
+        let dir = tempfile::Builder::new()
+            .prefix("test_remove_memtable")
+            .tempdir()
+            .unwrap();
+
+        let mut cfg = Config::default();
+        cfg.dir = dir.path().to_str().unwrap().to_owned();
+        let engine = RaftLogEngine::new(cfg.clone());
+
+        engine.purge_manager().remove_memtable(3, 10);
+        engine.purge_manager().remove_memtable(3, 9);
+        engine.purge_manager().remove_memtable(3, 11);
+        engine.purge_manager().remove_memtable(2, 9);
+        engine.purge_manager().remove_memtable(4, 4);
+        engine.purge_manager().remove_memtable(4, 3);
+
+        let mut tables = engine.purge_manager().removed_memtables.lock().unwrap();
+        for (file_num, raft_id) in vec![(2, 9), (3, 11), (3, 10), (3, 9), (4, 4), (4, 3)] {
+            let item = tables.pop().unwrap();
+            assert_eq!((item.0).0, file_num);
+            assert_eq!(item.1, raft_id);
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

It's possible for a region:
1. rewrite some entries and kvs into the rewrite queue
2. then the region has been removed from the engine
3. The log contains the `Command::Clean` for the region has been purged.
4. The regine restarts, the removed region appears again because there are some entires in the rewrite queue.

This PR resolves it. The `Command::Clean` will be written into the rewrite queue before the append queue has been purged.