### PR TITLE
Add bench case for recovery.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]
-byte-unit = "4.0.12"
 criterion = "0.3.5"
 ctor = "0.1"
 env_logger = "0.7"
@@ -55,4 +54,4 @@ members = [ "stress" ]
 [[bench]]
 name = "bench_recovery"
 harness = false
-required-features = ["fail/failpoints"]
+required-features = ["failpoints"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ fail = "0.4"
 fxhash = "0.2"
 hex = "0.4"
 lazy_static = "1.3"
+libc = "0.2.99"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }
 lz4-sys = "1.9.2"
 nix = "0.18.0"
@@ -27,6 +28,8 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]
+byte-unit = "4.0.12"
+criterion = "0.3.5"
 ctor = "0.1"
 env_logger = "0.7"
 kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = false, features = ["protobuf-codec"] }
@@ -48,3 +51,8 @@ protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", rev = "82
 
 [workspace]
 members = [ "stress" ]
+
+[[bench]]
+name = "bench_recovery"
+harness = false
+required-features = ["fail/failpoints"]

--- a/benches/bench_recovery.rs
+++ b/benches/bench_recovery.rs
@@ -1,0 +1,185 @@
+use byte_unit::Byte;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use raft::eraftpb::Entry;
+use raft_engine::ReadableSize;
+use raft_engine::{Config as EngineConfig, LogBatch, MessageExt, RaftLogEngine, Result};
+use rand::{Rng, SeedableRng};
+use std::collections::HashMap;
+use std::fmt;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+extern crate libc;
+
+type Engine = RaftLogEngine<MessageExtTyped>;
+
+#[derive(Clone)]
+struct MessageExtTyped;
+impl MessageExt for MessageExtTyped {
+    type Entry = Entry;
+
+    fn index(entry: &Entry) -> u64 {
+        entry.index
+    }
+}
+
+struct Config {
+    total_size: ReadableSize,
+    region_count: u64,
+    batch_size: ReadableSize,
+    item_size: ReadableSize,
+    entry_size: ReadableSize,
+    batch_compression_threshold: ReadableSize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            total_size: ReadableSize::gb(1),
+            region_count: 100,
+            batch_size: ReadableSize::mb(1),
+            item_size: ReadableSize::kb(1),
+            entry_size: ReadableSize(256),
+            batch_compression_threshold: ReadableSize(0),
+        }
+    }
+}
+
+impl fmt::Display for Config {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} [region-count: {}][batch-size: {}][item-size: {}][entry-size: {}][batch-compression-threshold: {}]",
+        size_to_readable_string(self.total_size.0 as u128),
+        self.region_count,
+        size_to_readable_string(self.batch_size.0 as u128),
+        size_to_readable_string(self.item_size.0 as u128),
+        size_to_readable_string(self.entry_size.0 as u128),
+        size_to_readable_string(self.batch_compression_threshold.0 as u128)
+    )
+    }
+}
+
+fn generate(cfg: &Config) -> Result<TempDir> {
+    let dir = tempfile::Builder::new().prefix("bench").tempdir().unwrap();
+    let path = dir.path().to_str().unwrap().to_owned();
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+
+    let mut ecfg = EngineConfig::new();
+    ecfg.dir = path.clone();
+    ecfg.batch_compression_threshold = cfg.batch_compression_threshold;
+
+    let engine = Engine::open(ecfg.clone()).unwrap();
+
+    let mut indexes: HashMap<u64, u64> = (1..cfg.region_count + 1).map(|rid| (rid, 0)).collect();
+    while dir_size(&path) < cfg.total_size.0 as u128 {
+        let mut batch = LogBatch::default();
+        while batch.approximate_size() < cfg.batch_size.0 as usize {
+            let region_id = rng.gen_range(1, cfg.region_count + 1);
+            let mut item_size = 0;
+            let mut entries = vec![];
+            while item_size < cfg.item_size.0 {
+                entries.push(Entry {
+                    data: (&mut rng)
+                        .sample_iter(rand::distributions::Standard)
+                        .take(cfg.entry_size.0 as usize)
+                        .collect::<Vec<u8>>(),
+                    ..Default::default()
+                });
+                item_size += cfg.entry_size.0;
+            }
+            let mut index = *indexes.get(&region_id).unwrap();
+            index = entries.iter_mut().fold(index, |index, e| {
+                e.index = index + 1;
+                index + 1
+            });
+            *indexes.get_mut(&region_id).unwrap() = index;
+            batch.add_entries(region_id, entries);
+        }
+        engine.write(&mut batch, false).unwrap();
+    }
+    drop(engine);
+    Ok(dir)
+}
+
+fn dir_size(path: &str) -> u128 {
+    let mut size: u128 = 0;
+    for entry in std::fs::read_dir(PathBuf::from(path)).unwrap() {
+        let entry = entry.unwrap();
+        size += std::fs::metadata(entry.path()).unwrap().len() as u128;
+    }
+    size
+}
+
+fn size_to_readable_string(size: u128) -> String {
+    Byte::from_bytes(size)
+        .get_appropriate_unit(true)
+        .to_string()
+}
+
+// Benchmarks
+
+fn bench_recovery(c: &mut Criterion) {
+    // prepare input
+    let cfgs = vec![
+        (
+            "default".to_owned(),
+            Config {
+                ..Default::default()
+            },
+        ),
+        (
+            "compressed".to_owned(),
+            Config {
+                batch_compression_threshold: ReadableSize::kb(8),
+                ..Default::default()
+            },
+        ),
+        (
+            "small-batch(1KB)".to_owned(),
+            Config {
+                region_count: 100,
+                batch_size: ReadableSize::kb(1),
+                item_size: ReadableSize(256),
+                entry_size: ReadableSize(32),
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (i, (name, cfg)) in cfgs.iter().enumerate() {
+        println!("config-{}: [{}] {}", i, name, cfg);
+    }
+
+    for (i, (name, cfg)) in cfgs.iter().enumerate() {
+        let dir = generate(&cfg).unwrap();
+        let path = dir.path().to_str().unwrap().to_owned();
+        fail::cfg("fadvise-dontneed", "return").unwrap();
+        let mut ecfg = EngineConfig::default();
+        ecfg.dir = path.clone();
+        ecfg.batch_compression_threshold = cfg.batch_compression_threshold;
+
+        c.bench_with_input(
+            BenchmarkId::new(
+                "Engine::open",
+                format!(
+                    "size:{} config-{}: {}",
+                    size_to_readable_string(dir_size(&path)),
+                    i,
+                    name
+                ),
+            ),
+            &ecfg,
+            |b, cfg| {
+                b.iter(|| {
+                    Engine::open(cfg.to_owned()).unwrap();
+                })
+            },
+        );
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_recovery
+}
+criterion_main!(benches);

--- a/benches/bench_recovery.rs
+++ b/benches/bench_recovery.rs
@@ -49,13 +49,13 @@ impl Default for Config {
 impl fmt::Display for Config {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} [region-count: {}][batch-size: {}][item-size: {}][entry-size: {}][batch-compression-threshold: {}]",
-        self.total_size,
-        self.region_count,
-        self.batch_size,
-        self.item_size,
-        self.entry_size,
-        self.batch_compression_threshold
-    )
+            self.total_size,
+            self.region_count,
+            self.batch_size,
+            self.item_size,
+            self.entry_size,
+            self.batch_compression_threshold
+        )
     }
 }
 

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -78,6 +78,7 @@ impl LogFd {
             let fd = fcntl::open(path, flags, mode).map_err(|e| parse_nix_error(e, "open"))?;
             let fd = LogFd(fd);
             fd.read_header()?;
+            #[cfg(target_os = "linux")]
             unsafe {
                 extern crate libc;
                 libc::posix_fadvise64(fd.0, 0, fd.file_size()? as i64, libc::POSIX_FADV_DONTNEED);

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
 
+use fail::fail_point;
 use log::{debug, info, warn};
 use nix::errno::Errno;
 use nix::fcntl::{self, OFlag};
@@ -73,6 +74,16 @@ impl LogFd {
     fn open<P: ?Sized + NixPath>(path: &P) -> Result<Self> {
         let flags = OFlag::O_RDWR;
         let mode = Mode::S_IRWXU;
+        fail_point!("fadvise-dontneed", |_| {
+            let fd = fcntl::open(path, flags, mode).map_err(|e| parse_nix_error(e, "open"))?;
+            let fd = LogFd(fd);
+            fd.read_header()?;
+            unsafe {
+                extern crate libc;
+                libc::posix_fadvise64(fd.0, 0, fd.file_size()? as i64, libc::POSIX_FADV_DONTNEED);
+            }
+            Ok(fd)
+        });
         let fd = fcntl::open(path, flags, mode).map_err(|e| parse_nix_error(e, "open"))?;
         let fd = LogFd(fd);
         fd.read_header()?;
@@ -263,7 +274,6 @@ impl LogManager {
             let mut path = PathBuf::from(&self.dir);
             path.push(logs.last().unwrap());
             let fd = Arc::new(LogFd::open(&path)?);
-
             self.active_log_size = fd.file_size()?;
             self.active_log_capacity = self.active_log_size;
             self.last_sync_size = self.active_log_size;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::collections::{HashMap as StdHashMap, VecDeque};
-use std::fmt::{self, Write};
+use std::fmt::{self, Display, Write};
 use std::hash::BuildHasherDefault;
 use std::ops::{Div, Mul};
 use std::str::FromStr;
@@ -134,6 +134,24 @@ impl FromStr for ReadableSize {
         match size.parse::<f64>() {
             Ok(n) => Ok(ReadableSize((n * unit as f64) as u64)),
             Err(_) => Err(format!("invalid size string: {:?}", s)),
+        }
+    }
+}
+
+impl Display for ReadableSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.0 >= PB {
+            write!(f, "{:.1}PiB", self.0 as f64 / PB as f64)
+        } else if self.0 >= TB {
+            write!(f, "{:.1}TiB", self.0 as f64 / TB as f64)
+        } else if self.0 >= GB {
+            write!(f, "{:.1}GiB", self.0 as f64 / GB as f64)
+        } else if self.0 >= MB {
+            write!(f, "{:.1}<MiB", self.0 as f64 / MB as f64)
+        } else if self.0 >= KB {
+            write!(f, "{:.1}KiB", self.0 as f64 / KB as f64)
+        } else {
+            write!(f, "{}B", self.0)
         }
     }
 }


### PR DESCRIPTION
 Add recovery benchmarking.

use `cargo bench --features=failpoints` to run `bench_recovery`.

To get the complete output, you may want to run:
```bash
cargo bench --bench bench_recovery --features="failpoints" -- --verbose --nocapture
```