### PR TITLE
squeeze the rewrite queue if necessary

### DIFF
--- a/src/cache_evict.rs
+++ b/src/cache_evict.rs
@@ -7,11 +7,11 @@ use std::sync::Arc;
 use crossbeam::channel::{bounded, Sender};
 use protobuf::Message;
 
-use crate::engine::{MemTableAccessor};
-use crate::GlobalStats;
+use crate::engine::MemTableAccessor;
 use crate::log_batch::{EntryExt, LogBatch, LogItemContent};
 use crate::pipe_log::{GenericPipeLog, LogQueue};
 use crate::util::{HandyRwLock, Runnable, Scheduler};
+use crate::GlobalStats;
 
 pub const DEFAULT_CACHE_CHUNK_SIZE: usize = 4 * 1024 * 1024;
 

--- a/src/cache_evict.rs
+++ b/src/cache_evict.rs
@@ -7,7 +7,8 @@ use std::sync::Arc;
 use crossbeam::channel::{bounded, Sender};
 use protobuf::Message;
 
-use crate::engine::{MemTableAccessor, SharedCacheStats};
+use crate::engine::{MemTableAccessor};
+use crate::GlobalStats;
 use crate::log_batch::{EntryExt, LogBatch, LogItemContent};
 use crate::pipe_log::{GenericPipeLog, LogQueue};
 use crate::util::{HandyRwLock, Runnable, Scheduler};
@@ -30,7 +31,7 @@ pub struct CacheSubmitor {
     scheduler: Scheduler<CacheTask>,
     cache_limit: usize,
     chunk_limit: usize,
-    cache_stats: Arc<SharedCacheStats>,
+    global_stats: Arc<GlobalStats>,
     block_on_full: bool,
 }
 
