### PR TITLE
fix bug when writing empty protobuf message

### DIFF
--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -646,7 +646,10 @@ impl LogBatch {
 
     pub fn parse_entry<M: MessageExt>(buf: &[u8], idx: &EntryIndex) -> Result<M::Entry> {
         let len = idx.entries_len;
-        verify_checksum(&buf[0..len])?;
+        if len > 0 {
+            // protobuf message can be serialized to empty string.
+            verify_checksum(&buf[0..len])?;
+        }
         match idx.compression_type {
             CompressionType::None => Ok(parse_from_bytes(
                 &buf[idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Protobuf message can be serialized to empty string (when its content is default zeros). But raft engine assumes otherwise, and yields error because it fails to locate checksum for empty strings.