### PR TITLE
update fine-tuned config recovery-read-block-size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,7 @@ impl Default for Config {
             target_file_size: ReadableSize::mb(128),
             purge_threshold: ReadableSize::gb(10),
             batch_compression_threshold: ReadableSize::kb(8),
-            recovery_read_block_size: ReadableSize::kb(4),
+            recovery_read_block_size: ReadableSize::kb(16),
             recovery_threads: 4,
         }
     }


### PR DESCRIPTION
Based on the benchmark, `16KB` is a better than `4KB` as the default `recovery-read-block-size`.

The performance depends on `batch size` of the workload. `16KB` read block size is a good value between `1MB` and `1KB` batch size.

### Configuration

| config | total size | region count | batch size | item size | entry size | compression threshold |
| --- | --- | --- | --- | --- | --- | --- |
| default | 1GB | 100 | 1MB | 1KB | 256B | - |
| compressed | 1GB | 100 | 1MB | 1KB | 256B | 8KB |
| small batch | 1GB | 100 | 1KB | 256B | 64B | - |
| 10GB | 10GB | 1000 | 1MB | 1KB | 256B | - |

### Measurement

| | default | compressed | small batch | 10GB |
| --- | --- | --- | --- | --- |
| 4 thread 4k | 716.69ms | 723.17ms | 5.5416s | 8.8535s |
| 4 thread 16k | 642.36ms | 667.45ms | 5.5778s | 8.7609s |
| 4 thread 64k | 813.19ms | 813.36ms | 5.2234s | 10.018s |
| 4 thread 1m | 1.8267s | 1.8126s | 6.1145s | 22.985s |
| 16 thread 4k | 556.95ms | 553.32ms | 4.2573s | 6.8685s |
| 16 thread 16k | 514.59ms | 494.68ms | 4.2400s | 6.3515s |
| 16 thread 64k | 574.95ms | 583.80ms | 4.0109s | 7.1795s |
| 16 thread 1m | 1.5220s | 1.5371s | 4.3459s | 18.867s |

Signed-off-by: MrCroxx <mrcroxx@outlook.com>