### PR TITLE
overhaul engine tests and fix bugs

### DIFF
--- a/src/file_builder.rs
+++ b/src/file_builder.rs
@@ -22,7 +22,7 @@ pub trait FileBuilder: Send + Sync {
 
 /// `DefaultFileBuilder` is a `FileBuilder` that builds out the original
 /// `Reader`/`Writer` as it is.
-pub struct DefaultFileBuilder {}
+pub struct DefaultFileBuilder;
 
 impl FileBuilder for DefaultFileBuilder {
     type Reader<R: Seek + Read + Send> = R;

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -367,7 +367,7 @@ impl<B: FileBuilder> LogManager<B> {
         if file_seq > self.active_file_seq {
             return Err(box_err!("Purge active or newer files"));
         }
-        let end_offset = (file_seq - self.first_file_seq) as usize;
+        let end_offset = file_seq.saturating_sub(self.first_file_seq) as usize;
         self.all_files.drain(..end_offset);
         self.first_file_seq = file_seq;
         self.update_metrics();
@@ -418,7 +418,7 @@ pub trait ReplayMachine: Send + Default {
 
 pub struct FilePipeLog<B: FileBuilder> {
     dir: String,
-    file_builder: Arc<B>,
+    pub(crate) file_builder: Arc<B>,
 
     appender: Arc<RwLock<LogManager<B>>>,
     rewriter: Arc<RwLock<LogManager<B>>>,
@@ -815,9 +815,10 @@ mod tests {
         assert_eq!(parse_file_name(file_name).unwrap(), file_id,);
         assert_eq!(build_file_name(file_id), file_name);
 
-        let invalid_file_name: &str = "123.log";
-        assert!(parse_file_name(invalid_file_name).is_none());
-        assert!(parse_file_name(invalid_file_name).is_none());
+        let invalid_cases = vec!["0000000000000123.log", "123.rewrite"];
+        for case in invalid_cases {
+            assert!(parse_file_name(case).is_none());
+        }
     }
 
     #[test]

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -1060,8 +1060,7 @@ mod tests {
                             entry_indexes.0.first().unwrap().index,
                             entry_indexes.0.last().unwrap().index + 1,
                         );
-                        let origin_entries =
-                            generate_entries(begin, end, Some(entry_data.to_vec()));
+                        let origin_entries = generate_entries(begin, end, Some(entry_data));
                         let decoded_entries =
                             decode_entries_from_bytes::<Entry>(entries, &entry_indexes.0, false);
                         assert_eq!(origin_entries, decoded_entries);
@@ -1074,13 +1073,13 @@ mod tests {
         let mut batch = LogBatch::default();
         let entry_data = vec![b'x'; 1024];
         batch
-            .add_entries::<Entry>(7, &generate_entries(1, 11, Some(entry_data.clone())))
+            .add_entries::<Entry>(7, &generate_entries(1, 11, Some(&entry_data)))
             .unwrap();
         batch.add_command(7, Command::Clean);
         batch.put(7, b"key".to_vec(), b"value".to_vec());
         batch.delete(7, b"key2".to_vec());
         batch
-            .add_entries::<Entry>(7, &generate_entries(1, 11, Some(entry_data.clone())))
+            .add_entries::<Entry>(7, &generate_entries(1, 11, Some(&entry_data)))
             .unwrap();
         batches.push((batch, entry_data));
         let mut batch = LogBatch::default();
@@ -1103,9 +1102,10 @@ mod tests {
         let region_id = 8;
         let mut entries = Vec::new();
         let mut kvs = Vec::new();
+        let data = vec![b'x'; 1024];
 
         let mut batch1 = LogBatch::default();
-        entries.push(generate_entries(1, 11, Some(vec![b'x'; 1024])));
+        entries.push(generate_entries(1, 11, Some(&data)));
         batch1
             .add_entries::<Entry>(region_id, entries.last().unwrap())
             .unwrap();
@@ -1119,7 +1119,7 @@ mod tests {
         }
 
         let mut batch2 = LogBatch::default();
-        entries.push(generate_entries(11, 21, Some(vec![b'x'; 1024])));
+        entries.push(generate_entries(11, 21, Some(&data)));
         batch2
             .add_entries::<Entry>(region_id, entries.last().unwrap())
             .unwrap();
@@ -1181,7 +1181,7 @@ mod tests {
             let _ = log_batch.drain();
         }
         let data: Vec<u8> = (0..128).map(|_| thread_rng().gen()).collect();
-        let entries = generate_entries(1, 11, Some(data));
+        let entries = generate_entries(1, 11, Some(&data));
         let mut log_batch = LogBatch::default();
         // warm up
         details(&mut log_batch, &entries, 100);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -387,7 +387,6 @@ impl MemTable {
             if begin.index <= end.index {
                 return self.fetch_entries_to(begin.index, end.index + 1, None, vec_idx);
             }
-            // TODO: cov
         }
         Ok(())
     }
@@ -398,7 +397,6 @@ impl MemTable {
             let end = self.entry_indexes[self.rewrite_count - 1].index + 1;
             self.fetch_entries_to(first, end, None, vec_idx)
         } else {
-            // TODO: cov
             Ok(())
         }
     }
@@ -1108,10 +1106,10 @@ mod tests {
         assert_eq!(kvs.pop().unwrap(), (k3.to_vec(), v3.to_vec()));
 
         // Rewrite indexes:
-        // [0, 10) queue = rewrite, file_num = 50,
+        // [0, 10) queue = rewrite, file_num = 1,
         // [10, 20) file_num = 2
         // [20, 25) file_num = 3
-        let ents_idx = generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 50));
+        let ents_idx = generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1));
         memtable.rewrite(ents_idx, Some(1));
         assert_eq!(memtable.entries_size(), 25);
         memtable.consistency_check();
@@ -1122,6 +1120,11 @@ mod tests {
             .is_ok());
         assert_eq!(ents_idx.len(), 10);
         assert_eq!(ents_idx.last().unwrap().index, 19);
+        ents_idx.clear();
+        assert!(memtable
+            .fetch_entry_indexes_before(1, &mut ents_idx)
+            .is_ok());
+        assert!(ents_idx.is_empty());
 
         ents_idx.clear();
         assert!(memtable

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -113,7 +113,6 @@ impl MemTable {
                 if first > rewrite_last + 1 {
                     rhs.compact_to(rewrite_last + 1);
                 } else {
-                    // TODO(tabokie): add test case for first < rewrite_first.
                     rhs.unsafe_truncate_back(first);
                 }
             }
@@ -211,16 +210,15 @@ impl MemTable {
 
     // This will only be called during recovery.
     pub fn append_rewrite(&mut self, entry_indexes: Vec<EntryIndex>) {
-        self.global_stats.add_rewrite(entry_indexes.len());
-        match (
-            self.entry_indexes.back().map(|x| x.index),
-            entry_indexes.first(),
-        ) {
-            (Some(back_idx), Some(first)) if back_idx + 1 < first.index => {
-                // It's possible that a hole occurs in the rewrite queue.
-                self.compact_to(back_idx + 1);
+        let len = entry_indexes.len();
+        self.global_stats.add_rewrite(len);
+        if len > 0 {
+            let first_to_add = entry_indexes[0].index;
+            if let Some((first, last)) = self.span() {
+                if last + 1 < first_to_add || first_to_add < first {
+                    self.compact_to(last + 1);
+                }
             }
-            _ => {}
         }
         self.append(entry_indexes);
         self.rewrite_count = self.entry_indexes.len();
@@ -370,6 +368,7 @@ impl MemTable {
         Ok(())
     }
 
+    // Inclusive.
     pub fn fetch_entry_indexes_before(
         &self,
         gate: FileSeq,
@@ -388,6 +387,7 @@ impl MemTable {
             if begin.index <= end.index {
                 return self.fetch_entries_to(begin.index, end.index + 1, None, vec_idx);
             }
+            // TODO: cov
         }
         Ok(())
     }
@@ -398,10 +398,12 @@ impl MemTable {
             let end = self.entry_indexes[self.rewrite_count - 1].index + 1;
             self.fetch_entries_to(first, end, None, vec_idx)
         } else {
+            // TODO: cov
             Ok(())
         }
     }
 
+    // Inclusive.
     pub fn fetch_kvs_before(&self, gate: FileSeq, vec: &mut Vec<(Vec<u8>, Vec<u8>)>) {
         for (key, (value, file_id)) in &self.kvs {
             if file_id.queue == LogQueue::Append && file_id.seq <= gate {
@@ -677,6 +679,13 @@ impl MemTableRecoverContext {
     pub fn finish(self) -> (MemTableAccessor, Arc<GlobalStats>) {
         (self.memtables, self.stats)
     }
+
+    pub fn merge_rewrite_context(&self, mut rewrite: MemTableRecoverContext) {
+        rewrite
+            .memtables
+            .apply(self.log_batch.clone().drain(), LogQueue::Append);
+        self.memtables.merge_rewrite_table(&mut rewrite.memtables);
+    }
 }
 
 impl Default for MemTableRecoverContext {
@@ -892,6 +901,15 @@ mod tests {
         assert_eq!(memtable.last_index().unwrap(), 24);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 3);
+        // Can't override compacted entries.
+        assert!(
+            catch_unwind_silent(|| memtable.append(generate_entry_indexes(
+                4,
+                5,
+                FileId::dummy(LogQueue::Append)
+            )))
+            .is_err()
+        );
         memtable.consistency_check();
 
         // Compact to 20.
@@ -1463,117 +1481,118 @@ mod tests {
         fn empty_table(id: u64) -> MemTable {
             MemTable::new(id, Arc::new(GlobalStats::default()))
         }
-        fn sequence_1(mut memtable: MemTable, on: Option<LogQueue>) -> MemTable {
-            match on {
-                Some(LogQueue::Append) => {
-                    memtable.append(generate_entry_indexes(
-                        0,
-                        10,
-                        FileId::new(LogQueue::Append, 1),
-                    ));
-                    memtable.append(generate_entry_indexes(
-                        7,
-                        15,
-                        FileId::new(LogQueue::Append, 2),
-                    ));
-                    memtable.compact_to(7);
+        let cases = [
+            |mut memtable: MemTable, on: Option<LogQueue>| -> MemTable {
+                match on {
+                    None => {
+                        memtable.append(generate_entry_indexes(
+                            0,
+                            10,
+                            FileId::new(LogQueue::Append, 1),
+                        ));
+                        memtable.append(generate_entry_indexes(
+                            7,
+                            15,
+                            FileId::new(LogQueue::Append, 2),
+                        ));
+                        memtable.rewrite(
+                            generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1)),
+                            Some(1),
+                        );
+                    }
+                    Some(LogQueue::Append) => {
+                        memtable.append(generate_entry_indexes(
+                            0,
+                            10,
+                            FileId::new(LogQueue::Append, 1),
+                        ));
+                        memtable.append(generate_entry_indexes(
+                            7,
+                            15,
+                            FileId::new(LogQueue::Append, 2),
+                        ));
+                        memtable.compact_to(7);
+                    }
+                    Some(LogQueue::Rewrite) => {
+                        memtable.append_rewrite(generate_entry_indexes(
+                            0,
+                            7,
+                            FileId::new(LogQueue::Rewrite, 1),
+                        ));
+                    }
                 }
-                Some(LogQueue::Rewrite) => {
-                    memtable.append_rewrite(generate_entry_indexes(
-                        0,
-                        10,
-                        FileId::new(LogQueue::Rewrite, 1),
-                    ));
+                memtable
+            },
+            |mut memtable: MemTable, on: Option<LogQueue>| -> MemTable {
+                match on {
+                    None => {
+                        memtable.append(generate_entry_indexes(
+                            0,
+                            10,
+                            FileId::new(LogQueue::Append, 1),
+                        ));
+                        memtable.append(generate_entry_indexes(
+                            7,
+                            15,
+                            FileId::new(LogQueue::Append, 2),
+                        ));
+                        memtable.rewrite(
+                            generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1)),
+                            Some(1),
+                        );
+                        memtable.compact_to(10);
+                    }
+                    Some(LogQueue::Append) => {
+                        memtable.append(generate_entry_indexes(
+                            0,
+                            10,
+                            FileId::new(LogQueue::Append, 1),
+                        ));
+                        memtable.append(generate_entry_indexes(
+                            7,
+                            15,
+                            FileId::new(LogQueue::Append, 2),
+                        ));
+                        memtable.compact_to(10);
+                    }
+                    Some(LogQueue::Rewrite) => {
+                        memtable.append_rewrite(generate_entry_indexes(
+                            0,
+                            7,
+                            FileId::new(LogQueue::Rewrite, 1),
+                        ));
+                    }
                 }
-                None => {
-                    memtable.append(generate_entry_indexes(
-                        0,
-                        10,
-                        FileId::new(LogQueue::Append, 1),
-                    ));
-                    memtable.append(generate_entry_indexes(
-                        7,
-                        15,
-                        FileId::new(LogQueue::Append, 2),
-                    ));
-                    memtable.rewrite(
-                        generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1)),
-                        Some(1),
-                    );
-                }
-            }
-            memtable
-        }
-
-        fn sequence_2(mut memtable: MemTable, on: Option<LogQueue>) -> MemTable {
-            match on {
-                Some(LogQueue::Append) => {
-                    memtable.append(generate_entry_indexes(
-                        0,
-                        10,
-                        FileId::new(LogQueue::Append, 1),
-                    ));
-                    memtable.append(generate_entry_indexes(
-                        7,
-                        15,
-                        FileId::new(LogQueue::Append, 2),
-                    ));
-                    memtable.compact_to(10);
-                }
-                Some(LogQueue::Rewrite) => {
-                    memtable.append_rewrite(generate_entry_indexes(
-                        0,
-                        7,
-                        FileId::new(LogQueue::Rewrite, 1),
-                    ));
-                }
-                None => {
-                    memtable.append(generate_entry_indexes(
-                        0,
-                        10,
-                        FileId::new(LogQueue::Append, 1),
-                    ));
-                    memtable.append(generate_entry_indexes(
-                        7,
-                        15,
-                        FileId::new(LogQueue::Append, 2),
-                    ));
-                    memtable.rewrite(
-                        generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1)),
-                        Some(1),
-                    );
-                    memtable.compact_to(10);
-                }
-            }
-            memtable
-        }
+                memtable
+            },
+        ];
 
         // merge against empty table.
-        for sequence in [sequence_1, sequence_2] {
+        for case in cases {
             let mut lhs = empty_table(region_id);
-            let mut rhs = sequence(empty_table(region_id), Some(LogQueue::Rewrite));
+            let mut rhs = case(empty_table(region_id), Some(LogQueue::Rewrite));
             lhs.merge_rewrite_table(&mut rhs);
             assert_eq!(
                 lhs.entry_indexes,
-                sequence(empty_table(region_id), Some(LogQueue::Rewrite)).entry_indexes,
+                case(empty_table(region_id), Some(LogQueue::Rewrite)).entry_indexes,
             );
             assert!(rhs.entry_indexes.is_empty());
 
-            let mut lhs = sequence(empty_table(region_id), Some(LogQueue::Append));
+            let mut lhs = case(empty_table(region_id), Some(LogQueue::Append));
             let mut rhs = empty_table(region_id);
             lhs.merge_rewrite_table(&mut rhs);
             assert_eq!(
                 lhs.entry_indexes,
-                sequence(empty_table(region_id), Some(LogQueue::Append)).entry_indexes
+                case(empty_table(region_id), Some(LogQueue::Append)).entry_indexes
             );
             assert!(rhs.entry_indexes.is_empty());
         }
 
-        for sequence in [sequence_1, sequence_2] {
-            let mut lhs = sequence(empty_table(region_id), Some(LogQueue::Append));
-            let mut rhs = sequence(empty_table(region_id), Some(LogQueue::Rewrite));
+        for case in cases {
+            let mut lhs = case(empty_table(region_id), Some(LogQueue::Append));
+            let mut rhs = case(empty_table(region_id), Some(LogQueue::Rewrite));
             lhs.merge_rewrite_table(&mut rhs);
-            let expected = sequence(empty_table(region_id), None);
+            let expected = case(empty_table(region_id), None);
             // stats could differ.
             assert_eq!(lhs.entry_indexes, expected.entry_indexes);
             assert!(rhs.entry_indexes.is_empty());
@@ -1581,7 +1600,7 @@ mod tests {
     }
 
     #[test]
-    fn test_memtable_recover() {
+    fn test_memtable_merge_neighbor() {
         let file_id = FileId::new(LogQueue::Append, 10);
 
         // ops:

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -51,7 +51,6 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
 
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
         if self.valid_offset < LOG_BATCH_HEADER_LEN {
-            // TODO: cov
             return Err(Error::Corruption(
                 "attempt to read file with broken header".to_owned(),
             ));
@@ -63,7 +62,6 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                 0,
             )?)?;
             if self.valid_offset + len > self.size {
-                // TODO: cov
                 return Err(Error::Corruption("log batch header broken".to_owned()));
             }
 
@@ -98,7 +96,6 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
             f.seek(std::io::SeekFrom::Start(self.buffer_offset as u64))?;
             let read = f.read(&mut self.buffer)?;
             if read < size {
-                // TODO: cov
                 return Err(Error::Corruption(format!(
                     "unexpected eof at {}",
                     self.buffer_offset + read
@@ -117,7 +114,6 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                 );
                 let read = f.read(&mut self.buffer[prev_len..])?;
                 if read + prefetch < should_read {
-                    // TODO: cov
                     return Err(Error::Corruption(format!(
                         "unexpected eof at {}",
                         read_offset + read,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -51,6 +51,7 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
 
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
         if self.valid_offset < LOG_BATCH_HEADER_LEN {
+            // TODO: cov
             return Err(Error::Corruption(
                 "attempt to read file with broken header".to_owned(),
             ));
@@ -62,6 +63,7 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                 0,
             )?)?;
             if self.valid_offset + len > self.size {
+                // TODO: cov
                 return Err(Error::Corruption("log batch header broken".to_owned()));
             }
 
@@ -96,6 +98,7 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
             f.seek(std::io::SeekFrom::Start(self.buffer_offset as u64))?;
             let read = f.read(&mut self.buffer)?;
             if read < size {
+                // TODO: cov
                 return Err(Error::Corruption(format!(
                     "unexpected eof at {}",
                     self.buffer_offset + read
@@ -114,6 +117,7 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                 );
                 let read = f.read(&mut self.buffer[prev_len..])?;
                 if read + prefetch < should_read {
+                    // TODO: cov
                     return Err(Error::Corruption(format!(
                         "unexpected eof at {}",
                         read_offset + read,


### PR DESCRIPTION
Overhaul unit tests for engine. Discover and fix several bugs:

- First rewrite entry could have larger index than first append entry, and causes panic
- Region tombstone in append queue is not applied to rewrite queue during recovery
- [NOT FIXED] State tombstone is lost during rewrite #141
- Rewrite queue log index could jump back, and causes panic
- [NOT FIXED] Recreated region is deleted after rewrite #142

Signed-off-by: tabokie <xy.tao@outlook.com>