### PR TITLE
truncate and sync active log correctly

### DIFF
--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -199,6 +199,14 @@ impl LogManager {
         self.active_log_capacity = bytes;
         self.last_sync_size = 0;
         self.all_files.push_back(fd);
+        self.sync_dir()?;
+
+        Ok(())
+    }
+
+    fn sync_dir(&self) -> Result<()> {
+        let path = PathBuf::from(&self.dir);
+        std::fs::File::open(path).and_then(|d| d.sync_all())?;
         Ok(())
     }
 
@@ -209,7 +217,6 @@ impl LogManager {
                 let io_error = IoError::new(IoErrorKind::UnexpectedEof, "truncate");
                 return Err(Error::Io(io_error));
             }
-            cmp::Ordering::Equal => return Ok(()),
             _ => {}
         }
         let active_fd = self.get_active_fd().unwrap();


### PR DESCRIPTION
Without the patch `truncate_log_file` will do nothing for switching active log file. This PR fixes it.