@@ -39,7 +40,7 @@ impl CacheSubmitor {
         cache_limit: usize,
         chunk_limit: usize,
         scheduler: Scheduler<CacheTask>,
-        cache_stats: Arc<SharedCacheStats>,
+        global_stats: Arc<GlobalStats>,
     ) -> Self {
         CacheSubmitor {
             file_num: 0,
@@ -49,7 +50,7 @@ impl CacheSubmitor {
             scheduler,
             cache_limit,
             chunk_limit,
-            cache_stats,
+            global_stats,
             block_on_full: false,
         }
     }
@@ -96,7 +97,7 @@ impl CacheSubmitor {
         }
 
         if self.block_on_full {
-            let cache_size = self.cache_stats.cache_size();
+            let cache_size = self.global_stats.cache_size();
             if cache_size > self.cache_limit {
                 let (tx, rx) = bounded(1);
                 if self.scheduler.schedule(CacheTask::EvictOldest(tx)).is_ok() {
@@ -107,7 +108,7 @@ impl CacheSubmitor {
 
         self.chunk_size += size;
         self.size_tracker.fetch_add(size, Ordering::Release);
-        self.cache_stats.add_mem_change(size);
+        self.global_stats.add_mem_change(size);
         Some(self.size_tracker.clone())
     }
 
@@ -126,7 +127,7 @@ where
     P: GenericPipeLog,
 {
     cache_limit: usize,
-    cache_stats: Arc<SharedCacheStats>,
+    global_stats: Arc<GlobalStats>,
     chunk_limit: usize,
     valid_cache_chunks: VecDeque<CacheChunk>,
     memtables: MemTableAccessor<E, W>,
@@ -141,14 +142,14 @@ where
 {
     pub fn new(
         cache_limit: usize,
-        cache_stats: Arc<SharedCacheStats>,
+        global_stats: Arc<GlobalStats>,
         chunk_limit: usize,
         memtables: MemTableAccessor<E, W>,
         pipe_log: P,
     ) -> Runner<E, W, P> {
         Runner {
             cache_limit,
-            cache_stats,
+            global_stats,
             chunk_limit,
             valid_cache_chunks: Default::default(),
             memtables,
@@ -157,7 +158,7 @@ where
     }
 
     fn retain_valid_cache(&mut self) {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         if self.valid_cache_chunks.len() * self.chunk_limit >= cache_size * 3 {
             // There could be many empty chunks.
             self.valid_cache_chunks
@@ -169,12 +170,12 @@ where
     }
 
     fn cache_reach_high_water(&self) -> bool {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         cache_size > (self.cache_limit as f64 * HIGH_WATER_RATIO) as usize
     }
 
     fn cache_reach_low_water(&self) -> bool {
-        let cache_size = self.cache_stats.cache_size();
+        let cache_size = self.global_stats.cache_size();
         cache_size <= (self.cache_limit as f64 * LOW_WATER_RATIO) as usize
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -18,7 +18,7 @@ use crate::memtable::{EntryIndex, MemTable};
 use crate::pipe_log::{GenericPipeLog, LogQueue, PipeLog, FILE_MAGIC_HEADER, VERSION};
 use crate::purge::PurgeManager;
 use crate::util::{HandyRwLock, HashMap, Worker};
-use crate::{codec, GlobalStats, CacheStats, Result};
+use crate::{codec, CacheStats, GlobalStats, Result};
 
 const SLOTS_COUNT: usize = 128;
 
@@ -285,14 +285,13 @@ where
         );
         cache_evict_worker.start(cache_evict_runner, Some(Duration::from_secs(1)));
 
-        let recovery_mode = cfg.recovery_mode;
         Engine::recover(
             LogQueue::Rewrite,
             &pipe_log,
             &memtables,
             RecoveryMode::TolerateCorruptedTailRecords,
         )?;
-        Engine::recover(LogQueue::Append, &pipe_log, &memtables, recovery_mode)?;
+        Engine::recover(LogQueue::Append, &pipe_log, &memtables, cfg.recovery_mode)?;
         pipe_log.cache_submitor().nonblock_on_full();
 
         let cfg = Arc::new(cfg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod util;
 
 use crate::pipe_log::PipeLog;
 
-pub use self::config::Config;
+pub use self::config::{Config, RecoveryMode};
 pub use self::errors::{Error, Result};
 pub use self::log_batch::{EntryExt, LogBatch};
 pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, PipeLog>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,3 +105,15 @@ impl GlobalStats {
         self.cache_size.store(0, Ordering::Relaxed);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::log_batch::EntryExt;
+    use raft::eraftpb::Entry;
+
+    impl EntryExt<Entry> for Entry {
+        fn index(e: &Entry) -> u64 {
+            e.get_index()
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,11 @@ pub struct GlobalStats {
     cache_hit: AtomicUsize,
     cache_miss: AtomicUsize,
     cache_size: AtomicUsize,
+
+    // How many operations in the rewrite queue.
+    rewrite_operations: AtomicUsize,
+    // How many compacted operations in the rewrite queue.
+    compacted_rewrite_operations: AtomicUsize,
 }
 
 impl GlobalStats {
@@ -77,6 +82,20 @@ impl GlobalStats {
             miss: self.cache_miss.swap(0, Ordering::SeqCst),
             cache_size: self.cache_size.load(Ordering::SeqCst),
         }
+    }
+
+    pub fn add_rewrite(&self, count: usize) {
+        self.rewrite_operations.fetch_add(count, Ordering::Release);
+    }
+    pub fn add_compacted_rewrite(&self, count: usize) {
+        self.compacted_rewrite_operations
+            .fetch_add(count, Ordering::Release);
+    }
+    pub fn rewrite_operations(&self) -> usize {
+        self.rewrite_operations.load(Ordering::Acquire)
+    }
+    pub fn compacted_rewrite_operations(&self) -> usize {
+        self.compacted_rewrite_operations.load(Ordering::Acquire)
     }
 
     #[cfg(test)]

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -94,6 +94,17 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         distance
     }
 
+    fn adjust_rewrite_count(&mut self, new_rewrite_count: usize) {
+        let rewrite_delta = new_rewrite_count as i64 - self.rewrite_count as i64;
+        self.rewrite_count = new_rewrite_count;
+        if rewrite_delta >= 0 {
+            self.global_stats.add_rewrite(rewrite_delta as usize);
+        } else {
+            let rewrite_delta = -rewrite_delta as usize;
+            self.global_stats.add_compacted_rewrite(rewrite_delta);
+        }
+    }
+
     // Remove all cached entries with index greater than or equal to the given.
     fn cut_entries_cache(&mut self, index: u64) {
         if self.entries_cache.is_empty() {
@@ -124,9 +135,9 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
     }
 
     // Remove all entry indexes with index greater than or equal to the given.
-    fn cut_entries_index(&mut self, index: u64) {
+    fn cut_entries_index(&mut self, index: u64) -> usize {
         if self.entries_index.is_empty() {
-            return;
+            return 0;
         }
         let last_index = self.entries_index.back().unwrap().index;
         let first_index = self.entries_index.front().unwrap().index;
@@ -134,14 +145,13 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         let conflict = if index <= last_index {
             (index - first_index) as usize
         } else {
-            return;
+            return 0;
         };
         self.entries_index.truncate(conflict);
 
-        let old_rewrite_count = self.rewrite_count;
-        self.rewrite_count = cmp::min(self.rewrite_count, self.entries_index.len());
-        let rewrite_sub = old_rewrite_count - self.rewrite_count;
-        self.global_stats.add_compacted_rewrite(rewrite_sub);
+        let new_rewrite_count = cmp::min(self.rewrite_count, self.entries_index.len());
+        self.adjust_rewrite_count(new_rewrite_count);
+        (last_index - index + 1) as usize
     }
 
     fn shrink_entries_cache(&mut self) {
@@ -223,42 +233,78 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         }
         self.append(entries, entries_index);
 
-        let old_rewrite_count = self.rewrite_count;
-        self.rewrite_count = self.entries_index.len();
-        let rewrite_add = self.rewrite_count - old_rewrite_count;
-        self.global_stats.add_rewrite(rewrite_add);
+        let new_rewrite_count = self.entries_index.len();
+        self.adjust_rewrite_count(new_rewrite_count);
     }
 
-    pub fn rewrite(&mut self, entries_index: Vec<EntryIndex>, latest_rewrite: u64) {
-        if entries_index.is_empty() || self.entries_index.is_empty() {
-            return;
+    pub fn rewrite(&mut self, entries_index: Vec<EntryIndex>, latest_rewrite: Option<u64>) {
+        if !entries_index.is_empty() {
+            self.global_stats.add_rewrite(entries_index.len());
+            let compacted_rewrite = self.rewrite_impl(entries_index, latest_rewrite);
+            self.global_stats.add_compacted_rewrite(compacted_rewrite);
+        }
+    }
+
+    // Try to rewrite some entries which have already been written into the rewrite queue.
+    // However some are not necessary any more, so that return `compacted_rewrite_operations`.
+    fn rewrite_impl(
+        &mut self,
+        mut entries_index: Vec<EntryIndex>,
+        latest_rewrite: Option<u64>,
+    ) -> usize {
+        if self.entries_index.is_empty() {
+            // All entries are compacted.
+            return entries_index.len();
         }
 
-        let first = entries_index.first().unwrap().index;
-        let front = self.entries_index[self.rewrite_count].index;
-        assert!(front >= first);
-        let distance = (front - first) as usize;
-        if distance >= entries_index.len() {
-            return;
-        }
+        let mut compacted_rewrite_operations = 0;
 
-        let last = entries_index.last().unwrap().index;
+        let front = self.entries_index.front().unwrap().index;
         let back = self.entries_index.back().unwrap().index;
-        let len = (cmp::min(last, back) - entries_index[distance].index + 1) as usize;
+        let mut first = entries_index.first().unwrap().index;
+        debug_assert!(first <= self.entries_index[self.rewrite_count].index);
+        let last = entries_index.last().unwrap().index;
 
-        let old_rewrite_count = 0;
-        for ei in entries_index.iter().skip(distance).take(len) {
-            if self.entries_index[self.rewrite_count].file_num > latest_rewrite {
-                // Some entries are overwritten by new appends.
-                break;
-            }
-            self.entries_index[self.rewrite_count].queue = ei.queue;
-            self.entries_index[self.rewrite_count].file_num = ei.file_num;
-            self.entries_index[self.rewrite_count].base_offset = ei.base_offset;
-            self.rewrite_count += 1;
+        if last < front {
+            // All rewritten entries are compacted.
+            return entries_index.len();
         }
-        let rewrite_add = self.rewrite_count - old_rewrite_count;
-        self.global_stats.add_rewrite(rewrite_add);
+
+        if first < front {
+            // Some of head entries in `entries_index` are compacted.
+            let offset = (front - first) as usize;
+            entries_index.drain(..offset);
+            first = entries_index.first().unwrap().index;
+            compacted_rewrite_operations += offset;
+        }
+
+        let distance = (first - front) as usize;
+        let len = (cmp::min(last, back) - first + 1) as usize;
+        for (i, ei) in entries_index.iter().take(len).enumerate() {
+            if let Some(latest_rewrite) = latest_rewrite {
+                debug_assert_eq!(self.entries_index[i + distance].queue, LogQueue::Append);
+                if self.entries_index[i + distance].file_num > latest_rewrite {
+                    // Some entries are overwritten by new appends.
+                    compacted_rewrite_operations += entries_index.len() - i;
+                    break;
+                }
+            } else {
+                // It's a squeeze operation.
+                debug_assert_eq!(self.entries_index[i + distance].queue, LogQueue::Rewrite);
+            }
+
+            if self.entries_index[i + distance].queue != LogQueue::Rewrite {
+                debug_assert_eq!(ei.queue, LogQueue::Rewrite);
+                self.entries_index[i + distance].queue = LogQueue::Rewrite;
+                self.rewrite_count += 1;
+            }
+
+            self.entries_index[i + distance].file_num = ei.file_num;
+            self.entries_index[i + distance].base_offset = ei.base_offset;
+            self.entries_index[i + distance].compression_type = ei.compression_type;
+            self.entries_index[i + distance].batch_len = ei.batch_len;
+        }
+        compacted_rewrite_operations
     }
 
     pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>, file_num: u64) {
@@ -269,13 +315,26 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         }
     }
 
-    pub fn rewrite_key(&mut self, key: Vec<u8>, latest_rewrite: u64, file_num: u64) {
+    pub fn rewrite_key(&mut self, key: Vec<u8>, latest_rewrite: Option<u64>, file_num: u64) {
+        self.global_stats.add_rewrite(1);
         if let Some(value) = self.kvs.get_mut(&key) {
-            if value.2 <= latest_rewrite {
-                value.1 = LogQueue::Rewrite;
+            if value.1 == LogQueue::Append {
+                if let Some(latest_rewrite) = latest_rewrite {
+                    if value.2 <= latest_rewrite {
+                        value.1 = LogQueue::Rewrite;
+                        value.2 = file_num;
+                    }
+                } else {
+                    // The rewritten key/value pair has been overwritten.
+                    self.global_stats.add_compacted_rewrite(1);
+                }
+            } else {
+                assert!(value.2 <= file_num);
                 value.2 = file_num;
-                self.global_stats.add_rewrite(1);
             }
+        } else {
+            // The rewritten key/value pair has been compacted.
+            self.global_stats.add_compacted_rewrite(1);
         }
     }
 
@@ -311,9 +370,7 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         self.shrink_entries_index();
 
         let rewrite_sub = cmp::min(drain_end, self.rewrite_count);
-        self.rewrite_count -= rewrite_sub;
-        self.global_stats.add_compacted_rewrite(rewrite_sub);
-
+        self.adjust_rewrite_count(self.rewrite_count - rewrite_sub);
         drain_end as u64
     }
 
@@ -455,9 +512,30 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         Ok(())
     }
 
+    pub fn fetch_entries_from_rewrite(
+        &self,
+        vec: &mut Vec<E>,
+        vec_idx: &mut Vec<EntryIndex>,
+    ) -> Result<()> {
+        if self.rewrite_count > 0 {
+            let end = self.entries_index[self.rewrite_count].index;
+            let first = self.entries_index.front().unwrap().index;
+            return self.fetch_entries_to(first, end, None, vec, vec_idx);
+        }
+        Ok(())
+    }
+
     pub fn fetch_rewrite_kvs(&self, latest_rewrite: u64, vec: &mut Vec<(Vec<u8>, Vec<u8>)>) {
         for (key, (value, queue, file_num)) in &self.kvs {
             if *queue == LogQueue::Append && *file_num <= latest_rewrite {
+                vec.push((key.clone(), value.clone()));
+            }
+        }
+    }
+
+    pub fn fetch_kvs_from_rewrite(&self, vec: &mut Vec<(Vec<u8>, Vec<u8>)>) {
+        for (key, (value, queue, _)) in &self.kvs {
+            if *queue == LogQueue::Rewrite {
                 vec.push((key.clone(), value.clone()));
             }
         }
@@ -919,6 +997,50 @@ mod tests {
     }
 
     #[test]
+    fn test_memtable_fetch_rewrite() {
+        let region_id = 8;
+        let cache_limit = 0;
+        let stats = Arc::new(GlobalStats::default());
+        let mut memtable = MemTable::<Entry, Entry>::new(region_id, cache_limit, stats.clone());
+
+        // After appending:
+        // [0, 10) file_num = 1
+        // [10, 20) file_num = 2
+        // [20, 30) file_num = 3
+        memtable.append(generate_ents(0, 10), generate_ents_index(0, 10, 1));
+        memtable.put(b"k1".to_vec(), b"v1".to_vec(), 1);
+        memtable.append(generate_ents(10, 20), generate_ents_index(10, 20, 2));
+        memtable.put(b"k2".to_vec(), b"v2".to_vec(), 2);
+        memtable.append(generate_ents(20, 25), generate_ents_index(20, 25, 3));
+        memtable.put(b"k3".to_vec(), b"v3".to_vec(), 3);
+
+        // After rewriting:
+        // [0, 10) queue = rewrite, file_num = 50,
+        // [10, 20) file_num = 2
+        // [20, 30) file_num = 3
+        memtable.rewrite(generate_rewrite_ents_index(0, 10, 50), Some(1));
+        memtable.rewrite_key(b"k1".to_vec(), Some(1), 50);
+
+        let (mut ents, mut ents_idx) = (vec![], vec![]);
+
+        assert!(memtable
+            .fetch_rewrite_entries(2, &mut ents, &mut ents_idx)
+            .is_ok());
+        assert_eq!(ents_idx.len(), 10);
+        assert_eq!(ents_idx.first().unwrap().index, 10);
+        assert_eq!(ents_idx.last().unwrap().index, 19);
+
+        ents.clear();
+        ents_idx.clear();
+        assert!(memtable
+            .fetch_entries_from_rewrite(&mut ents, &mut ents_idx)
+            .is_ok());
+        assert_eq!(ents_idx.len(), 10);
+        assert_eq!(ents_idx.first().unwrap().index, 0);
+        assert_eq!(ents_idx.last().unwrap().index, 9);
+    }
+
+    #[test]
     fn test_memtable_kv_operations() {
         let region_id = 8;
         let cache_limit = 1024;
@@ -979,7 +1101,7 @@ mod tests {
         memtable.append(generate_ents(20, 30), generate_ents_index(20, 30, 3));
         memtable.put(b"kk2".to_vec(), b"vv2".to_vec(), 3);
         memtable.append(generate_ents(30, 40), generate_ents_index(30, 40, 4));
-        memtable.put(b"kk2".to_vec(), b"vv3".to_vec(), 4);
+        memtable.put(b"kk3".to_vec(), b"vv3".to_vec(), 4);
 
         assert_eq!(memtable.cache_size, 15);
         assert_eq!(memtable.entries_size(), 30);
@@ -988,75 +1110,97 @@ mod tests {
         memtable.check_entries_index_and_cache();
 
         // Rewrite compacted entries.
-        memtable.rewrite(generate_rewrite_ents_index(1, 10, 50), 1);
-        memtable.rewrite_key(b"kk0".to_vec(), 1, 50);
+        memtable.rewrite(generate_rewrite_ents_index(0, 10, 50), Some(1));
+        memtable.rewrite_key(b"kk0".to_vec(), Some(1), 50);
         assert_eq!(memtable.min_file_num(LogQueue::Append).unwrap(), 2);
         assert_eq!(memtable.max_file_num(LogQueue::Append).unwrap(), 4);
         assert!(memtable.min_file_num(LogQueue::Rewrite).is_none());
         assert!(memtable.max_file_num(LogQueue::Rewrite).is_none());
         assert_eq!(memtable.rewrite_count, 0);
         assert_eq!(memtable.get(b"kk0"), None);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 11);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 11);
 
         // Rewrite compacted entries + valid entries.
-        memtable.rewrite(generate_rewrite_ents_index(1, 20, 100), 2);
-        memtable.rewrite_key(b"kk1".to_vec(), 2, 100);
+        memtable.rewrite(generate_rewrite_ents_index(0, 20, 100), Some(2));
+        memtable.rewrite_key(b"kk1".to_vec(), Some(2), 100);
         assert_eq!(memtable.min_file_num(LogQueue::Append).unwrap(), 3);
         assert_eq!(memtable.max_file_num(LogQueue::Append).unwrap(), 4);
         assert_eq!(memtable.min_file_num(LogQueue::Rewrite).unwrap(), 100);
         assert_eq!(memtable.max_file_num(LogQueue::Rewrite).unwrap(), 100);
         assert_eq!(memtable.rewrite_count, 10);
         assert_eq!(memtable.get(b"kk1"), Some(b"vv1".to_vec()));
+        assert_eq!(memtable.global_stats.rewrite_operations(), 32);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 21);
 
         // Rewrite vaild entries, some of them are in cache.
-        memtable.rewrite(generate_rewrite_ents_index(20, 30, 101), 3);
-        memtable.rewrite_key(b"kk2".to_vec(), 3, 101);
+        memtable.rewrite(generate_rewrite_ents_index(20, 30, 101), Some(3));
+        memtable.rewrite_key(b"kk2".to_vec(), Some(3), 101);
         assert_eq!(memtable.cache_size, 15);
         assert_eq!(memtable.min_file_num(LogQueue::Append).unwrap(), 4);
         assert_eq!(memtable.max_file_num(LogQueue::Append).unwrap(), 4);
         assert_eq!(memtable.min_file_num(LogQueue::Rewrite).unwrap(), 100);
         assert_eq!(memtable.max_file_num(LogQueue::Rewrite).unwrap(), 101);
         assert_eq!(memtable.rewrite_count, 20);
-        assert_eq!(memtable.get(b"kk2"), Some(b"vv3".to_vec()));
+        assert_eq!(memtable.get(b"kk2"), Some(b"vv2".to_vec()));
+        assert_eq!(memtable.global_stats.rewrite_operations(), 43);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 21);
 
         // Rewrite valid + overwritten entries.
         memtable.append(generate_ents(35, 36), generate_ents_index(35, 36, 5));
         memtable.put(b"kk2".to_vec(), b"vv4".to_vec(), 5);
         assert_eq!(memtable.cache_size, 11);
         assert_eq!(memtable.entries_index.back().unwrap().index, 35);
-        memtable.rewrite(generate_rewrite_ents_index(30, 40, 102), 4);
-        memtable.rewrite_key(b"kk2".to_vec(), 4, 102);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 43);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 22);
+        memtable.rewrite(generate_rewrite_ents_index(30, 40, 102), Some(4));
+        memtable.rewrite_key(b"kk3".to_vec(), Some(4), 102);
         assert_eq!(memtable.min_file_num(LogQueue::Append).unwrap(), 5);
         assert_eq!(memtable.max_file_num(LogQueue::Append).unwrap(), 5);
         assert_eq!(memtable.min_file_num(LogQueue::Rewrite).unwrap(), 100);
         assert_eq!(memtable.max_file_num(LogQueue::Rewrite).unwrap(), 102);
         assert_eq!(memtable.rewrite_count, 25);
         assert_eq!(memtable.get(b"kk2"), Some(b"vv4".to_vec()));
+        assert_eq!(memtable.global_stats.rewrite_operations(), 54);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 27);
 
         // Rewrite after compact.
         memtable.append(generate_ents(36, 50), generate_ents_index(36, 50, 6));
         memtable.compact_to(30);
         assert_eq!(memtable.rewrite_count, 5);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 54);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 47);
         memtable.compact_to(40);
         assert_eq!(memtable.rewrite_count, 0);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 54);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 52);
 
         assert_eq!(memtable.cache_size, 10);
         assert_eq!(memtable.entries_index.back().unwrap().index, 49);
-        memtable.rewrite(generate_rewrite_ents_index(30, 36, 103), 5);
-        memtable.rewrite_key(b"kk2".to_vec(), 5, 103);
+        memtable.rewrite(generate_rewrite_ents_index(30, 36, 103), Some(5));
+        memtable.rewrite_key(b"kk2".to_vec(), Some(5), 103);
         assert_eq!(memtable.min_file_num(LogQueue::Append).unwrap(), 6);
         assert_eq!(memtable.max_file_num(LogQueue::Append).unwrap(), 6);
         assert_eq!(memtable.min_file_num(LogQueue::Rewrite).unwrap(), 100);
         assert_eq!(memtable.max_file_num(LogQueue::Rewrite).unwrap(), 103);
         assert_eq!(memtable.rewrite_count, 0);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 61);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 58);
 
         // Rewrite after cut.
         memtable.append(generate_ents(50, 55), generate_ents_index(50, 55, 7));
-        memtable.rewrite(generate_rewrite_ents_index(30, 50, 104), 6);
+        memtable.rewrite(generate_rewrite_ents_index(30, 50, 104), Some(6));
         assert_eq!(memtable.rewrite_count, 10);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 81);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 68);
         memtable.append(generate_ents(45, 50), generate_ents_index(45, 50, 7));
         assert_eq!(memtable.rewrite_count, 5);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 81);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 73);
         memtable.append(generate_ents(40, 50), generate_ents_index(40, 50, 7));
         assert_eq!(memtable.rewrite_count, 0);
