### PR TITLE
Support hint files for fast recovery.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -381,7 +381,6 @@ where
         let mut batches = Vec::new();
         let mut file_id = first_file;
         while file_id <= active_file {
-            // TODO(MrCroxx): dir
             match hint_manager.read_hint_file(queue, file_id) {
                 Ok(mut batch) => {
                     info!(

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -20,4 +20,7 @@ pub trait EventListener: Sync + Send {
 
     /// Called *after* a log file get purged.
     fn post_purge(&self, _queue: LogQueue, _file_id: FileId) {}
+
+    /// Called *after* a log file is actually removed.
+    fn post_removed(&self, _queue: LogQueue, _file_id: FileId) {}
 }

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -2,17 +2,22 @@ use crate::pipe_log::{FileId, LogQueue};
 
 pub trait EventListener: Sync + Send {
     /// Called *after* a new log file is created.
-    fn post_new_log_file(&self, queue: LogQueue, file_id: FileId);
+    fn post_new_log_file(&self, _queue: LogQueue, _file_id: FileId) {}
+
+    /// Called *after* a log file is frozen.
+    fn post_log_file_frozen(&self, _queue: LogQueue, _file_id: FileId) {}
 
     /// Called *before* a log batch has been appended into a log file.
-    fn on_append_log_file(&self, queue: LogQueue, file_id: FileId);
+    fn on_append_log_file(&self, _queue: LogQueue, _file_id: FileId) {}
 
     /// Called *after* a log batch has been applied to memtables.
-    fn post_apply_memtables(&self, queue: LogQueue, file_id: FileId);
+    fn post_apply_memtables(&self, _queue: LogQueue, _file_id: FileId) {}
 
     /// Test whether a log file can be purged or not.
-    fn ready_for_purge(&self, queue: LogQueue, file_id: FileId) -> bool;
+    fn ready_for_purge(&self, _queue: LogQueue, _file_id: FileId) -> bool {
+        true
+    }
 
     /// Called *after* a log file get purged.
-    fn post_purge(&self, queue: LogQueue, file_id: FileId);
+    fn post_purge(&self, _queue: LogQueue, _file_id: FileId) {}
 }

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -650,6 +650,20 @@ fn write_file_header(fd: RawFd) -> Result<usize> {
 }
 
 #[cfg(test)]
+pub fn log_file_size(dir: &str, queue: LogQueue, file_id: FileId) -> usize {
+    let mut path = PathBuf::from(dir);
+    path.push(generate_file_name(
+        file_id,
+        match queue {
+            LogQueue::Append => LOG_SUFFIX,
+            LogQueue::Rewrite => REWRITE_SUFFIX,
+        },
+    ));
+    let fd = open_frozen_file(&path).unwrap();
+    file_size(fd).unwrap()
+}
+
+#[cfg(test)]
 mod tests {
 
     use tempfile::Builder;

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -1,0 +1,136 @@
+use core::panic;
+use std::vec;
+
+use log::warn;
+use protobuf::Message;
+
+use crate::codec::NumberEncoder;
+use crate::pipe_log::FileId;
+use crate::util::{HashMap, Runnable, Scheduler};
+use crate::{log_batch::LogItemContent, memtable::EntryIndex, EntryExt, LogBatch};
+
+pub struct HintManager<E, W>
+where
+    E: Message + Clone + 'static,
+    W: EntryExt<E> + Clone + 'static,
+{
+    scheduler: Scheduler<HintTask<E, W>>,
+}
+
+impl<E, W> HintManager<E, W>
+where
+    E: Message + Clone,
+    W: EntryExt<E> + Clone,
+{
+    pub fn new(scheduler: Scheduler<HintTask<E, W>>) -> Self {
+        Self { scheduler }
+    }
+
+    pub fn submit_log_batch(&self, file_id: FileId, batch: LogBatch<E, W>) {
+        self.submit(HintTask::Append(file_id, batch));
+    }
+
+    pub fn submit_flush(&self, file_id: FileId) {
+        self.submit(HintTask::Flush(file_id));
+    }
+
+    fn submit(&self, task: HintTask<E, W>) {
+        if let Err(e) = self.scheduler.schedule(task) {
+            panic!("hint manager task submitting error: {}", e);
+        }
+    }
+}
+
+pub struct Hint {
+    entries_index: Vec<(u64, Vec<EntryIndex>)>,
+}
+
+impl Hint {
+    pub fn new() -> Self {
+        Self {
+            entries_index: vec![],
+        }
+    }
+
+    /// append all entry indexes in a log batch
+    pub fn append<E: Message, W: EntryExt<E>>(&mut self, batch: &LogBatch<E, W>) {
+        self.entries_index
+            .extend(batch.items.iter().filter_map(|item| match &item.content {
+                LogItemContent::Command(_) | LogItemContent::Kv(_) => None,
+                LogItemContent::Entries(entries) => {
+                    Some((item.raft_group_id, entries.entries_index.to_owned()))
+                }
+            }));
+    }
+
+    /// encode Hint to bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // layout = { [ raft_group_id | EntryIndex ] }
+        let mut buf: Vec<u8> = Vec::with_capacity(1024);
+        self.entries_index
+            .iter()
+            .for_each(|(raft_group_id, entries_index)| {
+                buf.encode_u64(*raft_group_id).unwrap();
+                buf.encode_var_u64(entries_index.len() as u64).unwrap();
+                entries_index.iter().for_each(|entry_index| {
+                    entry_index.encode_to_bytes(&mut buf);
+                });
+            });
+
+        buf
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum HintTask<E: Message + 'static, W: EntryExt<E> + 'static> {
+    Append(FileId, LogBatch<E, W>),
+    Flush(FileId),
+}
+
+pub struct Runner {
+    hints: HashMap<FileId, Hint>,
+}
+
+impl Runner {
+    pub fn new() -> Self {
+        Self {
+            hints: HashMap::default(),
+        }
+    }
+
+    fn append_log_batch<E: Message, W: EntryExt<E>>(
+        &mut self,
+        file_id: FileId,
+        batch: LogBatch<E, W>,
+    ) {
+        self.hints
+            .entry(file_id)
+            .or_insert(Hint::new())
+            .append(&batch);
+    }
+
+    fn flush(&mut self, file_id: FileId) {
+        if let Some(hint) = self.hints.remove(&file_id) {
+            let buf = hint.to_bytes();
+            // TODO(MrCroxx): write file
+            // todo!()
+        }
+    }
+}
+
+impl<E, W> Runnable<HintTask<E, W>> for Runner
+where
+    E: Message + Clone,
+    W: EntryExt<E> + Clone,
+{
+    fn run(&mut self, task: HintTask<E, W>) -> bool {
+        match task {
+            HintTask::Append(file_id, batch) => self.append_log_batch(file_id, batch),
+            HintTask::Flush(file_id) => self.flush(file_id),
+        }
+        true
+    }
+    fn on_tick(&mut self) {
+        // todo!()
+    }
+}

--- a/src/hint.rs
+++ b/src/hint.rs
@@ -1,13 +1,26 @@
 use core::panic;
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
 use std::vec;
 
 use log::warn;
+use nix::fcntl;
+use nix::fcntl::OFlag;
+use nix::sys::stat::Mode;
+use nix::NixPath;
 use protobuf::Message;
 
-use crate::codec::NumberEncoder;
-use crate::pipe_log::FileId;
-use crate::util::{HashMap, Runnable, Scheduler};
+use crate::codec::{self, NumberEncoder};
+use crate::log_batch::{Command, KeyValue, SliceReader};
+
+use crate::pipe_log::{FileId, LogQueue};
+use crate::util::{
+    file_size, parse_nix_error, pread_exact, pwrite_exact, HashMap, Runnable, Scheduler,
+};
+use crate::Result;
 use crate::{log_batch::LogItemContent, memtable::EntryIndex, EntryExt, LogBatch};
+
+const HINT_SUFFIX: &str = ".hint";
 
 pub struct HintManager<E, W>
 where
@@ -19,19 +32,27 @@ where
 
 impl<E, W> HintManager<E, W>
 where
-    E: Message + Clone,
-    W: EntryExt<E> + Clone,
+    E: Message + Clone + 'static,
+    W: EntryExt<E> + Clone + 'static,
 {
-    pub fn new(scheduler: Scheduler<HintTask<E, W>>) -> Self {
+    pub fn open(scheduler: Scheduler<HintTask<E, W>>) -> Self {
         Self { scheduler }
     }
 
-    pub fn submit_log_batch(&self, file_id: FileId, batch: LogBatch<E, W>) {
-        self.submit(HintTask::Append(file_id, batch));
+    pub fn submit_log_batch(&self, queue: LogQueue, file_id: FileId, batch: LogBatch<E, W>) {
+        self.submit(HintTask::Append {
+            queue,
+            file_id,
+            batch,
+        });
     }
 
-    pub fn submit_flush(&self, file_id: FileId) {
-        self.submit(HintTask::Flush(file_id));
+    pub fn submit_flush(&self, dir: &str, queue: LogQueue, file_id: FileId) {
+        self.submit(HintTask::Flush {
+            queue,
+            dir: dir.to_owned(),
+            file_id,
+        });
     }
 
     fn submit(&self, task: HintTask<E, W>) {
@@ -39,56 +60,148 @@ where
             panic!("hint manager task submitting error: {}", e);
         }
     }
+
+    pub fn read_hint_file(dir: &str, queue: LogQueue, file_id: FileId) -> Result<LogBatch<E, W>> {
+        let mut path = PathBuf::from(&dir);
+        path.push(generate_filename(queue, file_id));
+        let fd = open_hint_file_r(&path)?;
+        let size = file_size(fd)?;
+        // TODO(MrCroxx): read header & version
+        let buf = pread_exact(fd, 0, size)?;
+        Ok(Self::read_bytes(queue, file_id, &mut &buf[..])?)
+    }
+
+    fn read_bytes(
+        queue: LogQueue,
+        file_id: FileId,
+        buf: &mut SliceReader<'_>,
+    ) -> Result<LogBatch<E, W>> {
+        if buf.is_empty() {
+            return Ok(LogBatch::default());
+        }
+        let mut batch: LogBatch<E, W> = LogBatch::default();
+        while !buf.is_empty() {
+            match HintItem::from_bytes(buf, queue, file_id)? {
+                HintItem::EntriesIndex(raft_group_id, entries_index) => {
+                    batch.add_raw_entries_index(raft_group_id, entries_index)
+                }
+                HintItem::Command(raft_group_id, command) => {
+                    batch.add_raw_command(raft_group_id, command)
+                }
+                HintItem::KV(raft_group_id, kv) => batch.add_raw_kv(raft_group_id, kv),
+            }
+        }
+        Ok(batch)
+    }
+}
+
+enum HintItem {
+    EntriesIndex(u64, Vec<EntryIndex>),
+    KV(u64, KeyValue),
+    Command(u64, Command),
+}
+
+impl HintItem {
+    pub fn encode_to(&self, buf: &mut Vec<u8>) -> Result<()> {
+        match self {
+            HintItem::EntriesIndex(raft_group_id, entries_index) => {
+                buf.encode_var_u64(1)?;
+                buf.encode_u64(*raft_group_id)?;
+                buf.encode_var_u64(entries_index.len() as u64)?;
+                entries_index.iter().for_each(|entry_index| {
+                    entry_index.encode_to_bytes(buf);
+                });
+            }
+            HintItem::KV(raft_group_id, kv) => {
+                buf.encode_var_u64(1)?;
+                buf.encode_u64(*raft_group_id)?;
+                kv.encode_to(buf)?;
+            }
+            HintItem::Command(raft_group_id, command) => {
+                buf.encode_var_u64(1)?;
+                buf.encode_u64(*raft_group_id)?;
+                command.encode_to(buf);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn from_bytes(buf: &mut SliceReader<'_>, queue: LogQueue, file_id: FileId) -> Result<Self> {
+        let item = codec::decode_var_u64(buf)?;
+        let raft_group_id = codec::decode_u64(buf)?;
+        match item {
+            1 => {
+                let entry_index_count = codec::decode_var_u64(buf)?;
+                let mut entries_index = Vec::with_capacity(entry_index_count as usize);
+                for _ in 0..entry_index_count {
+                    entries_index.push(EntryIndex::from_bytes(buf, file_id, queue)?);
+                }
+                Ok(HintItem::EntriesIndex(raft_group_id, entries_index))
+            }
+            2 => {
+                let kv = KeyValue::from_bytes(buf)?;
+                Ok(HintItem::KV(raft_group_id, kv))
+            }
+            3 => {
+                let command = Command::from_bytes(buf)?;
+                Ok(HintItem::Command(raft_group_id, command))
+            }
+            _ => Err(box_err!("unrecognized hint item".to_owned())),
+        }
+    }
 }
 
 pub struct Hint {
-    entries_index: Vec<(u64, Vec<EntryIndex>)>,
+    items: Vec<HintItem>,
 }
 
 impl Hint {
     pub fn new() -> Self {
-        Self {
-            entries_index: vec![],
-        }
+        Self { items: vec![] }
     }
 
     /// append all entry indexes in a log batch
     pub fn append<E: Message, W: EntryExt<E>>(&mut self, batch: &LogBatch<E, W>) {
-        self.entries_index
-            .extend(batch.items.iter().filter_map(|item| match &item.content {
-                LogItemContent::Command(_) | LogItemContent::Kv(_) => None,
+        self.items
+            .extend(batch.items.iter().map(|item| match &item.content {
                 LogItemContent::Entries(entries) => {
-                    Some((item.raft_group_id, entries.entries_index.to_owned()))
+                    HintItem::EntriesIndex(item.raft_group_id, entries.entries_index.to_owned())
                 }
+                LogItemContent::Command(command) => {
+                    HintItem::Command(item.raft_group_id, command.to_owned())
+                }
+                LogItemContent::Kv(kv) => HintItem::KV(item.raft_group_id, kv.to_owned()),
             }));
     }
 
-    /// encode Hint to bytes
-    pub fn to_bytes(&self) -> Vec<u8> {
-        // layout = { [ raft_group_id | EntryIndex ] }
+    pub fn to_bytes(&self) -> Result<Vec<u8>> {
+        // layout = { [ raft_group_id | N | [EntryIndex] ] }
         let mut buf: Vec<u8> = Vec::with_capacity(1024);
-        self.entries_index
-            .iter()
-            .for_each(|(raft_group_id, entries_index)| {
-                buf.encode_u64(*raft_group_id).unwrap();
-                buf.encode_var_u64(entries_index.len() as u64).unwrap();
-                entries_index.iter().for_each(|entry_index| {
-                    entry_index.encode_to_bytes(&mut buf);
-                });
-            });
-
-        buf
+        for item in self.items.iter() {
+            if let Err(e) = item.encode_to(&mut buf) {
+                return Err(e);
+            }
+        }
+        Ok(buf)
     }
 }
 
 #[derive(Clone, Debug)]
 pub enum HintTask<E: Message + 'static, W: EntryExt<E> + 'static> {
-    Append(FileId, LogBatch<E, W>),
-    Flush(FileId),
+    Append {
+        queue: LogQueue,
+        file_id: FileId,
+        batch: LogBatch<E, W>,
+    },
+    Flush {
+        dir: String,
+        queue: LogQueue,
+        file_id: FileId,
+    },
 }
 
 pub struct Runner {
-    hints: HashMap<FileId, Hint>,
+    hints: HashMap<(LogQueue, FileId), Hint>,
 }
 
 impl Runner {
@@ -100,21 +213,26 @@ impl Runner {
 
     fn append_log_batch<E: Message, W: EntryExt<E>>(
         &mut self,
+        queue: LogQueue,
         file_id: FileId,
         batch: LogBatch<E, W>,
     ) {
         self.hints
-            .entry(file_id)
+            .entry((queue, file_id))
             .or_insert(Hint::new())
             .append(&batch);
     }
 
-    fn flush(&mut self, file_id: FileId) {
-        if let Some(hint) = self.hints.remove(&file_id) {
-            let buf = hint.to_bytes();
-            // TODO(MrCroxx): write file
-            // todo!()
+    fn flush(&mut self, dir: String, queue: LogQueue, file_id: FileId) -> Result<()> {
+        if let Some(hint) = self.hints.remove(&(queue, file_id)) {
+            let mut path = PathBuf::from(&dir);
+            path.push(generate_filename(queue, file_id));
+            let buf = hint.to_bytes()?;
+            let fd = open_hint_file_w(&path)?;
+            // TODO(MrCroxx): write header & version
+            pwrite_exact(fd, 0, &buf)?;
         }
+        Ok(())
     }
 }
 
@@ -125,12 +243,43 @@ where
 {
     fn run(&mut self, task: HintTask<E, W>) -> bool {
         match task {
-            HintTask::Append(file_id, batch) => self.append_log_batch(file_id, batch),
-            HintTask::Flush(file_id) => self.flush(file_id),
+            HintTask::Append {
+                queue,
+                file_id,
+                batch,
+            } => self.append_log_batch(queue, file_id, batch),
+            HintTask::Flush {
+                dir,
+                queue,
+                file_id,
+            } => {
+                if let Err(e) = self.flush(dir, queue, file_id) {
+                    warn!("flush hint file error: {}", e);
+                }
+            }
         }
         true
     }
     fn on_tick(&mut self) {
         // todo!()
+    }
+}
+
+fn open_hint_file_w<P: ?Sized + NixPath>(path: &P) -> Result<RawFd> {
+    let flags = OFlag::O_RDWR | OFlag::O_CREAT;
+    let mode = Mode::S_IRUSR | Mode::S_IWUSR;
+    fcntl::open(path, flags, mode).map_err(|e| parse_nix_error(e, "open_hint_file_w"))
+}
+
+fn open_hint_file_r<P: ?Sized + NixPath>(path: &P) -> Result<RawFd> {
+    let flags = OFlag::O_RDONLY;
+    let mode = Mode::S_IRWXU;
+    fcntl::open(path, flags, mode).map_err(|e| parse_nix_error(e, "open_hint_file_r"))
+}
+
+fn generate_filename(queue: LogQueue, file_id: FileId) -> String {
+    match queue {
+        LogQueue::Append => format!("{:016}{}", file_id, HINT_SUFFIX),
+        LogQueue::Rewrite => format!("{:08}{}", file_id, HINT_SUFFIX),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub use self::config::{Config, RecoveryMode};
 pub use self::errors::{Error, Result};
 pub use self::log_batch::{EntryExt, LogBatch};
 pub use self::util::ReadableSize;
-pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, FilePipeLog<X, Y>>;
+pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, FilePipeLog>;
 
 #[derive(Default)]
 pub struct GlobalStats {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod engine;
 mod errors;
 mod event_listener;
 mod file_pipe_log;
+mod hint;
 mod log_batch;
 mod memtable;
 mod pipe_log;
@@ -33,7 +34,7 @@ pub use self::config::{Config, RecoveryMode};
 pub use self::errors::{Error, Result};
 pub use self::log_batch::{EntryExt, LogBatch};
 pub use self::util::ReadableSize;
-pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, FilePipeLog>;
+pub type RaftLogEngine<X, Y> = self::engine::Engine<X, Y, FilePipeLog<X, Y>>;
 
 #[derive(Default)]
 pub struct GlobalStats {

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -1,7 +1,7 @@
 use std::borrow::{Borrow, Cow};
 use std::io::BufRead;
 use std::marker::PhantomData;
-use std::{mem, u64};
+use std::{mem, u64, vec};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use crc32fast::Hasher;
@@ -618,6 +618,30 @@ where
 
     pub fn entries_size(&self) -> usize {
         self.entries_size
+    }
+
+    pub fn add_raw_entries_index(&mut self, region_id: u64, entries_index: Vec<EntryIndex>) {
+        let item = LogItem {
+            raft_group_id: region_id,
+            content: LogItemContent::Entries(Entries::new(vec![], Some(entries_index))),
+        };
+        self.items.push(item);
+    }
+
+    pub fn add_raw_kv(&mut self, region_id: u64, kv: KeyValue) {
+        let item = LogItem {
+            raft_group_id: region_id,
+            content: LogItemContent::Kv(kv),
+        };
+        self.items.push(item);
+    }
+
+    pub fn add_raw_command(&mut self, region_id: u64, command: Command) {
+        let item = LogItem {
+            raft_group_id: region_id,
+            content: LogItemContent::Command(command),
+        };
+        self.items.push(item);
     }
 }
 

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -1,4 +1,5 @@
 use std::borrow::{Borrow, Cow};
+use std::fmt::Debug;
 use std::io::BufRead;
 use std::marker::PhantomData;
 use std::{mem, u64, vec};

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -115,13 +115,13 @@ impl CompressionType {
     }
 }
 
-type SliceReader<'a> = &'a [u8];
+pub type SliceReader<'a> = &'a [u8];
 
 pub trait EntryExt<M: Message>: Send + Sync {
     fn index(m: &M) -> u64;
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Entries<E>
 where
     E: Message,
@@ -233,7 +233,7 @@ impl<E: Message> Entries<E> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Command {
     Clean,
     Compact { index: u64 },
@@ -282,7 +282,7 @@ impl OpType {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct KeyValue {
     pub op_type: OpType,
     pub key: Vec<u8>,
@@ -334,7 +334,7 @@ impl KeyValue {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LogItem<E>
 where
     E: Message,
@@ -343,7 +343,7 @@ where
     pub content: LogItemContent<E>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum LogItemContent<E>
 where
     E: Message,
@@ -446,7 +446,7 @@ impl<E: Message> LogItem<E> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LogBatch<E, W>
 where
     E: Message,

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -552,11 +552,9 @@ impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::file_pipe_log::FilePipeLog as RawFilePipeLog;
+    use crate::file_pipe_log::FilePipeLog;
     use crate::pipe_log::PipeLog;
     use raft::eraftpb::Entry;
-
-    type FilePipeLog = RawFilePipeLog<Entry, Entry>;
 
     impl<E: Message + Clone, W: EntryExt<E>> MemTable<E, W> {
         pub fn max_file_id(&self, queue: LogQueue) -> Option<FileId> {
@@ -1022,7 +1020,7 @@ mod tests {
         assert_eq!(memtable.global_stats.compacted_rewrite_operations(), 78);
     }
 
-    fn generate_ents<P: PipeLog<Entry, Entry>>(
+    fn generate_ents<P: PipeLog>(
         begin_idx: u64,
         end_idx: u64,
         queue: LogQueue,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -79,7 +79,12 @@ impl FileId {
     }
 }
 
-pub trait PipeLog: Sized + Clone + Send {
+pub trait PipeLog<E, W>
+where
+    E: Message + Clone + 'static,
+    W: EntryExt<E> + Clone + 'static,
+    Self: Sized + Clone + Send,
+{
     /// Close the pipe log.
     fn close(&self) -> Result<()>;
 
@@ -97,7 +102,7 @@ pub trait PipeLog: Sized + Clone + Send {
         len: u64,
     ) -> Result<Vec<u8>>;
 
-    fn read_file<E: Message, W: EntryExt<E>>(
+    fn read_file(
         &self,
         queue: LogQueue,
         file_id: FileId,
@@ -106,7 +111,7 @@ pub trait PipeLog: Sized + Clone + Send {
     ) -> Result<()>;
 
     /// Write a batch into the append queue.
-    fn append<E: Message, W: EntryExt<E>>(
+    fn append(
         &self,
         queue: LogQueue,
         batch: &mut LogBatch<E, W>,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -79,12 +79,7 @@ impl FileId {
     }
 }
 
-pub trait PipeLog<E, W>
-where
-    E: Message + Clone + 'static,
-    W: EntryExt<E> + Clone + 'static,
-    Self: Sized + Clone + Send,
-{
+pub trait PipeLog: Sized + Clone + Send {
     /// Close the pipe log.
     fn close(&self) -> Result<()>;
 
@@ -102,7 +97,7 @@ where
         len: u64,
     ) -> Result<Vec<u8>>;
 
-    fn read_file(
+    fn read_file<E: Message, W: EntryExt<E>>(
         &self,
         queue: LogQueue,
         file_id: FileId,
@@ -111,7 +106,7 @@ where
     ) -> Result<()>;
 
     /// Write a batch into the append queue.
-    fn append(
+    fn append<E: Message, W: EntryExt<E>>(
         &self,
         queue: LogQueue,
         batch: &mut LogBatch<E, W>,

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -25,9 +25,9 @@ const REWRITE_BATCH_SIZE: usize = 1024 * 1024;
 #[derive(Clone)]
 pub struct PurgeManager<E, W, P>
 where
-    E: Message + Clone,
-    W: EntryExt<E> + Clone,
-    P: PipeLog,
+    E: Message + Clone + 'static,
+    W: EntryExt<E> + Clone + 'static,
+    P: PipeLog<E, W>,
 {
     cfg: Arc<Config>,
     memtables: MemTableAccessor<E, W>,
@@ -41,9 +41,9 @@ where
 
 impl<E, W, P> PurgeManager<E, W, P>
 where
-    E: Message + Clone,
-    W: EntryExt<E> + Clone,
-    P: PipeLog,
+    E: Message + Clone + 'static,
+    W: EntryExt<E> + Clone + 'static,
+    P: PipeLog<E, W>,
 {
     pub fn new(
         cfg: Arc<Config>,

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,8 +6,12 @@ use std::fmt::{self, Write};
 use std::hash::BuildHasherDefault;
 use std::ops::{Div, Mul};
 use std::str::FromStr;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::thread::{Builder, JoinHandle};
+use std::time::Duration;
 
+use crossbeam::channel::{unbounded, Receiver, Sender};
+use log::warn;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -209,5 +213,108 @@ impl<T> HandyRwLock<T> for RwLock<T> {
     }
     fn rl(&self) -> RwLockReadGuard<'_, T> {
         self.read().unwrap()
+    }
+}
+
+pub trait Runnable<T> {
+    fn run(&mut self, task: T) -> bool;
+    fn on_tick(&mut self);
+    fn shutdown(&mut self) {}
+}
+
+#[derive(Clone)]
+pub struct Scheduler<T> {
+    name: Arc<String>,
+    sender: Sender<Option<T>>,
+}
+
+// `scheduler` is `!Sync`, but we didn't uses the field.
+// unsafe impl<T> Sync for Worker<T> {}
+
+impl<T> Scheduler<T> {
+    pub fn schedule(&self, task: T) -> Result<(), ScheduleError<T>> {
+        if let Err(ScheduleError(e)) = self.sender.send(Some(task)) {
+            return Err(ScheduleError(e.unwrap()));
+        }
+        Ok(())
+    }
+}
+
+pub struct Worker<T: Clone> {
+    scheduler: Scheduler<T>,
+    receiver: Option<Receiver<Option<T>>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl<T: Clone> Worker<T> {
+    pub fn new(name: String) -> Self {
+        let (tx, rx) = unbounded();
+        let scheduler = Scheduler {
+            name: Arc::new(name),
+            sender: tx,
+        };
+        Worker {
+            scheduler,
+            receiver: Some(rx),
+            handle: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn take_receiver(&mut self) -> Receiver<Option<T>> {
+        self.receiver.take().unwrap()
+    }
+
+    pub fn scheduler(&self) -> Scheduler<T> {
+        self.scheduler.clone()
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            let _ = self.scheduler.sender.send(None);
+            if let Err(e) = handle.join() {
+                warn!("{} aborts with {:?}", &self.scheduler.name, e);
+            }
+        }
+    }
+}
+
+impl<T: Clone + Send + 'static> Worker<T> {
+    pub fn start<R>(&mut self, runner: R, tick: Option<Duration>) -> bool
+    where
+        R: Runnable<T> + Send + 'static,
+    {
+        let tick = tick.unwrap_or_else(|| Duration::from_secs(u64::MAX));
+        let receiver = match self.receiver.take() {
+            Some(rx) => rx,
+            None => return false,
+        };
+        let name = self.scheduler.name.as_ref().clone();
+        let th = Builder::new()
+            .name(name)
+            .spawn(move || poll(runner, receiver, tick))
+            .unwrap();
+        self.handle = Some(th);
+        true
+    }
+}
+
+fn poll<T, R: Runnable<T>>(mut runner: R, receiver: Receiver<Option<T>>, tick: Duration) {
+    loop {
+        match receiver.recv_timeout(tick) {
+            Ok(None) | Err(crossbeam::channel::RecvTimeoutError::Disconnected) => return,
+            Ok(Some(task)) => {
+                if runner.run(task) {
+                    runner.on_tick();
+                }
+            }
+            Err(crossbeam::channel::RecvTimeoutError::Timeout) => runner.on_tick(),
+        }
+    }
+}
+
+impl<T: Clone> Drop for Worker<T> {
+    fn drop(&mut self) {
+        self.stop();
     }
 }


### PR DESCRIPTION
`Hint` is a special kind of log file which only save the indexes
of log entries that refer to the real log file. When recovering
RaftEngine, needs to restore memtable which maintains all log
indexes. Previously, RaftEngine had to scan all of the log files
which is slow and reading actuall data is unneeded.

This implemenation constructs and flushes hint file in a background
thread.

TODO:
- [x] Implement hint worker and tasks.
- [x] Implement hint file format.
- [x] Save to & restore from file.
- [x] Refine hint code. Not modifying `PipeLog` trait.
- [x] Delete hint file when dropping log file.
- [ ] Unittests.
- [ ] Benchmark.

Signed-off-by: MrCroxx <mrcroxx@outlook.com>