### PR TITLE
remove MessageExt trait from engine

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -295,48 +295,43 @@ impl SequentialReplayMachine for ParallelRecoverContext {
     }
 }
 
-pub struct Engine<M, B = DefaultFileBuilder, P = FilePipeLog<B>>
+pub struct Engine<B = DefaultFileBuilder, P = FilePipeLog<B>>
 where
-    M: MessageExt,
     B: FileBuilder,
     P: PipeLog,
 {
     memtables: MemTableAccessor,
     pipe_log: Arc<P>,
-    purge_manager: PurgeManager<M, P>,
+    purge_manager: PurgeManager<P>,
 
     listeners: Vec<Arc<dyn EventListener>>,
 
     _phantom: PhantomData<B>,
 }
 
-impl<M> Engine<M, DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>>
-where
-    M: MessageExt,
-{
+impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
     pub fn open(
         cfg: Config,
-    ) -> Result<Engine<M, DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>>> {
+    ) -> Result<Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>>> {
         Self::open_with_listeners(cfg, vec![])
     }
 
     pub fn open_with_listeners(
         cfg: Config,
         listeners: Vec<Arc<dyn EventListener>>,
-    ) -> Result<Engine<M, DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>>> {
+    ) -> Result<Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>>> {
         Self::open_with(cfg, Arc::new(DefaultFileBuilder {}), listeners)
     }
 }
 
-impl<M, B> Engine<M, B, FilePipeLog<B>>
+impl<B> Engine<B, FilePipeLog<B>>
 where
-    M: MessageExt,
     B: FileBuilder,
 {
     pub fn open_with_file_builder(
         cfg: Config,
         file_builder: Arc<B>,
-    ) -> Result<Engine<M, B, FilePipeLog<B>>> {
+    ) -> Result<Engine<B, FilePipeLog<B>>> {
         Self::open_with(cfg, file_builder, vec![])
     }
 
@@ -344,7 +339,7 @@ where
         cfg: Config,
         file_builder: Arc<B>,
         mut listeners: Vec<Arc<dyn EventListener>>,
-    ) -> Result<Engine<M, B, FilePipeLog<B>>> {
+    ) -> Result<Engine<B, FilePipeLog<B>>> {
         listeners.push(Arc::new(PurgeHook::new()) as Arc<dyn EventListener>);
 
         let start = Instant::now();
@@ -389,9 +384,8 @@ where
     }
 }
 
-impl<M, B, P> Engine<M, B, P>
+impl<B, P> Engine<B, P>
 where
-    M: MessageExt,
     B: FileBuilder,
     P: PipeLog,
 {
@@ -439,7 +433,11 @@ where
         Ok(None)
     }
 
-    pub fn get_entry(&self, region_id: u64, log_idx: u64) -> Result<Option<M::Entry>> {
+    pub fn get_entry<M: MessageExt>(
+        &self,
+        region_id: u64,
+        log_idx: u64,
+    ) -> Result<Option<M::Entry>> {
         let start = Instant::now();
         let mut entry = None;
         if let Some(memtable) = self.memtables.get(region_id) {
@@ -458,7 +456,7 @@ where
     }
 
     /// Return count of fetched entries.
-    pub fn fetch_entries_to(
+    pub fn fetch_entries_to<M: MessageExt>(
         &self,
         region_id: u64,
         begin: u64,
@@ -535,6 +533,19 @@ where
     let e = LogBatch::parse_entry::<M>(&buf, ent_idx)?;
     assert_eq!(M::index(&e), ent_idx.index);
     Ok(e)
+}
+
+pub fn read_entry_bytes_from_file<P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<Vec<u8>>
+where
+    P: PipeLog,
+{
+    let entries_buf = pipe_log.read_bytes(
+        ent_idx.queue,
+        ent_idx.file_id,
+        ent_idx.entries_offset,
+        ent_idx.entries_len as u64,
+    )?;
+    LogBatch::parse_entry_bytes(&entries_buf, ent_idx)
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use file_builder::FileBuilder;
 pub use log_batch::{Command, LogBatch, MessageExt};
 pub use pipe_log::{FileId, LogQueue};
 pub use util::ReadableSize;
-pub type Engine<M, FileBuilder = file_builder::DefaultFileBuilder> = engine::Engine<M, FileBuilder>;
+pub type Engine<FileBuilder = file_builder::DefaultFileBuilder> = engine::Engine<FileBuilder>;
 
 #[derive(Default)]
 pub struct GlobalStats {

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -14,12 +14,10 @@ use hdrhistogram::Histogram;
 use parking_lot_core::SpinWait;
 use raft::eraftpb::Entry;
 use raft_engine::{
-    Command, Config, Engine as RawEngine, EventListener, FileId, LogBatch, LogQueue, MessageExt,
-    ReadableSize,
+    Command, Config, Engine, EventListener, FileId, LogBatch, LogQueue, MessageExt, ReadableSize,
 };
 use rand::{thread_rng, Rng};
 
-type Engine = RawEngine<MessageExtTyped>;
 type WriteBatch = LogBatch;
 
 #[derive(Clone)]
@@ -285,7 +283,7 @@ fn spawn_read(
                 }
                 // Read newest entry to avoid conflicting with compact
                 if let Some(last) = engine.last_index(rid) {
-                    if let Err(e) = engine.get_entry(rid, last) {
+                    if let Err(e) = engine.get_entry::<MessageExtTyped>(rid, last) {
                         println!("read error {:?} in thread {}", e, index);
                     }
                     let end = Instant::now();


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

`MessageExt` trait is only needed when retrieving log entries. Modify purge to rewrite raw bytes instead of protobuf messages to completely remove this trait from `Engine`.