+        assert_eq!(memtable.global_stats.rewrite_operations(), 81);
+        assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 78);
     }
 
     fn generate_ents(begin_idx: u64, end_idx: u64) -> Vec<Entry> {

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -669,8 +669,8 @@ mod tests {
 
     use super::*;
     use crate::cache_evict::{CacheSubmitor, CacheTask};
-    use crate::GlobalStats;
     use crate::util::{ReadableSize, Worker};
+    use crate::GlobalStats;
 
     fn new_test_pipe_log(
         path: &str,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -73,6 +73,8 @@ pub trait GenericPipeLog: Sized + Clone + Send {
     /// Truncate the active log file of `queue`.
     fn truncate_active_log(&self, queue: LogQueue, offset: Option<usize>) -> Result<()>;
 
+    fn new_log_file(&self, queue: LogQueue) -> Result<()>;
+
     /// Sync the given queue.
     fn sync(&self, queue: LogQueue) -> Result<()>;
 
@@ -492,6 +494,10 @@ impl GenericPipeLog for PipeLog {
 
     fn truncate_active_log(&self, queue: LogQueue, offset: Option<usize>) -> Result<()> {
         self.mut_queue(queue).truncate_active_log(offset)
+    }
+
+    fn new_log_file(&self, queue: LogQueue) -> Result<()> {
+        self.mut_queue(queue).new_log_file()
     }
 
     fn sync(&self, queue: LogQueue) -> Result<()> {

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -669,7 +669,7 @@ mod tests {
 
     use super::*;
     use crate::cache_evict::{CacheSubmitor, CacheTask};
-    use crate::engine::SharedCacheStats;
+    use crate::GlobalStats;
     use crate::util::{ReadableSize, Worker};
 
     fn new_test_pipe_log(
@@ -683,7 +683,7 @@ mod tests {
         cfg.target_file_size = ReadableSize(rotate_size as u64);
 
         let mut worker = Worker::new("test".to_owned(), None);
-        let stats = Arc::new(SharedCacheStats::default());
+        let stats = Arc::new(GlobalStats::default());
         let submitor = CacheSubmitor::new(usize::MAX, 4096, worker.scheduler(), stats);
         let log = PipeLog::open(&cfg, submitor).unwrap();
         (log, worker.take_receiver())

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -242,6 +242,8 @@ where
     }
 
     fn squeeze_rewrite_queue(&self) {
+        self.pipe_log.new_log_file(LogQueue::Rewrite).unwrap();
+
         let memtables = self
             .memtables
             .collect(|t| t.min_file_num(LogQueue::Rewrite).unwrap_or_default() > 0);


### PR DESCRIPTION
Previously the rewrite queue's size can only grow but not decrease even if content in it are compacted.
This PR GCs the rewrite queue if necessary, so that it's size won't grow too large.