### PR TITLE
Change `version` format to u64

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,19 @@
 use std::error;
+use std::fmt::Display;
 use std::io::Error as IoError;
 
 use thiserror::Error;
 
 use crate::codec::Error as CodecError;
+
+#[derive(Debug, Error)]
+pub struct Corruption(pub Box<dyn error::Error + Send + Sync>);
+
+impl Display for Corruption {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -27,10 +37,8 @@ pub enum Error {
     StorageUnavailable,
     #[error("The entry acquired has been compacted")]
     StorageCompacted,
-    #[error("Unrecognized log file version: {0}")]
-    UnrecognizedLogFileVersion(u64),
-    #[error("Unrecognized log file magic header")]
-    UnrecognizedLogFileMagicHeader,
+    #[error("Corruption: {0}")]
+    Corruption(#[from] Corruption),
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,10 @@ pub enum Error {
     StorageUnavailable,
     #[error("The entry acquired has been compacted")]
     StorageCompacted,
+    #[error("Unrecognized log file version: {0}")]
+    UnrecognizedLogFileVersion(u64),
+    #[error("Unrecognized log file magic header")]
+    UnrecognizedLogFileMagicHeader,
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,19 +1,9 @@
 use std::error;
-use std::fmt::Display;
 use std::io::Error as IoError;
 
 use thiserror::Error;
 
 use crate::codec::Error as CodecError;
-
-#[derive(Debug, Error)]
-pub struct Corruption(pub Box<dyn error::Error + Send + Sync>);
-
-impl Display for Corruption {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -38,7 +28,7 @@ pub enum Error {
     #[error("The entry acquired has been compacted")]
     StorageCompacted,
     #[error("Corruption: {0}")]
-    Corruption(#[from] Corruption),
+    Corruption(String),
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -388,6 +388,7 @@ impl FilePipeLog {
         Ok(pipe_log)
     }
 
+    // TODO: use `LogFd` for reading file bytes instead of `std::fs`
     fn read_file_bytes(&self, queue: LogQueue, file_id: FileId) -> Result<Vec<u8>> {
         let mut path = PathBuf::from(&self.dir);
         path.push(generate_file_name(file_id, self.get_name_suffix(queue)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,16 @@ macro_rules! box_err {
     });
 }
 
+macro_rules! box_corruption {
+    ($e:expr) => {{
+        use crate::errors::Corruption;
+        Corruption(box_err!($e)).into()
+    }};
+    ($f:tt, $($arg:expr),+) => ({
+        box_corruption!(format!($f, $($arg),+))
+    });
+}
+
 pub mod codec;
 
 mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,16 +14,6 @@ macro_rules! box_err {
     });
 }
 
-macro_rules! box_corruption {
-    ($e:expr) => {{
-        use crate::errors::Corruption;
-        Corruption(box_err!($e)).into()
-    }};
-    ($f:tt, $($arg:expr),+) => ({
-        box_corruption!(format!($f, $($arg),+))
-    });
-}
-
 pub mod codec;
 
 mod config;


### PR DESCRIPTION
Previously we use [u8] to define version. It's hard to make sure everything is right (see [raft-engine#79](https://github.com/tikv/raft-engine/pull/79)).

For now RaftEngine is not GA, it's better change the version format to u64.

**IMPORTANT: Make sure that there MUST BE NO user using RaftEngine.**

**This patch is not compatibility with the previous log file foramt!!!**

Signed-off-by: MrCroxx <mrcroxx@outlook.com>