### PR TITLE
Fix build with older version on some platform.

### DIFF
--- a/benches/bench_recovery.rs
+++ b/benches/bench_recovery.rs
@@ -82,7 +82,8 @@ fn generate(cfg: &Config) -> Result<TempDir> {
                     data: (&mut rng)
                         .sample_iter(rand::distributions::Standard)
                         .take(cfg.entry_size.0 as usize)
-                        .collect::<Vec<u8>>(),
+                        .collect::<Vec<u8>>()
+                        .into(),
                     ..Default::default()
                 });
                 item_size += cfg.entry_size.0;


### PR DESCRIPTION
With `nightly-2021-07-28-x86_64-unknown-linux-gnu(rustc 1.56.0-nightly,
2faabf579)` on Centos, `bench_recovery` cannot compile. Add this line
will fix the problem.

Signed-off-by: MrCroxx <mrcroxx@outlook.com>