### PR TITLE
Improve codebase readability

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: RUST_BACKTRACE=1 cargo test --all --verbose
+        run: RUST_BACKTRACE=1 cargo test --features failpoints --all --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,28 +4,35 @@ version = "0.1.0"
 authors = ["zhangjinpeng1987 <zhangjinpeng@pingcap.com>"]
 edition = "2018"
 
+[features]
+failpoints = [
+  "fail/failpoints",
+]
+
 [dependencies]
-protobuf = "=2.8.0"
-serde = { version = "1.0", features = ["derive"] }
+byteorder = "1.2"
 crc32fast = "1.2"
+crossbeam = "0.8"
+fail = "0.4"
+fxhash = "0.2"
+hex = "0.4"
+lazy_static = "1.3"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 lz4-sys = "1.9.2"
-byteorder = "1.2"
-lazy_static = "1.3"
-fxhash = "0.2"
 nix = "0.18.0"
-crossbeam = "0.8"
+parking_lot = "0.11"
+protobuf = "=2.8.0"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
-hex = "0.4"
 
 [dev-dependencies]
-raft = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false, features = ["protobuf-codec"] }
-tempfile = "3.1"
-toml = "0.5"
+ctor = "0.1"
 env_logger = "0.7"
+raft = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false, features = ["protobuf-codec"] }
 rand = "0.7"
 rand_distr = "0.3"
-ctor = "0.1"
+tempfile = "3.1"
+toml = "0.5"
 
 [patch.crates-io]
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "82b49fea7e696fd647b5aca0a6c6ec944eab3189" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "1.0"
 [dev-dependencies]
 ctor = "0.1"
 env_logger = "0.7"
+kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, features = ["protobuf-codec"] }
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false, features = ["protobuf-codec"] }
 rand = "0.7"
 rand_distr = "0.3"
@@ -35,7 +36,9 @@ tempfile = "3.1"
 toml = "0.5"
 
 [patch.crates-io]
+raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", rev = "82b49fea7e696fd647b5aca0a6c6ec944eab3189" }
+protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "82b49fea7e696fd647b5aca0a6c6ec944eab3189" }
 
 [[example]]
 name = "append-compact-purge"

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -6,7 +6,7 @@ use raft_engine::{Config, LogBatch, MessageExt, RaftLogEngine, ReadableSize};
 use rand::thread_rng;
 use rand_distr::{Distribution, Normal};
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MessageExtTyped;
 
 impl MessageExt for MessageExtTyped {
@@ -58,7 +58,7 @@ fn main() {
             e.index = state.last_index + 1;
             batch.add_entries(region, vec![e; 1]);
             batch
-                .put_state(region, b"last_index".to_vec(), state.clone())
+                .put_state(region, b"last_index".to_vec(), &state)
                 .unwrap();
             engine.write(&mut batch, false).unwrap();
 

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use kvproto::raft_serverpb::RaftLocalState;
 use raft::eraftpb::Entry;
 use raft_engine::{Config, LogBatch, MessageExt, RaftLogEngine, ReadableSize};

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -1,5 +1,4 @@
-use std::convert::TryInto;
-
+use kvproto::raft_serverpb::RaftLocalState;
 use raft::eraftpb::Entry;
 use raft_engine::{Config, LogBatch, MessageExt, RaftLogEngine, ReadableSize};
 use rand::thread_rng;
@@ -9,8 +8,8 @@ use rand_distr::{Distribution, Normal};
 pub struct MessageExtTyped;
 
 impl MessageExt for MessageExtTyped {
-    type Entry = raft::eraftpb::Entry;
-    type State = kvproto::raft_serverpb::RaftLocalState;
+    type Entry = Entry;
+    type State = RaftLocalState;
     fn entry_index(e: &Self::Entry) -> u64 {
         e.index
     }
@@ -41,36 +40,43 @@ fn main() {
     let mut batch = LogBatch::with_capacity(256);
     let mut entry = Entry::new();
     entry.set_data(vec![b'x'; 1024 * 32].into());
+    let init_state = RaftLocalState {
+        last_index: 0,
+        ..Default::default()
+    };
     loop {
         for _ in 0..1024 {
             let region = rand_regions.next().unwrap();
-            let index = match engine.get(region, b"last_index").unwrap() {
-                Some(value) => u64::from_le_bytes(value.try_into().unwrap()) + 1,
-                None => 1,
-            };
+            let state = engine
+                .get_state(region, b"last_index")
+                .unwrap()
+                .unwrap_or(init_state.clone());
 
             let mut e = entry.clone();
-            e.index = index;
+            e.index = state.last_index + 1;
             batch.add_entries(region, vec![e; 1]);
-            batch.put(region, b"last_index".to_vec(), index.to_le_bytes().to_vec());
+            batch
+                .put_state(region, b"last_index".to_vec(), &state)
+                .unwrap();
             engine.write(&mut batch, false).unwrap();
 
-            if index % compact_offset == 0 {
+            if state.last_index % compact_offset == 0 {
                 let rand_compact_offset = rand_compacts.next().unwrap();
-                if index > rand_compact_offset {
-                    let compact_to = index - rand_compact_offset;
+                if state.last_index > rand_compact_offset {
+                    let compact_to = state.last_index - rand_compact_offset;
                     engine.compact_to(region, compact_to);
                     println!("[EXAMPLE] compact {} to {}", region, compact_to);
                 }
             }
         }
         for region in engine.purge_expired_files().unwrap() {
-            let index = match engine.get(region, b"last_index").unwrap() {
-                Some(value) => u64::from_le_bytes(value.try_into().unwrap()) + 1,
-                None => unreachable!(),
-            };
-            engine.compact_to(region, index - 8);
-            println!("[EXAMPLE] force compact {} to {}", region, index - 8);
+            let state = engine.get_state(region, b"last_index").unwrap().unwrap();
+            engine.compact_to(region, state.last_index - 7);
+            println!(
+                "[EXAMPLE] force compact {} to {}",
+                region,
+                state.last_index - 7
+            );
         }
     }
 }

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -6,7 +6,7 @@ use raft_engine::{Config, LogBatch, MessageExt, RaftLogEngine, ReadableSize};
 use rand::thread_rng;
 use rand_distr::{Distribution, Normal};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MessageExtTyped;
 
 impl MessageExt for MessageExtTyped {
@@ -58,7 +58,7 @@ fn main() {
             e.index = state.last_index + 1;
             batch.add_entries(region, vec![e; 1]);
             batch
-                .put_state(region, b"last_index".to_vec(), &state)
+                .put_state(region, b"last_index".to_vec(), state.clone())
                 .unwrap();
             engine.write(&mut batch, false).unwrap();
 

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -22,7 +22,7 @@ fn main() {
     config.dir = "append-compact-purge-data".to_owned();
     config.purge_threshold = ReadableSize::gb(2);
     config.batch_compression_threshold = ReadableSize::kb(0);
-    let engine = RaftLogEngine::<Entry, EntryExtImpl>::new(config);
+    let engine = RaftLogEngine::<Entry, EntryExtImpl>::open(config).expect("Open raft engine");
 
     let compact_offset = 32; // In src/purge.rs, it's the limit for rewrite.
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::io::{self, ErrorKind, Write};
 use std::mem;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,4 @@
-// Copyright 2017 PingCAP, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::collections::{HashSet, VecDeque};
 use std::marker::PhantomData;
 use std::sync::Arc;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -27,20 +27,20 @@ use crate::{codec, GlobalStats, Result};
 const SLOTS_COUNT: usize = 128;
 
 // Modifying MemTables collection requires a write lock.
-type MemTables = HashMap<u64, Arc<RwLock<MemTable>>>;
+type MemTables<M> = HashMap<u64, Arc<RwLock<MemTable<M>>>>;
 
 /// Collection of MemTables, indexed by Raft group ID.
 #[derive(Clone)]
-pub struct MemTableAccessor {
-    slots: Vec<Arc<RwLock<MemTables>>>,
-    initializer: Arc<dyn Fn(u64) -> MemTable + Send + Sync>,
+pub struct MemTableAccessor<M: MessageExt> {
+    slots: Vec<Arc<RwLock<MemTables<M>>>>,
+    initializer: Arc<dyn Fn(u64) -> MemTable<M> + Send + Sync>,
 
     // Deleted region memtables that are not yet rewritten.
     removed_memtables: Arc<Mutex<VecDeque<u64>>>,
 }
 
-impl MemTableAccessor {
-    pub fn new(initializer: Arc<dyn Fn(u64) -> MemTable + Send + Sync>) -> MemTableAccessor {
+impl<M: MessageExt> MemTableAccessor<M> {
+    pub fn new(initializer: Arc<dyn Fn(u64) -> MemTable<M> + Send + Sync>) -> MemTableAccessor<M> {
         let mut slots = Vec::with_capacity(SLOTS_COUNT);
         for _ in 0..SLOTS_COUNT {
             slots.push(Arc::new(RwLock::new(MemTables::default())));
@@ -52,7 +52,7 @@ impl MemTableAccessor {
         }
     }
 
-    pub fn get_or_insert(&self, raft_group_id: u64) -> Arc<RwLock<MemTable>> {
+    pub fn get_or_insert(&self, raft_group_id: u64) -> Arc<RwLock<MemTable<M>>> {
         let mut memtables = self.slots[raft_group_id as usize % SLOTS_COUNT].write();
         let memtable = memtables
             .entry(raft_group_id)
@@ -60,14 +60,14 @@ impl MemTableAccessor {
         memtable.clone()
     }
 
-    pub fn get(&self, raft_group_id: u64) -> Option<Arc<RwLock<MemTable>>> {
+    pub fn get(&self, raft_group_id: u64) -> Option<Arc<RwLock<MemTable<M>>>> {
         self.slots[raft_group_id as usize % SLOTS_COUNT]
             .read()
             .get(&raft_group_id)
             .cloned()
     }
 
-    pub fn insert(&self, raft_group_id: u64, memtable: Arc<RwLock<MemTable>>) {
+    pub fn insert(&self, raft_group_id: u64, memtable: Arc<RwLock<MemTable<M>>>) {
         self.slots[raft_group_id as usize % SLOTS_COUNT]
             .write()
             .insert(raft_group_id, memtable);
@@ -83,7 +83,7 @@ impl MemTableAccessor {
         }
     }
 
-    pub fn fold<B, F: Fn(B, &MemTable) -> B>(&self, mut init: B, fold: F) -> B {
+    pub fn fold<B, F: Fn(B, &MemTable<M>) -> B>(&self, mut init: B, fold: F) -> B {
         for tables in &self.slots {
             for memtable in tables.read().values() {
                 init = fold(init, &*memtable.read());
@@ -92,10 +92,10 @@ impl MemTableAccessor {
         init
     }
 
-    pub fn collect<F: FnMut(&MemTable) -> bool>(
+    pub fn collect<F: FnMut(&MemTable<M>) -> bool>(
         &self,
         mut condition: F,
-    ) -> Vec<Arc<RwLock<MemTable>>> {
+    ) -> Vec<Arc<RwLock<MemTable<M>>>> {
         let mut memtables = Vec::new();
         for tables in &self.slots {
             memtables.extend(tables.read().values().filter_map(|t| {
@@ -109,10 +109,7 @@ impl MemTableAccessor {
     }
 
     // Returns a `LogBatch` containing Clean commands for all the removed MemTables.
-    pub fn take_cleaned_region_logs<M>(&self) -> LogBatch<M>
-    where
-        M: MessageExt,
-    {
+    pub fn take_cleaned_region_logs(&self) -> LogBatch<M> {
         let mut log_batch = LogBatch::<M>::default();
         let mut removed_memtables = self.removed_memtables.lock();
         for id in removed_memtables.drain(..) {
@@ -140,7 +137,7 @@ where
     P: PipeLog,
 {
     cfg: Arc<Config>,
-    memtables: MemTableAccessor,
+    memtables: MemTableAccessor<M>,
     pipe_log: P,
     global_stats: Arc<GlobalStats>,
     purge_manager: PurgeManager<M, P>,
@@ -235,7 +232,7 @@ where
     }
 
     fn recover_queue(
-        memtables: &mut MemTableAccessor,
+        memtables: &mut MemTableAccessor<M>,
         pipe_log: &mut P,
         queue: LogQueue,
         recovery_mode: RecoveryMode,
@@ -265,7 +262,7 @@ where
     }
 
     fn apply_to_memtable(
-        memtables: &MemTableAccessor,
+        memtables: &MemTableAccessor<M>,
         log_batch: &mut LogBatch<M>,
         queue: LogQueue,
         file_id: FileId,
@@ -303,24 +300,26 @@ where
                     );
                     memtable.write().compact_to(index);
                 }
-                LogItemContent::Kv(kv) => match kv.op_type {
+                LogItemContent::State(state) => match state.op_type {
                     OpType::Put => {
-                        let (key, value) = (kv.key, kv.value.unwrap());
+                        let (key, state) = (state.key, state.state.unwrap());
                         debug!(
-                            "{} append to {:?}.{}, Put({}, {})",
+                            "{} append to {:?}.{}, Put({}, {:?})",
                             raft,
                             queue,
                             file_id,
                             hex::encode(&key),
-                            hex::encode(&value)
+                            &state,
                         );
                         match queue {
-                            LogQueue::Append => memtable.write().put(key, value, file_id),
-                            LogQueue::Rewrite => memtable.write().put_rewrite(key, value, file_id),
+                            LogQueue::Append => memtable.write().put_state(key, state, file_id),
+                            LogQueue::Rewrite => {
+                                memtable.write().put_rewrite_state(key, state, file_id)
+                            }
                         }
                     }
                     OpType::Del => {
-                        let key = kv.key;
+                        let key = state.key;
                         debug!(
                             "{} append to {:?}.{}, Del({})",
                             raft,
@@ -328,7 +327,7 @@ where
                             file_id,
                             hex::encode(&key),
                         );
-                        memtable.write().delete(key.as_slice());
+                        memtable.write().delete_state(key.as_slice());
                     }
                 },
             }
@@ -360,7 +359,7 @@ where
         self.pipe_log.sync(LogQueue::Append)
     }
 
-    pub fn put_state(&self, region_id: u64, key: &[u8], m: &M::State) -> Result<()> {
+    pub fn put_state(&self, region_id: u64, key: &[u8], m: M::State) -> Result<()> {
         let mut log_batch = LogBatch::default();
         log_batch.put_state(region_id, key.to_vec(), m)?;
         self.write(&mut log_batch, false).map(|_| ())
@@ -368,13 +367,10 @@ where
 
     pub fn get_state(&self, region_id: u64, key: &[u8]) -> Result<Option<M::State>> {
         if let Some(memtable) = self.memtables.get(region_id) {
-            if let Some(value) = memtable.read().get(key) {
-                let mut m = M::State::new();
-                m.merge_from_bytes(&value)?;
-                return Ok(Some(m));
-            }
+            Ok(memtable.read().get_state(key))
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
 
     pub fn get_entry(&self, region_id: u64, log_idx: u64) -> Result<Option<M::Entry>> {
@@ -526,7 +522,7 @@ mod tests {
             .put_state(
                 raft,
                 b"last_index".to_vec(),
-                &RaftLocalState {
+                RaftLocalState {
                     last_index: entry.index,
                     ..Default::default()
                 },
@@ -813,7 +809,7 @@ mod tests {
         assert!(memtable_1.read().max_file_id(LogQueue::Append).is_none());
         assert!(memtable_1
             .read()
-            .kvs_max_file_id(LogQueue::Append)
+            .states_max_file_id(LogQueue::Append)
             .is_none());
         // Entries of region 1 after the clean command should be still valid.
         for j in 2..=11 {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::error;
 use std::io::Error as IoError;
 

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use crate::pipe_log::{FileId, LogQueue};
 
 pub trait EventListener: Sync + Send {

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -11,7 +11,7 @@ pub trait EventListener: Sync + Send {
     fn post_apply_memtables(&self, queue: LogQueue, file_id: FileId);
 
     /// Test whether a log file can be purged or not.
-    fn ready_for_purge(&self, queue: LogQueue, file_id: FileId) -> bool;
+    fn first_file_not_ready_for_purge(&self, queue: LogQueue) -> FileId;
 
     /// Called *after* a log file get purged.
     fn post_purge(&self, queue: LogQueue, file_id: FileId);

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -309,7 +309,6 @@ impl FilePipeLog {
                     Ok(num) => num,
                     Err(_) => continue,
                 };
-                println!("file id = {}", file_id);
                 min_file_id = FileId::min(min_file_id, file_id);
                 max_file_id = FileId::max(max_file_id, file_id);
                 log_files.push(file_name.to_string());
@@ -798,19 +797,8 @@ mod tests {
         );
         assert!(trunc_big_offset.is_err());
 
-        /**************************
-        // read next file
-        let mut header: Vec<u8> = vec![];
-        header.extend(FILE_MAGIC_HEADER);
-        header.extend(VERSION);
-        let content = pipe_log.read_next_file_id().unwrap().unwrap();
-        assert_eq!(header, content);
-        assert!(pipe_log.read_next_file_id().unwrap().is_none());
-        **************************/
-
-        pipe_log.close().unwrap();
-
         // reopen
+        pipe_log.close().unwrap();
         let pipe_log = new_test_pipe_log(path, bytes_per_sync, rotate_size);
         assert_eq!(pipe_log.active_file_id(queue), 3.into());
         assert_eq!(

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::collections::VecDeque;
 use std::fs;
 use std::io::{BufRead, Error as IoError, ErrorKind as IoErrorKind};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,16 @@
+// Copyright (c) 2017-present, PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #![feature(shrink_to)]
 #![feature(cell_update)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,8 +88,8 @@ mod tests {
 
     impl MessageExt for Entry {
         type Entry = Entry;
-        type State = kvproto::raft_serverpb::RaftLocalState;
-        fn entry_index(e: &Self::Entry) -> u64 {
+
+        fn index(e: &Self::Entry) -> u64 {
             e.index
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,6 @@ impl GlobalStats {
 #[cfg(test)]
 mod tests {
     use crate::log_batch::MessageExt;
-    use kvproto::raft_serverpb::RaftLocalState;
     use raft::eraftpb::Entry;
 
     #[ctor::ctor]
@@ -88,14 +87,6 @@ mod tests {
     }
 
     impl MessageExt for Entry {
-        type Entry = Entry;
-        type State = kvproto::raft_serverpb::RaftLocalState;
-        fn entry_index(e: &Self::Entry) -> u64 {
-            e.index
-        }
-    }
-
-    impl MessageExt for RaftLocalState {
         type Entry = Entry;
         type State = kvproto::raft_serverpb::RaftLocalState;
         fn entry_index(e: &Self::Entry) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@ use crate::file_pipe_log::FilePipeLog;
 
 pub use self::config::{Config, RecoveryMode};
 pub use self::errors::{Error, Result};
-pub use self::log_batch::{EntryExt, LogBatch};
+pub use self::log_batch::{LogBatch, MessageExt};
 pub use self::util::ReadableSize;
-pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, FilePipeLog>;
+pub type RaftLogEngine<X> = self::engine::Engine<X, FilePipeLog>;
 
 #[derive(Default)]
 pub struct GlobalStats {
@@ -61,7 +61,7 @@ impl GlobalStats {
 
 #[cfg(test)]
 mod tests {
-    use crate::log_batch::EntryExt;
+    use crate::log_batch::MessageExt;
     use raft::eraftpb::Entry;
 
     #[ctor::ctor]
@@ -69,9 +69,11 @@ mod tests {
         env_logger::init();
     }
 
-    impl EntryExt<Entry> for Entry {
-        fn index(e: &Entry) -> u64 {
-            e.get_index()
+    impl MessageExt for Entry {
+        type Entry = Entry;
+        type State = kvproto::raft_serverpb::RaftLocalState;
+        fn entry_index(e: &Self::Entry) -> u64 {
+            e.index
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ impl GlobalStats {
 #[cfg(test)]
 mod tests {
     use crate::log_batch::MessageExt;
+    use kvproto::raft_serverpb::RaftLocalState;
     use raft::eraftpb::Entry;
 
     #[ctor::ctor]
@@ -83,6 +84,14 @@ mod tests {
     }
 
     impl MessageExt for Entry {
+        type Entry = Entry;
+        type State = kvproto::raft_serverpb::RaftLocalState;
+        fn entry_index(e: &Self::Entry) -> u64 {
+            e.index
+        }
+    }
+
+    impl MessageExt for RaftLocalState {
         type Entry = Entry;
         type State = kvproto::raft_serverpb::RaftLocalState;
         fn entry_index(e: &Self::Entry) -> u64 {

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -400,7 +400,7 @@ impl<M: MessageExt> LogBatch<M> {
     }
 
     pub fn put_state(&mut self, region_id: u64, key: Vec<u8>, s: M::State) -> Result<()> {
-        let item = LogItem::from_state(region_id, OpType::Put, key, Some(s.clone()));
+        let item = LogItem::from_state(region_id, OpType::Put, key, Some(s));
         self.items.push(item);
         Ok(())
     }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::borrow::{Borrow, Cow};
 use std::io::BufRead;
 use std::marker::PhantomData;

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,10 +1,8 @@
-// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
-
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::{cmp, u64};
 
-use crate::log_batch::CompressionType;
+use crate::log_batch::{CompressionType, MessageExt};
 use crate::pipe_log::{FileId, LogQueue};
 use crate::util::{slices_in_range, HashMap};
 use crate::{Error, GlobalStats, Result};
@@ -52,7 +50,7 @@ impl Default for EntryIndex {
  *                      |                                        |
  *                 first entry                               last entry
  */
-pub struct MemTable {
+pub struct MemTable<M: MessageExt> {
     region_id: u64,
 
     // Entries are pushed back with continuously ascending indexes.
@@ -62,18 +60,18 @@ pub struct MemTable {
     rewrite_count: usize,
 
     // key -> (value, queue, file_id)
-    kvs: HashMap<Vec<u8>, (Vec<u8>, LogQueue, FileId)>,
+    states: HashMap<Vec<u8>, (M::State, LogQueue, FileId)>,
 
     global_stats: Arc<GlobalStats>,
 }
 
-impl MemTable {
-    pub fn new(region_id: u64, global_stats: Arc<GlobalStats>) -> MemTable {
+impl<M: MessageExt> MemTable<M> {
+    pub fn new(region_id: u64, global_stats: Arc<GlobalStats>) -> MemTable<M> {
         MemTable {
             region_id,
             entries_index: VecDeque::with_capacity(SHRINK_CACHE_CAPACITY),
             rewrite_count: 0,
-            kvs: HashMap::default(),
+            states: HashMap::default(),
 
             global_stats,
         }
@@ -95,12 +93,12 @@ impl MemTable {
         Some(entry_index)
     }
 
-    pub fn get(&self, key: &[u8]) -> Option<Vec<u8>> {
-        self.kvs.get(key).map(|v| v.0.clone())
+    pub fn get_state(&self, key: &[u8]) -> Option<M::State> {
+        self.states.get(key).map(|v| v.0.clone())
     }
 
-    pub fn delete(&mut self, key: &[u8]) {
-        if let Some(value) = self.kvs.remove(key) {
+    pub fn delete_state(&mut self, key: &[u8]) {
+        if let Some(value) = self.states.remove(key) {
             if value.1 == LogQueue::Rewrite {
                 self.global_stats.add_compacted_rewrite(1);
             }
@@ -212,22 +210,22 @@ impl MemTable {
         self.rewrite_count = distance + ents_len;
     }
 
-    pub fn put(&mut self, key: Vec<u8>, value: Vec<u8>, file_id: FileId) {
-        if let Some(origin) = self.kvs.insert(key, (value, LogQueue::Append, file_id)) {
+    pub fn put_state(&mut self, key: Vec<u8>, state: M::State, file_id: FileId) {
+        if let Some(origin) = self.states.insert(key, (state, LogQueue::Append, file_id)) {
             if origin.1 == LogQueue::Rewrite {
                 self.global_stats.add_compacted_rewrite(1);
             }
         }
     }
 
-    pub fn put_rewrite(&mut self, key: Vec<u8>, value: Vec<u8>, file_id: FileId) {
-        self.kvs.insert(key, (value, LogQueue::Rewrite, file_id));
+    pub fn put_rewrite_state(&mut self, key: Vec<u8>, state: M::State, file_id: FileId) {
+        self.states.insert(key, (state, LogQueue::Rewrite, file_id));
         self.global_stats.add_rewrite(1);
     }
 
-    pub fn rewrite_key(&mut self, key: Vec<u8>, latest_rewrite: Option<FileId>, file_id: FileId) {
+    pub fn rewrite_state(&mut self, key: Vec<u8>, latest_rewrite: Option<FileId>, file_id: FileId) {
         self.global_stats.add_rewrite(1);
-        if let Some(value) = self.kvs.get_mut(&key) {
+        if let Some(value) = self.states.get_mut(&key) {
             if value.1 == LogQueue::Append {
                 if let Some(latest_rewrite) = latest_rewrite {
                     if value.2 <= latest_rewrite {
@@ -325,8 +323,8 @@ impl MemTable {
             }
         }
 
-        for (key, (value, queue, file_id)) in std::mem::take(&mut self.kvs) {
-            rhs.kvs.insert(key, (value, queue, file_id));
+        for (key, (value, queue, file_id)) in std::mem::take(&mut self.states) {
+            rhs.states.insert(key, (value, queue, file_id));
         }
 
         std::mem::swap(self, rhs);
@@ -405,16 +403,16 @@ impl MemTable {
         Ok(())
     }
 
-    pub fn fetch_kvs_before(&self, latest_rewrite: FileId, vec: &mut Vec<(Vec<u8>, Vec<u8>)>) {
-        for (key, (value, queue, file_id)) in &self.kvs {
+    pub fn fetch_states_before(&self, latest_rewrite: FileId, vec: &mut Vec<(Vec<u8>, M::State)>) {
+        for (key, (value, queue, file_id)) in &self.states {
             if *queue == LogQueue::Append && *file_id <= latest_rewrite {
                 vec.push((key.clone(), value.clone()));
             }
         }
     }
 
-    pub fn fetch_rewritten_kvs(&self, vec: &mut Vec<(Vec<u8>, Vec<u8>)>) {
-        for (key, (value, queue, _)) in &self.kvs {
+    pub fn fetch_rewritten_states(&self, vec: &mut Vec<(Vec<u8>, M::State)>) {
+        for (key, (value, queue, _)) in &self.states {
             if *queue == LogQueue::Rewrite {
                 vec.push((key.clone(), value.clone()));
             }
@@ -428,8 +426,8 @@ impl MemTable {
             LogQueue::Rewrite => self.entries_index.front(),
         };
         let ents_min = entry.map(|e| e.file_id);
-        let kvs_min = self
-            .kvs
+        let states_min = self
+            .states
             .values()
             .filter(|v| v.1 == queue)
             .fold(None, |min, v| {
@@ -439,10 +437,10 @@ impl MemTable {
                     Some(v.2)
                 }
             });
-        match (ents_min, kvs_min) {
-            (Some(ents_min), Some(kvs_min)) => Some(FileId::min(kvs_min, ents_min)),
+        match (ents_min, states_min) {
+            (Some(ents_min), Some(states_min)) => Some(FileId::min(states_min, ents_min)),
             (Some(ents_min), None) => Some(ents_min),
-            (None, Some(kvs_min)) => Some(kvs_min),
+            (None, Some(states_min)) => Some(states_min),
             (None, None) => None,
         }
     }
@@ -467,8 +465,9 @@ impl MemTable {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kvproto::raft_serverpb::RaftLocalState;
 
-    impl MemTable {
+    impl<M: MessageExt> MemTable<M> {
         pub fn max_file_id(&self, queue: LogQueue) -> Option<FileId> {
             let entry = match queue {
                 LogQueue::Append if self.rewrite_count == self.entries_index.len() => None,
@@ -478,17 +477,17 @@ mod tests {
             };
             let ents_max = entry.map(|e| e.file_id);
 
-            let kvs_max = self.kvs_max_file_id(queue);
-            match (ents_max, kvs_max) {
-                (Some(ents_max), Some(kvs_max)) => Some(FileId::max(kvs_max, ents_max)),
+            let states_max = self.states_max_file_id(queue);
+            match (ents_max, states_max) {
+                (Some(ents_max), Some(states_max)) => Some(FileId::max(states_max, ents_max)),
                 (Some(ents_max), None) => Some(ents_max),
-                (None, Some(kvs_max)) => Some(kvs_max),
+                (None, Some(states_max)) => Some(states_max),
                 (None, None) => None,
             }
         }
 
-        pub fn kvs_max_file_id(&self, queue: LogQueue) -> Option<FileId> {
-            self.kvs
+        pub fn states_max_file_id(&self, queue: LogQueue) -> Option<FileId> {
+            self.states
                 .values()
                 .filter(|v| v.1 == queue)
                 .fold(None, |max, v| {
@@ -532,12 +531,12 @@ mod tests {
     fn test_memtable_append() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // Append entries [10, 20) file_num = 1.
         // after appending
         // [10, 20) file_num = 1
-        let ents_idx = generate_entry_indexes(10, 20, LogQueue::Append, 1.into());
+        let ents_idx = build_entry_indexes(10, 20, LogQueue::Append, 1.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.entries_size(), 10);
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 1.into());
@@ -548,7 +547,7 @@ mod tests {
         // after appending:
         // [10, 20) file_num = 1
         // [20, 30) file_num = 2
-        let ents_idx = generate_entry_indexes(20, 30, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(20, 30, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.entries_size(), 20);
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 1.into());
@@ -561,7 +560,7 @@ mod tests {
         // [10, 20) file_num = 1
         // [20, 25) file_num = 2
         // [25, 35) file_num = 3
-        let ents_idx = generate_entry_indexes(25, 35, LogQueue::Append, 3.into());
+        let ents_idx = build_entry_indexes(25, 35, LogQueue::Append, 3.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.entries_size(), 25);
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 1.into());
@@ -572,7 +571,7 @@ mod tests {
         // Append entries [10, 40) file_num = 4.
         // After appending:
         // [10, 40) file_num = 4
-        let ents_idx = generate_entry_indexes(10, 40, LogQueue::Append, 4.into());
+        let ents_idx = build_entry_indexes(10, 40, LogQueue::Append, 4.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.entries_size(), 30);
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 4.into());
@@ -584,19 +583,19 @@ mod tests {
     fn test_memtable_compact() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // After appending:
         // [0, 10) file_num = 1
         // [10, 20) file_num = 2
         // [20, 25) file_num = 3
-        let ents_idx = generate_entry_indexes(0, 10, LogQueue::Append, 1.into());
+        let ents_idx = build_entry_indexes(0, 10, LogQueue::Append, 1.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(10, 15, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(10, 15, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(15, 20, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(15, 20, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(20, 25, LogQueue::Append, 3.into());
+        let ents_idx = build_entry_indexes(20, 25, LogQueue::Append, 3.into());
         memtable.append(ents_idx);
 
         assert_eq!(memtable.entries_size(), 25);
@@ -630,18 +629,18 @@ mod tests {
     fn test_memtable_fetch() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // After appending:
         // [0, 10) file_num = 1
         // [10, 15) file_num = 2
         // [15, 20) file_num = 2
         // [20, 25) file_num = 3
-        let ents_idx = generate_entry_indexes(0, 10, LogQueue::Append, 1.into());
+        let ents_idx = build_entry_indexes(0, 10, LogQueue::Append, 1.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(10, 20, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(10, 20, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(20, 25, LogQueue::Append, 3.into());
+        let ents_idx = build_entry_indexes(20, 25, LogQueue::Append, 3.into());
         memtable.append(ents_idx);
 
         // Fetching all
@@ -717,29 +716,29 @@ mod tests {
     fn test_memtable_fetch_rewrite() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // After appending:
         // [0, 10) file_num = 1
         // [10, 20) file_num = 2
         // [20, 25) file_num = 3
-        let ents_idx = generate_entry_indexes(0, 10, LogQueue::Append, 1.into());
+        let ents_idx = build_entry_indexes(0, 10, LogQueue::Append, 1.into());
         memtable.append(ents_idx);
-        memtable.put(b"k1".to_vec(), b"v1".to_vec(), 1.into());
-        let ents_idx = generate_entry_indexes(10, 20, LogQueue::Append, 2.into());
+        memtable.put_state(b"k1".to_vec(), build_state(1), 1.into());
+        let ents_idx = build_entry_indexes(10, 20, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
-        memtable.put(b"k2".to_vec(), b"v2".to_vec(), 2.into());
-        let ents_idx = generate_entry_indexes(20, 25, LogQueue::Append, 3.into());
+        memtable.put_state(b"k2".to_vec(), build_state(2), 2.into());
+        let ents_idx = build_entry_indexes(20, 25, LogQueue::Append, 3.into());
         memtable.append(ents_idx);
-        memtable.put(b"k3".to_vec(), b"v3".to_vec(), 3.into());
+        memtable.put_state(b"k3".to_vec(), build_state(3), 3.into());
 
         // After rewriting:
         // [0, 10) queue = rewrite, file_num = 50,
         // [10, 20) file_num = 2
         // [20, 25) file_num = 3
-        let ents_idx = generate_entry_indexes(0, 10, LogQueue::Rewrite, 50.into());
+        let ents_idx = build_entry_indexes(0, 10, LogQueue::Rewrite, 50.into());
         memtable.rewrite(ents_idx, Some(1.into()));
-        memtable.rewrite_key(b"k1".to_vec(), Some(1.into()), 50.into());
+        memtable.rewrite_state(b"k1".to_vec(), Some(1.into()), 50.into());
         assert_eq!(memtable.entries_size(), 25);
 
         let mut ents_idx = vec![];
@@ -759,35 +758,35 @@ mod tests {
     }
 
     #[test]
-    fn test_memtable_kv_operations() {
+    fn test_memtable_state_operations() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats);
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats);
 
-        let (k1, v1) = (b"key1", b"value1");
-        let (k5, v5) = (b"key5", b"value5");
-        memtable.put(k1.to_vec(), v1.to_vec(), 1.into());
-        memtable.put(k5.to_vec(), v5.to_vec(), 5.into());
+        let (k1, v1) = (b"key1", build_state(1));
+        let (k5, v5) = (b"key5", build_state(5));
+        memtable.put_state(k1.to_vec(), v1, 1.into());
+        memtable.put_state(k5.to_vec(), v5, 5.into());
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 1.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 5.into());
-        assert_eq!(memtable.get(k1.as_ref()), Some(v1.to_vec()));
-        assert_eq!(memtable.get(k5.as_ref()), Some(v5.to_vec()));
+        assert_eq!(memtable.get_state(k1.as_ref()), Some(build_state(1)));
+        assert_eq!(memtable.get_state(k5.as_ref()), Some(build_state(5)));
 
-        memtable.delete(k5.as_ref());
-        assert_eq!(memtable.get(k5.as_ref()), None);
+        memtable.delete_state(k5.as_ref());
+        assert_eq!(memtable.get_state(k5.as_ref()), None);
     }
 
     #[test]
     fn test_memtable_get_entry() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // [5, 10) file_num = 1
         // [10, 20) file_num = 2
-        let ents_idx = generate_entry_indexes(5, 10, LogQueue::Append, 1.into());
+        let ents_idx = build_entry_indexes(5, 10, LogQueue::Append, 1.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(10, 20, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(10, 20, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
 
         // Not in range.
@@ -802,21 +801,21 @@ mod tests {
     fn test_memtable_rewrite() {
         let region_id = 8;
         let stats = Arc::new(GlobalStats::default());
-        let mut memtable = MemTable::new(region_id, stats.clone());
+        let mut memtable = MemTable::<RaftLocalState>::new(region_id, stats.clone());
 
         // After appending and compacting:
         // [10, 20) file_num = 2
         // [20, 30) file_num = 3
         // [30, 40) file_num = 4
-        let ents_idx = generate_entry_indexes(10, 20, LogQueue::Append, 2.into());
+        let ents_idx = build_entry_indexes(10, 20, LogQueue::Append, 2.into());
         memtable.append(ents_idx);
-        memtable.put(b"kk1".to_vec(), b"vv1".to_vec(), 2.into());
-        let ents_idx = generate_entry_indexes(20, 30, LogQueue::Append, 3.into());
+        memtable.put_state(b"kk1".to_vec(), build_state(1), 2.into());
+        let ents_idx = build_entry_indexes(20, 30, LogQueue::Append, 3.into());
         memtable.append(ents_idx);
-        memtable.put(b"kk2".to_vec(), b"vv2".to_vec(), 3.into());
-        let ents_idx = generate_entry_indexes(30, 40, LogQueue::Append, 4.into());
+        memtable.put_state(b"kk2".to_vec(), build_state(2), 3.into());
+        let ents_idx = build_entry_indexes(30, 40, LogQueue::Append, 4.into());
         memtable.append(ents_idx);
-        memtable.put(b"kk3".to_vec(), b"vv3".to_vec(), 4.into());
+        memtable.put_state(b"kk3".to_vec(), build_state(3), 4.into());
 
         assert_eq!(memtable.entries_size(), 30);
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 2.into());
@@ -824,71 +823,71 @@ mod tests {
         memtable.check_entries_index();
 
         // Rewrite compacted entries.
-        let ents_idx = generate_entry_indexes(0, 10, LogQueue::Rewrite, 50.into());
+        let ents_idx = build_entry_indexes(0, 10, LogQueue::Rewrite, 50.into());
         memtable.rewrite(ents_idx, Some(1.into()));
-        memtable.rewrite_key(b"kk0".to_vec(), Some(1.into()), 50.into());
+        memtable.rewrite_state(b"kk0".to_vec(), Some(1.into()), 50.into());
 
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 2.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 4.into());
         assert!(memtable.min_file_id(LogQueue::Rewrite).is_none());
         assert!(memtable.max_file_id(LogQueue::Rewrite).is_none());
         assert_eq!(memtable.rewrite_count, 0);
-        assert_eq!(memtable.get(b"kk0"), None);
+        assert_eq!(memtable.get_state(b"kk0"), None);
         assert_eq!(memtable.global_stats.rewrite_operations(), 11);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 11);
 
         // Rewrite compacted entries + valid entries.
-        let ents_idx = generate_entry_indexes(0, 20, LogQueue::Rewrite, 100.into());
+        let ents_idx = build_entry_indexes(0, 20, LogQueue::Rewrite, 100.into());
         memtable.rewrite(ents_idx, Some(2.into()));
         assert_eq!(memtable.global_stats.rewrite_operations(), 31);
-        memtable.rewrite_key(b"kk0".to_vec(), Some(1.into()), 50.into());
-        memtable.rewrite_key(b"kk1".to_vec(), Some(2.into()), 100.into());
+        memtable.rewrite_state(b"kk0".to_vec(), Some(1.into()), 50.into());
+        memtable.rewrite_state(b"kk1".to_vec(), Some(2.into()), 100.into());
 
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 3.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 4.into());
         assert_eq!(memtable.min_file_id(LogQueue::Rewrite).unwrap(), 100.into());
         assert_eq!(memtable.max_file_id(LogQueue::Rewrite).unwrap(), 100.into());
         assert_eq!(memtable.rewrite_count, 10);
-        assert_eq!(memtable.get(b"kk1"), Some(b"vv1".to_vec()));
+        assert_eq!(memtable.get_state(b"kk1"), Some(build_state(1)));
         assert_eq!(memtable.global_stats.rewrite_operations(), 33);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 22);
 
         // Rewrite vaild entries.
-        let ents_idx = generate_entry_indexes(20, 30, LogQueue::Rewrite, 101.into());
+        let ents_idx = build_entry_indexes(20, 30, LogQueue::Rewrite, 101.into());
         memtable.rewrite(ents_idx, Some(3.into()));
-        memtable.rewrite_key(b"kk2".to_vec(), Some(3.into()), 101.into());
+        memtable.rewrite_state(b"kk2".to_vec(), Some(3.into()), 101.into());
 
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 4.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 4.into());
         assert_eq!(memtable.min_file_id(LogQueue::Rewrite).unwrap(), 100.into());
         assert_eq!(memtable.max_file_id(LogQueue::Rewrite).unwrap(), 101.into());
         assert_eq!(memtable.rewrite_count, 20);
-        assert_eq!(memtable.get(b"kk2"), Some(b"vv2".to_vec()));
+        assert_eq!(memtable.get_state(b"kk2"), Some(build_state(2)));
         assert_eq!(memtable.global_stats.rewrite_operations(), 44);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 22);
 
         // Put some entries overwritting entires in file 4.
-        let ents_idx = generate_entry_indexes(35, 36, LogQueue::Append, 5.into());
+        let ents_idx = build_entry_indexes(35, 36, LogQueue::Append, 5.into());
         memtable.append(ents_idx);
-        memtable.put(b"kk3".to_vec(), b"vv33".to_vec(), 5.into());
+        memtable.put_state(b"kk3".to_vec(), build_state(3), 5.into());
         assert_eq!(memtable.entries_index.back().unwrap().index, 35);
 
         // Rewrite valid + overwritten entries.
-        let ents_idx = generate_entry_indexes(30, 40, LogQueue::Rewrite, 102.into());
+        let ents_idx = build_entry_indexes(30, 40, LogQueue::Rewrite, 102.into());
         memtable.rewrite(ents_idx, Some(4.into()));
-        memtable.rewrite_key(b"kk3".to_vec(), Some(4.into()), 102.into());
+        memtable.rewrite_state(b"kk3".to_vec(), Some(4.into()), 102.into());
 
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 5.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 5.into());
         assert_eq!(memtable.min_file_id(LogQueue::Rewrite).unwrap(), 100.into());
         assert_eq!(memtable.max_file_id(LogQueue::Rewrite).unwrap(), 102.into());
         assert_eq!(memtable.rewrite_count, 25);
-        assert_eq!(memtable.get(b"kk3"), Some(b"vv33".to_vec()));
+        assert_eq!(memtable.get_state(b"kk3"), Some(build_state(3)));
         assert_eq!(memtable.global_stats.rewrite_operations(), 55);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 27);
 
         // Compact after rewrite.
-        let ents_idx = generate_entry_indexes(35, 50, LogQueue::Append, 6.into());
+        let ents_idx = build_entry_indexes(35, 50, LogQueue::Append, 6.into());
         memtable.append(ents_idx);
         memtable.compact_to(30);
         assert_eq!(memtable.entries_index.back().unwrap().index, 49);
@@ -900,9 +899,9 @@ mod tests {
         assert_eq!(memtable.global_stats.rewrite_operations(), 55);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 52);
 
-        let ents_idx = generate_entry_indexes(30, 36, LogQueue::Rewrite, 103.into());
+        let ents_idx = build_entry_indexes(30, 36, LogQueue::Rewrite, 103.into());
         memtable.rewrite(ents_idx, Some(5.into()));
-        memtable.rewrite_key(b"kk3".to_vec(), Some(5.into()), 103.into());
+        memtable.rewrite_state(b"kk3".to_vec(), Some(5.into()), 103.into());
 
         assert_eq!(memtable.min_file_id(LogQueue::Append).unwrap(), 6.into());
         assert_eq!(memtable.max_file_id(LogQueue::Append).unwrap(), 6.into());
@@ -913,28 +912,28 @@ mod tests {
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 58);
 
         // Rewrite after cut.
-        let ents_idx = generate_entry_indexes(50, 55, LogQueue::Append, 7.into());
+        let ents_idx = build_entry_indexes(50, 55, LogQueue::Append, 7.into());
         memtable.append(ents_idx);
-        let ents_idx = generate_entry_indexes(30, 50, LogQueue::Rewrite, 104.into());
+        let ents_idx = build_entry_indexes(30, 50, LogQueue::Rewrite, 104.into());
         memtable.rewrite(ents_idx, Some(6.into()));
         assert_eq!(memtable.rewrite_count, 10);
         assert_eq!(memtable.global_stats.rewrite_operations(), 82);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 68);
 
-        let ents_idx = generate_entry_indexes(45, 50, LogQueue::Append, 7.into());
+        let ents_idx = build_entry_indexes(45, 50, LogQueue::Append, 7.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.rewrite_count, 5);
         assert_eq!(memtable.global_stats.rewrite_operations(), 82);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 73);
 
-        let ents_idx = generate_entry_indexes(40, 50, LogQueue::Append, 7.into());
+        let ents_idx = build_entry_indexes(40, 50, LogQueue::Append, 7.into());
         memtable.append(ents_idx);
         assert_eq!(memtable.rewrite_count, 0);
         assert_eq!(memtable.global_stats.rewrite_operations(), 82);
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 78);
     }
 
-    fn generate_entry_indexes(
+    fn build_entry_indexes(
         begin_idx: u64,
         end_idx: u64,
         queue: LogQueue,
@@ -953,5 +952,12 @@ mod tests {
             ents_idx.push(ent_idx);
         }
         ents_idx
+    }
+
+    fn build_state(idx: u64) -> RaftLocalState {
+        RaftLocalState {
+            last_index: idx,
+            ..Default::default()
+        }
     }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::{cmp, u64};

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -97,7 +97,7 @@ pub trait PipeLog: Sized + Clone + Send {
         len: u64,
     ) -> Result<Vec<u8>>;
 
-    fn read_file<E: Message, W: EntryExt<E>>(
+    fn read_file_into_log_batch<E: Message, W: EntryExt<E>>(
         &self,
         queue: LogQueue,
         file_id: FileId,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -1,7 +1,5 @@
-use protobuf::Message;
-
 use crate::config::RecoveryMode;
-use crate::log_batch::{EntryExt, LogBatch};
+use crate::log_batch::{LogBatch, MessageExt};
 use crate::Result;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
@@ -97,19 +95,19 @@ pub trait PipeLog: Sized + Clone + Send {
         len: u64,
     ) -> Result<Vec<u8>>;
 
-    fn read_file_into_log_batch<E: Message, W: EntryExt<E>>(
+    fn read_file_into_log_batch<M: MessageExt>(
         &self,
         queue: LogQueue,
         file_id: FileId,
         mode: RecoveryMode,
-        batches: &mut Vec<LogBatch<E, W>>,
+        batches: &mut Vec<LogBatch<M>>,
     ) -> Result<()>;
 
     /// Write a batch into the append queue.
-    fn append<E: Message, W: EntryExt<E>>(
+    fn append<M: MessageExt>(
         &self,
         queue: LogQueue,
-        batch: &mut LogBatch<E, W>,
+        batch: &mut LogBatch<M>,
         sync: bool,
     ) -> Result<(FileId, usize)>;
 

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use crate::config::RecoveryMode;
 use crate::log_batch::{LogBatch, MessageExt};
 use crate::Result;

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -1,3 +1,5 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::cmp;
 use std::collections::VecDeque;
 use std::marker::PhantomData;

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -317,9 +317,11 @@ where
 }
 
 pub struct PurgeHook {
-    // Append queue log files that are not yet fully applied to MemTable.
-    // They must not be purged even when not referenced by any MemTable.
-    // No need to track rewrite queue because it is only written by purge thread.
+    // Append queue log files that are not yet fully applied to MemTable must not be
+    // purged even when not referenced by any MemTable.
+    // In order to identify them, maintain a per-file reference counter for all active
+    // log files in append queue. No need to track rewrite queue because it is only
+    // written by purge thread.
     active_log_files: RwLock<VecDeque<(FileId, AtomicUsize)>>,
 }
 

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -198,7 +198,7 @@ where
 
     // Compact the entire rewrite queue into new rewrite files.
     fn compact_rewrite_queue(&self) -> Result<()> {
-        self.pipe_log.new_log_file(LogQueue::Rewrite).unwrap();
+        self.pipe_log.new_log_file(LogQueue::Rewrite)?;
 
         let memtables = self
             .memtables

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -240,7 +240,7 @@ where
             }
             log_batch.add_entries(region_id, entries);
             for (k, v) in kvs {
-                log_batch.put(region_id, k, v);
+                log_batch.put(region_id, k, v)?;
             }
 
             let target_file_size = self.cfg.target_file_size.0 as usize;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 pub use std::collections::hash_map::Entry as HashMapEntry;
 use std::collections::{HashMap as StdHashMap, VecDeque};

--- a/src/util.rs
+++ b/src/util.rs
@@ -187,7 +187,7 @@ impl<'de> Deserialize<'de> for ReadableSize {
 /// ### Panics
 ///
 /// if [low, high) is out of bound.
-pub fn slices_in_range<T>(entry: &VecDeque<T>, low: usize, high: usize) -> (&[T], &[T]) {
+pub(crate) fn slices_in_range<T>(entry: &VecDeque<T>, low: usize, high: usize) -> (&[T], &[T]) {
     let (first, second) = entry.as_slices();
     if low >= first.len() {
         (&second[low - first.len()..high - first.len()], &[])
@@ -198,7 +198,7 @@ pub fn slices_in_range<T>(entry: &VecDeque<T>, low: usize, high: usize) -> (&[T]
     }
 }
 
-pub trait HandyRwLock<T> {
+pub(crate) trait HandyRwLock<T> {
     fn wl(&self) -> RwLockWriteGuard<'_, T>;
     fn rl(&self) -> RwLockReadGuard<'_, T>;
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,6 @@ use std::fmt::{self, Write};
 use std::hash::BuildHasherDefault;
 use std::ops::{Div, Mul};
 use std::str::FromStr;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -195,19 +194,5 @@ pub(crate) fn slices_in_range<T>(entry: &VecDeque<T>, low: usize, high: usize) -
         (&first[low..high], &[])
     } else {
         (&first[low..], &second[..high - first.len()])
-    }
-}
-
-pub(crate) trait HandyRwLock<T> {
-    fn wl(&self) -> RwLockWriteGuard<'_, T>;
-    fn rl(&self) -> RwLockReadGuard<'_, T>;
-}
-
-impl<T> HandyRwLock<T> for RwLock<T> {
-    fn wl(&self) -> RwLockWriteGuard<'_, T> {
-        self.write().unwrap()
-    }
-    fn rl(&self) -> RwLockReadGuard<'_, T> {
-        self.read().unwrap()
     }
 }


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

~1. Remove generic type in `MemTable`~
2. Update name and placement for function and constant
3. Remove redundant functions
4. Reduce uses of `unwrap()` or `expect(..)` in production code
5. Simplify generic parameters from `E: Message`, `W: EntryExt<E>` to `M: MessageExt`
~6. Directly store `protobuf::Message` in memtable~