### PR TITLE
avoid calling fsync() from PipeLog

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -410,17 +410,14 @@ where
                     sync |= writer.is_sync();
                     let log_batch = writer.get_payload();
                     let res = if !log_batch.is_empty() {
-                        self.pipe_log.append(
-                            LogQueue::Append,
-                            log_batch.encoded_bytes(),
-                            false, /*sync*/
-                        )
+                        self.pipe_log
+                            .append(LogQueue::Append, log_batch.encoded_bytes())
                     } else {
                         Ok((FileId::default(), 0))
                     };
                     writer.set_output(res);
                 }
-                if sync {
+                if sync || self.pipe_log.should_sync(LogQueue::Append) {
                     // fsync() is not retryable, a failed attempt could result in
                     // unrecoverable loss of data written after last successful
                     // fsync(). See [PostgreSQL's fsync() surprise]

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -99,7 +99,9 @@ pub trait PipeLog: Sized {
     ) -> Result<Vec<u8>>;
 
     /// Write a batch into the append queue.
-    fn append(&self, queue: LogQueue, bytes: &[u8], sync: bool) -> Result<(FileId, u64)>;
+    fn append(&self, queue: LogQueue, bytes: &[u8]) -> Result<(FileId, u64)>;
+
+    fn should_sync(&self, queue: LogQueue) -> bool;
 
     /// Sync the given queue.
     fn sync(&self, queue: LogQueue) -> Result<()>;

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -262,10 +262,11 @@ where
             return Ok(());
         }
 
-        let (file_id, offset) =
-            self.pipe_log
-                .append(LogQueue::Rewrite, log_batch.encoded_bytes(), sync)?;
+        let (file_id, offset) = self
+            .pipe_log
+            .append(LogQueue::Rewrite, log_batch.encoded_bytes())?;
         debug_assert!(file_id.valid());
+        self.pipe_log.sync(LogQueue::Rewrite)?;
         log_batch.finish_write(LogQueue::Rewrite, file_id, offset);
         let queue = LogQueue::Rewrite;
         for item in log_batch.drain() {


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Previously fsync() will be called within pipe log when buffered data exceeds `bytes_per_sync`. Moving this logic to engine side so that one write group calls fsync() at most once.