### PR TITLE
Support configuring parallelizing fsync

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub recovery_mode: RecoveryMode,
     pub bytes_per_sync: ReadableSize,
     pub target_file_size: ReadableSize,
+    pub parallelize_fsync: bool,
 
     /// Only purge if disk file size is greater than `purge_threshold`.
     pub purge_threshold: ReadableSize,
@@ -33,7 +34,7 @@ pub struct Config {
 
     /// Read block size for recovery. Default value: "4KB". Min value: "512B".
     pub recovery_read_block_size: ReadableSize,
-    /// Parallel recovery concurrency. Default value: "8". Min value: "1".
+    /// Parallel recovery concurrency. Default value: 4. Min value: 1.
     pub recovery_threads: usize,
 }
 
@@ -44,10 +45,11 @@ impl Default for Config {
             recovery_mode: RecoveryMode::TolerateCorruptedTailRecords,
             bytes_per_sync: ReadableSize::kb(256),
             target_file_size: ReadableSize::mb(128),
+            parallelize_fsync: false,
             purge_threshold: ReadableSize::gb(10),
             batch_compression_threshold: ReadableSize::kb(8),
             recovery_read_block_size: ReadableSize::kb(4),
-            recovery_threads: 8,
+            recovery_threads: 4,
         }
     }
 }

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -389,6 +389,7 @@ pub struct FilePipeLog<B: FileBuilder> {
     dir: String,
     rotate_size: usize,
     compression_threshold: usize,
+    parallelize_fsync: bool,
 
     appender: Arc<RwLock<LogManager<B>>>,
     rewriter: Arc<RwLock<LogManager<B>>>,
@@ -499,6 +500,7 @@ impl<B: FileBuilder> FilePipeLog<B> {
                 dir: cfg.dir.clone(),
                 rotate_size: cfg.target_file_size.0 as usize,
                 compression_threshold: cfg.batch_compression_threshold.0 as usize,
+                parallelize_fsync: cfg.parallelize_fsync,
                 appender,
                 rewriter,
                 file_builder,
@@ -617,13 +619,16 @@ impl<B: FileBuilder> FilePipeLog<B> {
         content: &[u8],
         sync: &mut bool,
     ) -> Result<(FileId, u64)> {
-        let (file_id, offset, fd) = self.mut_queue(queue).append(content, sync)?;
+        let mut queue = self.mut_queue(queue);
+        let (file_id, offset, fd) = queue.append(content, sync)?;
+        if self.parallelize_fsync {
+            std::mem::drop(queue);
+        }
         if *sync {
             let start = Instant::now();
             fd.sync()?;
             LOG_SYNC_TIME_HISTOGRAM.observe(start.saturating_elapsed().as_secs_f64());
         }
-
         Ok((file_id, offset))
     }
 

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -546,6 +546,14 @@ fn main() {
                 .help("Compress log batch bigger than this threshold")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("parallelize_fsync")
+                .long("parallelize-fsync")
+                .value_name("enable")
+                .default_value("false")
+                .help("Whether to call fsync in parallel")
+                .takes_value(true),
+        )
         .get_matches();
     // Raft Engine configurations
     if let Some(s) = matches.value_of("path") {
@@ -559,6 +567,9 @@ fn main() {
     }
     if let Some(s) = matches.value_of("batch_compression_threshold") {
         config.batch_compression_threshold = ReadableSize::from_str(s).unwrap();
+    }
+    if let Some(s) = matches.value_of("parallelize_fsync") {
+        config.parallelize_fsync = s.parse::<bool>().unwrap();
     }
     // Test configurations
     if let Some(s) = matches.value_of("time") {


### PR DESCRIPTION
Previously, `fsync` is called outside of write mutex, which could results in excessive IOPS and hurts performance of other IO sensitive tasks resident on the same disk.

Add configuration item `parallelize_fsync` to toggle between fsync inside/outside write mutex.

Benchmark shows less than 3% regression for single thread workload:
```
Master:
- Thread 1
[write]
Throughput(QPS) = 13878.95
Latency(μs) min = 23, avg = 53.08, p50 = 41, p90 = 100, p95 = 122, p99 = 162, p99.9 = 258, max = 3991
Fairness = 100.0%
Write Bandwidth = 10.3MiB/s

Patched:
- Thread 1
[write]
Throughput(QPS) = 13562.47
Latency(μs) min = 23, avg = 54.68, p50 = 43, p90 = 103, p95 = 125, p99 = 164, p99.9 = 253, max = 2985
Fairness = 100.0%
Write Bandwidth = 10.1MiB/s
```