### PR TITLE
Add recover-only option to stress.

### DIFF
--- a/stress/Cargo.toml
+++ b/stress/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["The TiKV Authors"]
 edition = "2018"
 
 [dependencies]
+byte-unit = "4.0.12"
 clap = "2.32"
 const_format = "0.2.13"
 hdrhistogram = "6.0"


### PR DESCRIPTION
Add `recovery-only` option to stress for measuring the recovery duration.

Signed-off-by: MrCroxx <mrcroxx@outlook.com>