### PR TITLE
reduce allocation of log batch compression

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2020-10-19
+          toolchain: nightly-2021-07-28
           override: true
           components: clippy
       - name: Clippy

--- a/benches/bench_recovery.rs
+++ b/benches/bench_recovery.rs
@@ -95,7 +95,7 @@ fn generate(cfg: &Config) -> Result<TempDir> {
             });
             *indexes.get_mut(&region_id).unwrap() = index;
             batch
-                .add_entries::<MessageExtTyped>(region_id, entries)
+                .add_entries::<MessageExtTyped>(region_id, &entries)
                 .unwrap();
         }
         engine.write(&mut batch, false).unwrap();

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -57,7 +57,7 @@ fn main() {
             let mut e = entry.clone();
             e.index = state.last_index + 1;
             batch
-                .add_entries::<MessageExtTyped>(region, vec![e; 1])
+                .add_entries::<MessageExtTyped>(region, &[e])
                 .unwrap();
             batch
                 .put_message(region, b"last_index".to_vec(), &state)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -312,16 +312,15 @@ where
             0
         } else {
             let (file_id, bytes) = self.pipe_log.append(LogQueue::Append, log_batch, sync)?;
-            if file_id.valid() {
-                Self::apply_to_memtable(
-                    &self.memtables,
-                    log_batch.drain(),
-                    LogQueue::Append,
-                    file_id,
-                );
-                for listener in &self.listeners {
-                    listener.post_apply_memtables(LogQueue::Append, file_id);
-                }
+            debug_assert!(file_id.valid());
+            Self::apply_to_memtable(
+                &self.memtables,
+                log_batch.drain(),
+                LogQueue::Append,
+                file_id,
+            );
+            for listener in &self.listeners {
+                listener.post_apply_memtables(LogQueue::Append, file_id);
             }
             bytes
         };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -466,7 +466,7 @@ mod tests {
 
     type RaftLogEngine = Engine<Entry, FilePipeLog>;
     impl RaftLogEngine {
-        fn append(&self, raft_group_id: u64, entries: Vec<Entry>) -> Result<usize> {
+        fn append(&self, raft_group_id: u64, entries: &Vec<Entry>) -> Result<usize> {
             let mut batch = LogBatch::default();
             batch.add_entries::<Entry>(raft_group_id, entries)?;
             self.write(&mut batch, false)
@@ -476,7 +476,7 @@ mod tests {
     fn append_log(engine: &RaftLogEngine, raft: u64, entry: &Entry) {
         let mut log_batch = LogBatch::default();
         log_batch
-            .add_entries::<Entry>(raft, vec![entry.clone()])
+            .add_entries::<Entry>(raft, &vec![entry.clone()])
             .unwrap();
         log_batch
             .put_message(
@@ -539,9 +539,9 @@ mod tests {
             entry.set_data(vec![b'x'; entry_size].into());
             for i in 10..20 {
                 entry.set_index(i);
-                engine.append(i, vec![entry.clone()]).unwrap();
+                engine.append(i, &vec![entry.clone()]).unwrap();
                 entry.set_index(i + 1);
-                engine.append(i, vec![entry.clone()]).unwrap();
+                engine.append(i, &vec![entry.clone()]).unwrap();
             }
 
             for i in 10..20 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@
 
 #![feature(shrink_to)]
 #![feature(cell_update)]
+#![feature(test)]
 
 #[macro_use]
 extern crate lazy_static;
+extern crate test;
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -25,7 +25,8 @@ const TYPE_KV: u8 = 0x3;
 const CMD_CLEAN: u8 = 0x01;
 const CMD_COMPACT: u8 = 0x02;
 
-const DEFAULT_BATCH_CAP: usize = 64;
+const DEFAULT_LOG_ITEM_BATCH_CAP: usize = 64;
+const MAX_LOG_BATCH_BUFFER_CAP: usize = 4 * 1024 * 1024; // 4MB
 
 pub trait MessageExt: Send + Sync {
     type Entry: Message + Clone + PartialEq;
@@ -319,12 +320,6 @@ pub struct LogItemBatch {
     item_size: usize,
 }
 
-impl Default for LogItemBatch {
-    fn default() -> Self {
-        Self::with_capacity(DEFAULT_BATCH_CAP)
-    }
-}
-
 impl LogItemBatch {
     pub fn with_capacity(cap: usize) -> Self {
         Self {
@@ -427,83 +422,82 @@ impl LogItemBatch {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 enum BufState {
-    Uninitialized,
-    EntriesFilled,
+    /// Buffer contains header and optionally entries.
+    /// # Invariants
+    /// LOG_BATCH_HEADER_LEN <= buf.len()
+    Open,
+    /// Buffer contains header, entries and footer; ready to be written. This
+    /// state only briefly exists between encoding and writing, user operation
+    /// will panic under this state.
+    /// # Content
+    /// counter: Buffer offset of header.
+    /// # Invariants
+    /// LOG_BATCH_HEADER_LEN <= buf.len()
     Sealed(usize),
+    /// Buffer is undergoing writes. User operation will panic under this state.
     Incomplete,
 }
 
 // Format:
 // { u56 len | u8 compression type | u64 item offset | (compressed) entries | crc32 | item batch }
-#[derive(Debug, PartialEq)]
 pub struct LogBatch {
     item_batch: LogItemBatch,
-    buf: Vec<u8>,
     buf_state: BufState,
+    buf: Vec<u8>,
 }
 
 impl Default for LogBatch {
     fn default() -> Self {
-        Self::with_capacity(DEFAULT_BATCH_CAP)
+        Self::with_capacity(DEFAULT_LOG_ITEM_BATCH_CAP)
     }
 }
 
 impl LogBatch {
     pub fn with_capacity(cap: usize) -> Self {
+        let mut buf = Vec::with_capacity(4096);
+        buf.resize(LOG_BATCH_HEADER_LEN, 0);
         Self {
             item_batch: LogItemBatch::with_capacity(cap),
-            buf: Vec::with_capacity(4096),
-            buf_state: BufState::Uninitialized,
+            buf_state: BufState::Open,
+            buf,
         }
     }
 
-    pub fn drain(&mut self) -> LogItemDrain {
-        self.buf.clear();
-        self.buf_state = BufState::Uninitialized;
+    pub(crate) fn drain(&mut self) -> LogItemDrain {
+        debug_assert!(matches!(self.buf_state, BufState::Sealed(_)));
+
+        self.buf.shrink_to(MAX_LOG_BATCH_BUFFER_CAP);
+        self.buf.truncate(LOG_BATCH_HEADER_LEN);
+        self.buf_state = BufState::Open;
         self.item_batch.drain()
     }
 
-    pub fn merge(&mut self, rhs: &mut Self) {
+    pub fn merge(&mut self, rhs: &mut Self) -> Result<()> {
+        debug_assert!(self.buf_state == BufState::Open && rhs.buf_state == BufState::Open);
+
+        if !rhs.buf.is_empty() {
+            self.buf_state = BufState::Incomplete;
+            let buf_offset = self.buf.len() - LOG_BATCH_HEADER_LEN;
+            self.buf.extend_from_slice(&rhs.buf[LOG_BATCH_HEADER_LEN..]);
+            rhs.buf.shrink_to(MAX_LOG_BATCH_BUFFER_CAP);
+            rhs.buf.truncate(LOG_BATCH_HEADER_LEN);
+            for item in &mut rhs.item_batch.items {
+                if let LogItemContent::EntriesIndex(entries_index) = &mut item.content {
+                    for ei in entries_index.0.iter_mut() {
+                        ei.entries_offset += buf_offset as u64;
+                    }
+                }
+            }
+            self.buf_state = BufState::Open;
+        }
         self.item_batch.items.append(&mut rhs.item_batch.items);
-        if rhs.buf_state != BufState::Uninitialized {
-            // truncate both footers
-            if let BufState::Sealed(footer) = self.buf_state {
-                self.buf.truncate(footer);
-            }
-            if let BufState::Sealed(footer) = rhs.buf_state {
-                rhs.buf.truncate(footer);
-            }
-            match self.buf_state {
-                BufState::Uninitialized => {
-                    self.buf.append(&mut rhs.buf);
-                }
-                _ => {
-                    self.buf.extend_from_slice(&rhs.buf[LOG_BATCH_HEADER_LEN..]);
-                    rhs.buf.clear();
-                }
-            }
-            self.buf_state = BufState::EntriesFilled;
-            rhs.buf_state = BufState::Uninitialized;
-        }
-    }
-
-    pub fn set_position(&mut self, queue: LogQueue, file_id: FileId, offset: Option<u64>) {
-        self.item_batch.set_position(queue, file_id, offset);
-    }
-
-    fn prepare_buffer_for_write(&mut self) -> Result<()> {
-        if self.buf_state == BufState::Uninitialized {
-            self.buf_state = BufState::Incomplete;
-            self.buf.encode_u64(0)?;
-            self.buf.encode_u64(0)?;
-        } else if self.buf_state != BufState::EntriesFilled {
-            // return error
-        } else {
-            self.buf_state = BufState::Incomplete;
-        }
         Ok(())
+    }
+
+    pub(crate) fn set_position(&mut self, queue: LogQueue, file_id: FileId, offset: Option<u64>) {
+        self.item_batch.set_position(queue, file_id, offset);
     }
 
     pub fn add_entries<M: MessageExt>(
@@ -511,8 +505,10 @@ impl LogBatch {
         region_id: u64,
         mut entries: Vec<M::Entry>,
     ) -> Result<()> {
+        debug_assert!(self.buf_state == BufState::Open);
+
         let mut entry_indexes = Vec::with_capacity(entries.len());
-        self.prepare_buffer_for_write()?;
+        self.buf_state = BufState::Incomplete;
         for e in entries.drain(..) {
             let buf_offset = self.buf.len();
             e.write_to_vec(&mut self.buf)?;
@@ -523,7 +519,7 @@ impl LogBatch {
                 ..Default::default()
             });
         }
-        self.buf_state = BufState::EntriesFilled;
+        self.buf_state = BufState::Open;
         self.item_batch.add_entry_indexes(region_id, entry_indexes);
         Ok(())
     }
@@ -548,37 +544,43 @@ impl LogBatch {
         self.item_batch.items.is_empty()
     }
 
-    pub fn encoded_bytes(&mut self, compression_threshold: usize) -> Result<&[u8]> {
+    pub(crate) fn encoded_bytes(&mut self, compression_threshold: usize) -> Result<&[u8]> {
         // TODO: avoid to write a large batch into one compressed chunk.
-        if self.is_empty() || matches!(self.buf_state, BufState::Sealed(_)) {
-            return Ok(&self.buf);
+        if let BufState::Sealed(header_offset) = self.buf_state {
+            return Ok(&self.buf[header_offset..]);
         }
-        self.prepare_buffer_for_write()?;
+        debug_assert!(self.buf_state == BufState::Open);
+        self.buf_state = BufState::Incomplete;
 
-        // encode entries.
-        let compression_type = if compression_threshold > 0
-            && (self.buf.len() - LOG_BATCH_HEADER_LEN) > compression_threshold
+        // entries
+        let (header_offset, compression_type) = if compression_threshold > 0
+            && self.buf.len() > LOG_BATCH_HEADER_LEN + compression_threshold
         {
-            self.buf =
-                lz4::encode_block(&self.buf[LOG_BATCH_HEADER_LEN..], LOG_BATCH_HEADER_LEN, 4);
-            CompressionType::Lz4
+            let buf_len = self.buf.len();
+            lz4::append_encode_block(&mut self.buf, LOG_BATCH_HEADER_LEN);
+            (buf_len - LOG_BATCH_HEADER_LEN, CompressionType::Lz4)
         } else {
-            CompressionType::None
+            (0, CompressionType::None)
         };
-        if self.buf.len() > LOG_BATCH_HEADER_LEN {
-            let checksum = crc32(&self.buf[LOG_BATCH_HEADER_LEN..]);
+
+        // checksum
+        if self.buf.len() > header_offset + LOG_BATCH_HEADER_LEN {
+            let checksum = crc32(&self.buf[header_offset + LOG_BATCH_HEADER_LEN..]);
             self.buf.encode_u32_le(checksum)?;
         }
-        let offset = self.buf.len() as u64;
+        let footer_roffset = self.buf.len() - header_offset;
 
+        // footer
         self.item_batch.encode(&mut self.buf)?;
 
-        // encode header.
-        let len = ((self.buf.len() as u64) << 8) | u64::from(compression_type.to_u8());
-        (&mut self.buf[..LOG_BATCH_HEADER_LEN]).write_u64::<BigEndian>(len)?;
-        (&mut self.buf[8..LOG_BATCH_HEADER_LEN]).write_u64::<BigEndian>(offset)?;
+        // header
+        let len =
+            (((self.buf.len() - header_offset) as u64) << 8) | u64::from(compression_type.to_u8());
+        (&mut self.buf[header_offset..header_offset + 8]).write_u64::<BigEndian>(len)?;
+        (&mut self.buf[header_offset + 8..header_offset + 16])
+            .write_u64::<BigEndian>(footer_roffset as u64)?;
 
-        self.buf_state = BufState::Sealed(offset as usize);
+        self.buf_state = BufState::Sealed(header_offset);
 
         // update entry indexes.
         for item in self.item_batch.items.iter_mut() {
@@ -586,29 +588,23 @@ impl LogBatch {
                 for ei in entries_index.0.iter_mut() {
                     ei.compression_type = compression_type;
                     ei.entries_offset = LOG_BATCH_HEADER_LEN as u64; // need to add batch offset of the file after written.
-                    ei.entries_len = offset as usize - LOG_BATCH_HEADER_LEN;
+                    ei.entries_len = footer_roffset - LOG_BATCH_HEADER_LEN;
                 }
             }
         }
-        Ok(&self.buf)
+        Ok(&self.buf[header_offset..])
     }
 
-    // Not meaningful after recovery.
+    /// Report encoded size of current log batch.
     pub fn size(&self) -> usize {
         if self.is_empty() {
             0
         } else {
             match self.buf_state {
-                BufState::Uninitialized => LOG_BATCH_HEADER_LEN + self.item_batch.size(),
-                BufState::EntriesFilled => {
-                    LOG_BATCH_HEADER_LEN
-                        + self.buf.len()
-                        + LOG_BATCH_CHECKSUM_LEN
-                        + self.item_batch.size()
-                }
-                BufState::Sealed(_) => self.buf.len(),
-                BufState::Incomplete => {
-                    error!("querying incomplete log batch");
+                BufState::Open => self.buf.len() + LOG_BATCH_CHECKSUM_LEN + self.item_batch.size(),
+                BufState::Sealed(header_offset) => self.buf.len() - header_offset,
+                s => {
+                    error!("querying incomplete log batch with state {:?}", s);
                     0
                 }
             }
@@ -617,6 +613,7 @@ impl LogBatch {
 
     pub fn decode_header(buf: &mut SliceReader) -> Result<(usize, CompressionType, usize)> {
         assert!(buf.len() >= LOG_BATCH_HEADER_LEN);
+
         let len = codec::decode_u64(buf)? as usize;
         let offset = codec::decode_u64(buf)? as usize;
         let compression_type = CompressionType::from_u8(len as u8);
@@ -626,17 +623,18 @@ impl LogBatch {
     pub fn parse_entry<M: MessageExt>(buf: &[u8], idx: &EntryIndex) -> Result<M::Entry> {
         let len = idx.entries_len;
         verify_checksum(&buf[0..len])?;
-        let bytes = match idx.compression_type {
-            CompressionType::None => {
-                buf[idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len].to_owned()
-            }
+        match idx.compression_type {
+            CompressionType::None => Ok(parse_from_bytes(
+                &buf[idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
+            )?),
             CompressionType::Lz4 => {
                 let decompressed = lz4::decode_block(&buf[..len - LOG_BATCH_CHECKSUM_LEN]);
-                decompressed[idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len]
-                    .to_vec()
+                Ok(parse_from_bytes(
+                    &decompressed
+                        [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
+                )?)
             }
-        };
-        Ok(parse_from_bytes(&bytes)?)
+        }
     }
 }
 
@@ -657,27 +655,16 @@ mod tests {
     use super::*;
 
     use crate::test_util::{generate_entries, generate_entry_indexes};
-    use protobuf::parse_from_bytes;
     use raft::eraftpb::Entry;
 
-    fn decode_entries_from_bytes<E: Message>(
+    fn decode_entries_from_bytes<M: MessageExt>(
         buf: &[u8],
-        entries_index: &[EntryIndex],
-        encoded: bool,
-    ) -> Vec<E> {
-        let mut data = buf.to_owned();
-        if encoded {
-            data = lz4::decode_block(&data[..data.len() - LOG_BATCH_CHECKSUM_LEN]);
-        }
-        let mut entries = vec![];
-        for entry_index in entries_index {
-            entries.push(
-                parse_from_bytes(
-                    &data[entry_index.entry_offset as usize
-                        ..entry_index.entry_offset as usize + entry_index.entry_len],
-                )
-                .unwrap(),
-            );
+        entry_indexes: &[EntryIndex],
+        _encoded: bool,
+    ) -> Vec<M::Entry> {
+        let mut entries = Vec::with_capacity(entry_indexes.len());
+        for ei in entry_indexes {
+            entries.push(LogBatch::parse_entry::<M>(buf, ei).unwrap());
         }
         entries
     }
@@ -804,7 +791,7 @@ mod tests {
             if let LogItemContent::EntriesIndex(entries_index) = &item.content {
                 let origin_entries = generate_entries(1, 10, Some(vec![b'x'; 1024].into()));
                 let decoded_entries =
-                    decode_entries_from_bytes(&mut entries, &entries_index.0, false);
+                    decode_entries_from_bytes::<Entry>(&mut entries, &entries_index.0, false);
                 assert_eq!(origin_entries, decoded_entries);
             }
         }

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -241,7 +241,7 @@ where
                 total_size += entry.compute_size();
                 entries.push(entry);
             }
-            log_batch.add_entries::<M>(region_id, entries)?;
+            log_batch.add_entries::<M>(region_id, &entries)?;
             for (k, v) in kvs {
                 log_batch.put(region_id, k, v);
             }

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -230,7 +230,7 @@ fn spawn_write(
                     let last = engine.last_index(rid).unwrap_or(0);
                     let entries = prepare_entries(&entry_batch, last + 1);
                     log_batch
-                        .add_entries::<MessageExtTyped>(rid, entries)
+                        .add_entries::<MessageExtTyped>(rid, &entries)
                         .unwrap();
                     if args.compact_count > 0 && last - first + 1 > args.compact_count {
                         log_batch.add_command(


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

1. Append compressed entries to log batch buffer instead of replacing the buffer.
2. Avoid allocate twice when creating `protobuf::Message` from decompressed slice
3. Use entry reference for log batch append

Bench results:
```
Patched:
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     136,299 ns/iter (+/- 44,912)
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     131,405 ns/iter (+/- 82,630)

Master:
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     199,314 ns/iter (+/- 95,954)
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     197,948 ns/iter (+/- 16,842)

Without streaming encoding(#91):
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     407,738 ns/iter (+/- 142,417)
test log_batch::tests::bench_log_batch_add_entry_and_encode ... bench:     411,079 ns/iter (+/- 111,409)
```