### PR TITLE
Add some micro optimizations

### DIFF
--- a/src/log_file.rs
+++ b/src/log_file.rs
@@ -10,7 +10,7 @@ use nix::errno::Errno;
 use nix::fcntl::{self, OFlag};
 use nix::sys::stat::Mode;
 use nix::sys::uio::{pread, pwrite};
-use nix::unistd::{close, fsync, ftruncate, lseek, Whence};
+use nix::unistd::{close, fdatasync, ftruncate, lseek, Whence};
 use nix::NixPath;
 
 /// A `LogFd` is a RAII file that provides basic I/O functionality.
@@ -59,7 +59,7 @@ impl LogFd {
     }
 
     pub fn sync(&self) -> IoResult<()> {
-        fsync(self.0).map_err(|e| from_nix_error(e, "fsync"))
+        fdatasync(self.0).map_err(|e| from_nix_error(e, "fsync"))
     }
 
     pub fn read(&self, mut offset: usize, buf: &mut [u8]) -> IoResult<usize> {
@@ -112,7 +112,7 @@ impl LogFd {
         {
             fcntl::fallocate(
                 self.0,
-                fcntl::FallocateFlags::FALLOC_FL_KEEP_SIZE,
+                fcntl::FallocateFlags::empty(),
                 offset as i64,
                 size as i64,
             )

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -84,9 +84,6 @@ impl FileId {
 }
 
 pub trait PipeLog: Sized {
-    /// Close the pipe log.
-    fn close(&self) -> Result<()>;
-
     fn file_size(&self, queue: LogQueue, file_id: FileId) -> Result<u64>;
 
     /// Total size of the given queue.

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -55,6 +55,9 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                 LOG_BATCH_HEADER_LEN,
                 0,
             )?)?;
+            if self.valid_offset + len > self.size {
+                return Err(Error::Corruption("log batch header broken".to_owned()));
+            }
             let entries_offset = self.valid_offset + LOG_BATCH_HEADER_LEN;
             let entries_len = footer_offset - LOG_BATCH_HEADER_LEN;
 


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

This PR contains some micro optimizations:
1. use `fdatasync` instead of `fsync`
2. Fallocate without `FALLOC_FL_KEEP_SIZE`
3. Reduce useless fallocate near end of file, so we don't need to truncate them again when rotating

Up to 60% throughput improvement:

```
> Commit 3a12e9b
- Thread 1
[write]
Throughput(QPS) = 8861.94
Latency(μs) min = 54, avg = 92.93, p50 = 89, p90 = 116, p95 = 127, p99 = 158, p99.9 = 379, max = 4979
Fairness = 100.0%
Write Bandwidth = 6.5MiB/s
- Thread 2
[write]
Throughput(QPS) = 18929.47
Latency(μs) min = 44, avg = 87.72, p50 = 84, p90 = 108, p95 = 120, p99 = 151, p99.9 = 393, max = 3977
Fairness = 100.0%
Write Bandwidth = 14.1MiB/s
- Thread 4
[write]
Throughput(QPS) = 33652.27
Latency(μs) min = 48, avg = 100.87, p50 = 96, p90 = 126, p95 = 140, p99 = 186, p99.9 = 559, max = 5851
Fairness = 99.9%
Write Bandwidth = 25.1MiB/s
- Thread 8
[write]
Throughput(QPS) = 50167.37
Latency(μs) min = 49, avg = 141.98, p50 = 135, p90 = 200, p95 = 221, p99 = 273, p99.9 = 793, max = 8839
Fairness = 99.8%
Write Bandwidth = 37.5MiB/s
- Thread 16
[write]
Throughput(QPS) = 54640.66
Latency(μs) min = 54, avg = 274.61, p50 = 270, p90 = 407, p95 = 477, p99 = 634, p99.9 = 1096, max = 5571
Fairness = 99.9%
Write Bandwidth = 40.9MiB/s
> Branch micro-optims (current)
Your branch is ahead of 'pingcap/master' by 1 commit.
  (use "git push" to publish your local commits)
- Thread 1
[write]
Throughput(QPS) = 14211.08
Latency(μs) min = 22, avg = 52.25, p50 = 39, p90 = 99, p95 = 120, p99 = 160, p99.9 = 246, max = 5227
Fairness = 100.0%
Write Bandwidth = 10.6MiB/s
- Thread 2
[write]
Throughput(QPS) = 25428.83
Latency(μs) min = 25, avg = 61.42, p50 = 51, p90 = 94, p95 = 103, p99 = 130, p99.9 = 228, max = 4979
Fairness = 99.8%
Write Bandwidth = 19.0MiB/s
- Thread 4
[write]
Throughput(QPS) = 40231.87
Latency(μs) min = 29, avg = 82.12, p50 = 86, p90 = 111, p95 = 121, p99 = 143, p99.9 = 326, max = 5071
Fairness = 99.8%
Write Bandwidth = 30.1MiB/s
- Thread 8
[write]
Throughput(QPS) = 59353.86
Latency(μs) min = 30, avg = 117.21, p50 = 113, p90 = 171, p95 = 189, p99 = 242, p99.9 = 522, max = 11607
Fairness = 99.4%
Write Bandwidth = 44.5MiB/s
- Thread 16
[write]
Throughput(QPS) = 62574.20
Latency(μs) min = 30, avg = 236.92, p50 = 226, p90 = 362, p95 = 423, p99 = 579, p99.9 = 1019, max = 5747
Fairness = 99.7%
Write Bandwidth = 46.9MiB/s
```