### PR TITLE
Update `rust-prometheus` to 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ nix = "0.18.0"
 num-derive = "0.3"
 num-traits = "0.2"
 parking_lot = "0.11"
-prometheus = { version = "0.12", features = ["nightly"] }
+prometheus = { version = "0.13", features = ["nightly"] }
 prometheus-static-metric = "0.5"
 protobuf = "=2.8.0"
 rayon = "1.5.0"


### PR DESCRIPTION
To fix https://github.com/tikv/tikv/issues/10997, we need to update `rust-prometheus` in TiKV to 0.13. As a dependency of TiKV, the `rust-prometheus` in `raft-engine` should be updated first.

This PR updates `rust-prometheus` to 0.13.