### PR TITLE
improve exception safety of FilePipeLog and overhaul failpoint tests

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::time::Instant;
 use std::u64;
 
-use fail::fail_point;
 use log::{error, info};
 use protobuf::{parse_from_bytes, Message};
 
@@ -120,7 +119,6 @@ where
             if let Some(mut group) = self.write_barrier.enter(&mut writer) {
                 let _t = StopWatch::new(&ENGINE_WRITE_LEADER_DURATION_HISTOGRAM);
                 for writer in group.iter_mut() {
-                    fail_point!("engine::write::pre");
                     sync |= writer.is_sync();
                     let log_batch = writer.get_payload();
                     let res = if !log_batch.is_empty() {

--- a/src/file_pipe_log.rs
+++ b/src/file_pipe_log.rs
@@ -320,7 +320,7 @@ impl<B: FileBuilder> LogManager<B> {
             &self.dir,
             FileId {
                 queue: self.queue,
-                seq: self.active_file_seq,
+                seq: self.active_file_seq + 1,
             },
         );
         let fd = Arc::new(LogFd::create(&path)?);

--- a/src/log_file.rs
+++ b/src/log_file.rs
@@ -84,11 +84,11 @@ impl LogFd {
     }
 
     pub fn read(&self, mut offset: usize, buf: &mut [u8]) -> IoResult<usize> {
-        fail_point!("log_fd::read::err", |_| {
-            Err(from_nix_error(nix::Error::invalid_argument(), "fp"))
-        });
         let mut readed = 0;
         while readed < buf.len() {
+            fail_point!("log_fd::read::err", |_| {
+                Err(from_nix_error(nix::Error::invalid_argument(), "fp"))
+            });
             let bytes = match pread(self.0, &mut buf[readed..], offset as i64) {
                 Ok(bytes) => bytes,
                 Err(e) if e.as_errno() == Some(Errno::EAGAIN) => continue,

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -1,299 +1,146 @@
-use crate::util::catch_unwind_silent;
-use raft::eraftpb::Entry;
-use raft_engine::{Config, Engine as RaftLogEngine, LogBatch, MessageExt, ReadableSize, Result};
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
-#[derive(Clone)]
-pub struct M;
+use raft::eraftpb::Entry;
+use raft_engine::{Config, Engine, LogBatch, ReadableSize};
 
-impl MessageExt for M {
-    type Entry = Entry;
+use crate::util::*;
 
-    fn index(e: &Entry) -> u64 {
-        e.index
-    }
-}
-
-fn generate_batch(region: u64, begin_index: u64, end_index: u64, data: Vec<u8>) -> LogBatch {
-    let mut batch = LogBatch::default();
-    let mut v = vec![Entry::new(); (end_index - begin_index) as usize];
-    let mut index = begin_index;
-    for e in v.iter_mut() {
-        e.set_index(index);
-        e.set_data(data.clone().into());
-        index += 1;
-    }
-    batch.add_entries::<M>(region, &v).unwrap();
-    batch
-}
-
-fn tmp_engine(
-    path_perfix: &str,
-    bytes_per_sync: ReadableSize,
-    target_file_size: ReadableSize,
-) -> RaftLogEngine {
+#[test]
+fn test_file_open_error() {
     let dir = tempfile::Builder::new()
-        .prefix(path_perfix)
+        .prefix("test_file_open_error")
         .tempdir()
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync,
-        target_file_size,
-        batch_compression_threshold: ReadableSize(0),
         ..Default::default()
     };
-    RaftLogEngine::open(cfg).unwrap()
-}
 
-struct ConcurrentWriteContext {
-    engine: Arc<RaftLogEngine>,
-    ths: Vec<std::thread::JoinHandle<()>>,
-    ticket: u64,
-    timer: Arc<AtomicU64>,
-}
-
-impl ConcurrentWriteContext {
-    fn new(engine: Arc<RaftLogEngine>) -> Self {
-        Self {
-            engine,
-            ths: Vec::new(),
-            ticket: 0,
-            timer: Arc::new(AtomicU64::new(0)),
-        }
+    {
+        let _f = FailGuard::new("log_fd::create::err", "return");
+        assert!(catch_unwind_silent(|| {
+            let _ = Engine::open(cfg.clone());
+        })
+        .is_err());
     }
 
-    fn leader_write<F: FnOnce(Result<usize>) + Send + Sync + 'static>(
-        &mut self,
-        mut log_batch: LogBatch,
-        sync: bool,
-        cb: Option<F>,
-        panic: bool,
-    ) {
-        if self.ths.is_empty() {
-            fail::cfg("write_barrier::leader_exit", "pause").unwrap();
-            let engine_clone = self.engine.clone();
-            let ticket = self.ticket;
-            self.ticket += 1;
-            let timer = self.timer.clone();
-            self.ths.push(
-                std::thread::Builder::new()
-                    .spawn(move || {
-                        while ticket != timer.load(std::sync::atomic::Ordering::Acquire) {}
-                        engine_clone.write(&mut LogBatch::default(), false).unwrap();
-                        timer.store(ticket + 1, std::sync::atomic::Ordering::Release);
-                    })
-                    .unwrap(),
-            );
-        }
-        let engine_clone = self.engine.clone();
-        let ticket = self.ticket;
-        self.ticket += 1;
-        let timer = self.timer.clone();
-        self.ths.push(
-            std::thread::Builder::new()
-                .spawn(move || {
-                    while ticket != timer.load(std::sync::atomic::Ordering::Acquire) {}
-                    if panic {
-                        assert!(catch_unwind_silent(|| {
-                            engine_clone.write(&mut log_batch, sync).unwrap();
-                        })
-                        .is_err());
-                        return;
-                    }
-                    let r = engine_clone.write(&mut log_batch, sync);
-                    timer.store(ticket + 1, std::sync::atomic::Ordering::Release);
-                    if let Some(f) = cb {
-                        f(r)
-                    }
-                })
-                .unwrap(),
-        );
-    }
-
-    fn follower_write<F: FnOnce(Result<usize>) + Send + Sync + 'static>(
-        &mut self,
-        mut log_batch: LogBatch,
-        sync: bool,
-        cb: Option<F>,
-        panic: bool,
-    ) {
-        assert!(self.ticket >= 2);
-        let engine_clone = self.engine.clone();
-        let ticket = self.ticket;
-        self.ticket += 1;
-        let timer = self.timer.clone();
-        self.ths.push(
-            std::thread::Builder::new()
-                .spawn(move || {
-                    while ticket != timer.load(std::sync::atomic::Ordering::Acquire) {}
-                    if panic {
-                        assert!(catch_unwind_silent(|| {
-                            engine_clone.write(&mut log_batch, sync).unwrap();
-                        })
-                        .is_err());
-                        return;
-                    }
-                    let r = engine_clone.write(&mut log_batch, sync);
-                    if let Some(f) = cb {
-                        f(r)
-                    }
-                    timer.store(ticket + 1, std::sync::atomic::Ordering::Release);
-                })
-                .unwrap(),
-        );
-    }
-
-    fn join(&mut self) {
-        fail::remove("write_barrier::leader_exit");
-        for t in self.ths.drain(..) {
-            t.join().unwrap();
-        }
+    {
+        let _f = FailGuard::new("log_fd::open::err", "return");
+        let _ = Engine::open(cfg.clone()).unwrap();
+        assert!(catch_unwind_silent(|| {
+            let _ = Engine::open(cfg.clone());
+        })
+        .is_err());
     }
 }
 
 #[test]
-fn test_open_error() {
+fn test_read_error() {
     let dir = tempfile::Builder::new()
-        .prefix("test_open_error")
+        .prefix("test_read_error")
         .tempdir()
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1),
-        target_file_size: ReadableSize::kb(4),
-        batch_compression_threshold: ReadableSize(0),
         ..Default::default()
     };
-    // fp "log_fd::open::err" is only triggered when opening existing log files
-    fail::cfg("log_fd::open::err", "return").unwrap();
-    let engine = RaftLogEngine::open(cfg.clone()).unwrap();
-    drop(engine);
-    assert!(catch_unwind_silent(|| {
-        RaftLogEngine::open(cfg.clone()).unwrap();
-    })
-    .is_err());
-    fail::cfg("log_fd::open::err", "off").unwrap();
+    let entry = vec![b'x'; 1024];
+
+    let engine = Engine::open(cfg).unwrap();
+    // Writing an empty message.
+    engine
+        .write(&mut generate_batch(1, 0, 1, None), true)
+        .unwrap();
+    engine
+        .write(&mut generate_batch(2, 1, 10, Some(&entry)), true)
+        .unwrap();
+    let mut kv_batch = LogBatch::default();
+    let entry_value = Entry {
+        index: 111,
+        data: entry.to_vec().into(),
+        ..Default::default()
+    };
+    kv_batch
+        .put_message(1, b"k".to_vec(), &entry_value)
+        .unwrap();
+    engine.write(&mut kv_batch, true).unwrap();
+
+    let mut entries = Vec::new();
+    let _f = FailGuard::new("log_fd::read::err", "return");
+    engine
+        .fetch_entries_to::<MessageExtTyped>(1, 0, 1, None, &mut entries)
+        .unwrap();
+    engine.get_message::<Entry>(1, b"k".as_ref()).unwrap();
+    engine
+        .fetch_entries_to::<MessageExtTyped>(2, 1, 10, None, &mut entries)
+        .unwrap_err();
 }
 
 #[test]
 fn test_rotate_error() {
+    let dir = tempfile::Builder::new()
+        .prefix("test_rotate_error")
+        .tempdir()
+        .unwrap();
+    let cfg = Config {
+        dir: dir.path().to_str().unwrap().to_owned(),
+        bytes_per_sync: ReadableSize::kb(1024),
+        target_file_size: ReadableSize::kb(4),
+        ..Default::default()
+    };
     let entry = vec![b'x'; 1024];
 
-    // panic when truncate
-    let engine = tmp_engine(
-        "test_rotate_error_truncate",
-        ReadableSize::kb(1024),
-        ReadableSize::kb(4),
-    );
+    let engine = Engine::open(cfg.clone()).unwrap();
     engine
-        .write(&mut generate_batch(1, 1, 2, entry.clone()), false)
+        .write(&mut generate_batch(1, 1, 2, Some(&entry)), false)
         .unwrap();
     engine
-        .write(&mut generate_batch(1, 2, 3, entry.clone()), false)
+        .write(&mut generate_batch(1, 2, 3, Some(&entry)), false)
         .unwrap();
     engine
-        .write(&mut generate_batch(1, 3, 4, entry.clone()), false)
+        .write(&mut generate_batch(1, 3, 4, Some(&entry)), false)
         .unwrap();
-    fail::cfg("active_file::truncate::force", "return").unwrap();
-    fail::cfg("log_fd::truncate::err", "return").unwrap();
-    assert!(catch_unwind_silent(|| {
-        engine
-            .write(&mut generate_batch(1, 4, 5, entry.clone()), false)
-            .unwrap();
-    })
-    .is_err());
-    fail::cfg("active_file::truncate::force", "off").unwrap();
-    fail::cfg("log_fd::truncate::err", "off").unwrap();
 
-    // panic when sync
-    let engine = tmp_engine(
-        "test_rotate_error_sync",
-        ReadableSize::kb(4),
-        ReadableSize::kb(1024),
-    );
-    engine
-        .write(&mut generate_batch(1, 1, 2, entry.clone()), false)
-        .unwrap();
-    engine
-        .write(&mut generate_batch(1, 2, 3, entry.clone()), false)
-        .unwrap();
-    engine
-        .write(&mut generate_batch(1, 3, 4, entry.clone()), false)
-        .unwrap();
-    fail::cfg("log_fd::sync::err", "return").unwrap();
-    assert!(catch_unwind_silent(|| {
-        engine
-            .write(&mut generate_batch(1, 4, 5, entry.clone()), false)
-            .unwrap();
-    })
-    .is_err());
-    fail::cfg("log_fd::sync::err", "off").unwrap();
+    {
+        let _f = FailGuard::new("log_fd::create::err", "return");
+        assert!(catch_unwind_silent(|| {
+            let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
+        })
+        .is_err());
+    }
+    {
+        let _f = FailGuard::new("log_fd::write::err", "return");
+        assert!(catch_unwind_silent(|| {
+            let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
+        })
+        .is_err());
+    }
+    {
+        let _f = FailGuard::new("log_fd::sync::err", "return");
+        assert!(catch_unwind_silent(|| {
+            let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
+        })
+        .is_err());
+    }
 
-    // panic when create file
-    let engine = tmp_engine(
-        "test_rotate_error_create",
-        ReadableSize::kb(1024),
-        ReadableSize::kb(4),
-    );
+    // Internal states are still consistent after panics.
     engine
-        .write(&mut generate_batch(1, 1, 2, entry.clone()), false)
+        .write(&mut generate_batch(1, 4, 5, Some(&entry)), true)
         .unwrap();
+    drop(engine);
+    let engine = Engine::open(cfg).unwrap();
+    let mut entries = Vec::new();
     engine
-        .write(&mut generate_batch(1, 2, 3, entry.clone()), false)
+        .fetch_entries_to::<MessageExtTyped>(1, 1, 5, None, &mut entries)
         .unwrap();
-    engine
-        .write(&mut generate_batch(1, 3, 4, entry.clone()), false)
-        .unwrap();
-    fail::cfg("log_fd::create::err", "return").unwrap();
-    assert!(catch_unwind_silent(|| {
-        engine
-            .write(&mut generate_batch(1, 4, 5, entry.clone()), false)
-            .unwrap();
-    })
-    .is_err());
-    fail::cfg("log_fd::create::err", "off").unwrap();
-
-    // panic when write header
-    let engine = tmp_engine(
-        "test_rotate_error_create",
-        ReadableSize::kb(1024),
-        ReadableSize::kb(4),
-    );
-    engine
-        .write(&mut generate_batch(1, 1, 2, entry.clone()), false)
-        .unwrap();
-    engine
-        .write(&mut generate_batch(1, 2, 3, entry.clone()), false)
-        .unwrap();
-    engine
-        .write(&mut generate_batch(1, 3, 4, entry.clone()), false)
-        .unwrap();
-    fail::cfg("log_fd::write::err", "return").unwrap();
-    assert!(catch_unwind_silent(|| {
-        engine
-            .write(&mut generate_batch(1, 4, 5, entry.clone()), false)
-            .unwrap();
-    })
-    .is_err());
-    fail::cfg("log_fd::write::err", "off").unwrap();
+    assert_eq!(entries.len(), 4);
 }
 
 #[test]
 fn test_concurrent_write_error() {
-    // write-1 success; write-2 fail, truncate; write-3 success
-    let timer = AtomicU64::new(0);
-    fail::cfg_callback("engine::write::pre", move || {
-        match timer.fetch_add(1, std::sync::atomic::Ordering::SeqCst) {
-            2 => fail::cfg("log_fd::write::err", "return").unwrap(),
-            3 => fail::cfg("log_fd::write::err", "off").unwrap(),
-            _ => {}
-        }
-    })
-    .unwrap();
-
-    // truncate and sync when write error
     let dir = tempfile::Builder::new()
         .prefix("test_concurrent_write_error")
         .tempdir()
@@ -302,111 +149,87 @@ fn test_concurrent_write_error() {
         dir: dir.path().to_str().unwrap().to_owned(),
         bytes_per_sync: ReadableSize::kb(1024),
         target_file_size: ReadableSize::kb(1024),
-        batch_compression_threshold: ReadableSize(0),
         ..Default::default()
     };
+    let entry = vec![b'x'; 1024];
 
-    let engine = Arc::new(RaftLogEngine::open(cfg).unwrap());
+    let engine = Arc::new(Engine::open(cfg.clone()).unwrap());
     let mut ctx = ConcurrentWriteContext::new(engine.clone());
 
-    let content = vec![b'x'; 1024];
-
-    ctx.leader_write(
-        generate_batch(1, 1, 11, content.clone()),
-        false,
-        Some(|r: Result<usize>| {
-            assert!(r.is_ok());
-        }),
-        false,
-    );
-    ctx.follower_write(
-        generate_batch(2, 1, 11, content.clone()),
-        false,
-        Some(|r: Result<usize>| {
-            assert!(r.is_err());
-        }),
-        false,
-    );
-    ctx.follower_write(
-        generate_batch(3, 1, 11, content),
-        false,
-        Some(|r: Result<usize>| {
-            assert!(r.is_ok());
-        }),
-        false,
-    );
+    // The second of three writes will fail.
+    let seq = AtomicU64::new(0);
+    fail::cfg_callback("file_pipe_log::append", move || {
+        match seq.fetch_add(1, std::sync::atomic::Ordering::Relaxed) {
+            1 => fail::cfg("log_fd::write::err", "return").unwrap(),
+            2 => fail::remove("log_fd::write::err"),
+            _ => {}
+        }
+    })
+    .unwrap();
+    let entry_clone = entry.clone();
+    ctx.write_ext(move |e| {
+        e.write(&mut generate_batch(1, 1, 11, Some(&entry_clone)), false)
+            .unwrap();
+    });
+    let entry_clone = entry.clone();
+    ctx.write_ext(move |e| {
+        e.write(&mut generate_batch(2, 1, 11, Some(&entry_clone)), false)
+            .unwrap_err();
+    });
+    let entry_clone = entry.clone();
+    ctx.write_ext(move |e| {
+        e.write(&mut generate_batch(3, 1, 11, Some(&entry_clone)), false)
+            .unwrap();
+    });
     ctx.join();
+    fail::remove("file_pipe_log::append");
+
     assert_eq!(
         10,
         engine
-            .fetch_entries_to::<M>(1, 1, 11, None, &mut vec![])
+            .fetch_entries_to::<MessageExtTyped>(1, 1, 11, None, &mut vec![])
             .unwrap()
     );
     assert_eq!(
         0,
         engine
-            .fetch_entries_to::<M>(2, 1, 11, None, &mut vec![])
+            .fetch_entries_to::<MessageExtTyped>(2, 1, 11, None, &mut vec![])
             .unwrap()
     );
     assert_eq!(
         10,
         engine
-            .fetch_entries_to::<M>(3, 1, 11, None, &mut vec![])
+            .fetch_entries_to::<MessageExtTyped>(3, 1, 11, None, &mut vec![])
             .unwrap()
     );
-    fail::cfg("engine::write::pre", "off").unwrap();
-}
 
-#[test]
-fn test_concurrent_write_truncate_error() {
-    // truncate and sync when write error
-    // write-1 success; write-2 fail, truncate, panic; write-3 (x)
-    let timer = AtomicU64::new(0);
-    fail::cfg_callback("engine::write::pre", move || {
-        match timer.fetch_add(1, std::sync::atomic::Ordering::SeqCst) {
-            2 => {
-                fail::cfg("log_fd::write::err", "return").unwrap();
-                fail::cfg("log_fd::truncate::err", "return").unwrap()
-            }
-            3 => {
-                fail::cfg("log_fd::write::err", "off").unwrap();
-                fail::cfg("log_fd::truncate::err", "off").unwrap()
-            }
-            _ => {}
-        }
-    })
-    .unwrap();
+    {
+        let _f1 = FailGuard::new("log_fd::write::err", "return");
+        let _f2 = FailGuard::new("log_fd::truncate::err", "return");
+        let entry_clone = entry.clone();
+        ctx.write_ext(move |e| {
+            catch_unwind_silent(|| {
+                e.write(&mut generate_batch(1, 11, 21, Some(&entry_clone)), false)
+            })
+            .unwrap_err();
+        });
+        // We don't test followers, their panics are hard to catch.
+        ctx.join();
+    }
 
-    let dir = tempfile::Builder::new()
-        .prefix("test_concurrent_write_truncate_error")
-        .tempdir()
+    // Internal states are consistent, we can still override write.
+    engine
+        .write(&mut generate_batch(1, 11, 21, Some(&entry)), true)
         .unwrap();
-    let cfg = Config {
-        dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1024),
-        target_file_size: ReadableSize::kb(1024),
-        batch_compression_threshold: ReadableSize(0),
-        ..Default::default()
-    };
 
-    let engine = Arc::new(RaftLogEngine::open(cfg).unwrap());
-    let mut ctx = ConcurrentWriteContext::new(engine);
+    drop(ctx);
+    drop(engine);
 
-    let content = vec![b'x'; 1024];
-
-    ctx.leader_write(
-        generate_batch(1, 1, 11, content.clone()),
-        false,
-        None::<fn(_)>,
-        false,
+    let engine = Engine::open(cfg).unwrap();
+    assert_eq!(
+        20,
+        engine
+            .fetch_entries_to::<MessageExtTyped>(1, 1, 21, None, &mut vec![])
+            .unwrap()
     );
-    ctx.follower_write(
-        generate_batch(2, 1, 11, content),
-        false,
-        Some(|_| unreachable!()),
-        true,
-    );
-    ctx.join();
-    fail::cfg("log_fd::write::err", "off").unwrap();
-    fail::cfg("log_fd::truncate::err", "off").unwrap()
 }

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -21,19 +21,13 @@ fn test_file_open_error() {
 
     {
         let _f = FailGuard::new("log_fd::create::err", "return");
-        assert!(catch_unwind_silent(|| {
-            let _ = Engine::open(cfg.clone());
-        })
-        .is_err());
+        assert!(Engine::open(cfg.clone()).is_err());
     }
 
     {
         let _f = FailGuard::new("log_fd::open::err", "return");
         let _ = Engine::open(cfg.clone()).unwrap();
-        assert!(catch_unwind_silent(|| {
-            let _ = Engine::open(cfg.clone());
-        })
-        .is_err());
+        assert!(Engine::open(cfg).is_err());
     }
 }
 

--- a/tests/failpoints/util.rs
+++ b/tests/failpoints/util.rs
@@ -1,9 +1,10 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::panic::{self, AssertUnwindSafe};
+use std::sync::{mpsc, Arc};
 
 use raft::eraftpb::Entry;
-use raft_engine::MessageExt;
+use raft_engine::{Engine, LogBatch, MessageExt};
 
 #[derive(Clone)]
 pub struct MessageExtTyped;
@@ -13,6 +14,32 @@ impl MessageExt for MessageExtTyped {
     fn index(entry: &Entry) -> u64 {
         entry.index
     }
+}
+
+pub fn generate_entries(begin_index: u64, end_index: u64, data: Option<&[u8]>) -> Vec<Entry> {
+    let mut v = vec![Entry::new(); (end_index - begin_index) as usize];
+    let mut index = begin_index;
+    for e in v.iter_mut() {
+        e.set_index(index);
+        if let Some(data) = data {
+            e.set_data(data.to_vec().into())
+        }
+        index += 1;
+    }
+    v
+}
+
+pub fn generate_batch(
+    region: u64,
+    begin_index: u64,
+    end_index: u64,
+    data: Option<&[u8]>,
+) -> LogBatch {
+    let mut batch = LogBatch::default();
+    batch
+        .add_entries::<MessageExtTyped>(region, &generate_entries(begin_index, end_index, data))
+        .unwrap();
+    batch
 }
 
 /// Catch panic while suppressing default panic hook.
@@ -25,4 +52,85 @@ where
     let result = panic::catch_unwind(AssertUnwindSafe(f));
     panic::set_hook(prev_hook);
     result
+}
+
+pub struct FailGuard {
+    fp: String,
+}
+
+impl FailGuard {
+    pub fn new(fp: &str, action: &str) -> Self {
+        fail::cfg(fp, action).unwrap();
+        Self { fp: fp.to_owned() }
+    }
+}
+
+impl Drop for FailGuard {
+    fn drop(&mut self) {
+        fail::remove(&self.fp);
+    }
+}
+
+pub struct ConcurrentWriteContext {
+    engine: Arc<Engine>,
+    ths: Vec<std::thread::JoinHandle<()>>,
+}
+
+impl ConcurrentWriteContext {
+    pub fn new(engine: Arc<Engine>) -> Self {
+        Self {
+            engine,
+            ths: Vec::new(),
+        }
+    }
+
+    pub fn write(&mut self, mut log_batch: LogBatch) {
+        self.write_ext(move |e| {
+            e.write(&mut log_batch, true).unwrap();
+        });
+    }
+
+    pub fn write_ext<F>(&mut self, f: F)
+    where
+        F: FnOnce(&Engine) + Send + Sync + 'static,
+    {
+        let (ready_tx, ready_rx) = mpsc::channel();
+        if self.ths.is_empty() {
+            fail::cfg("write_barrier::leader_exit", "pause").unwrap();
+            let engine_clone = self.engine.clone();
+            let ready_tx_clone = ready_tx.clone();
+            self.ths.push(
+                std::thread::Builder::new()
+                    .spawn(move || {
+                        ready_tx_clone.send(()).unwrap();
+                        // Noop.
+                        engine_clone.write(&mut LogBatch::default(), false).unwrap();
+                    })
+                    .unwrap(),
+            );
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            ready_rx.recv().unwrap();
+        } else {
+            // Follower.
+            assert!(self.ths.len() >= 2);
+        }
+        let engine_clone = self.engine.clone();
+        self.ths.push(
+            std::thread::Builder::new()
+                .spawn(move || {
+                    ready_tx.send(()).unwrap();
+                    f(&engine_clone);
+                })
+                .unwrap(),
+        );
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        ready_rx.recv().unwrap();
+    }
+
+    pub fn join(&mut self) {
+        fail::remove("write_barrier::leader_exit");
+        for t in self.ths.drain(..) {
+            t.join().unwrap();
+        }
+    }
 }


### PR DESCRIPTION
We should guarantee the in-memory states of objects are still consistent after exception (error or panic). i.e. We should be able to operate on `Engine` even after catching a panic from it. Reorder some the execution to achieve that, and add test cases for verification.

Some other considerations during overhaul:
- Avoid `unwrap`-ing inside a `catch_unwind` block
- Clean up `ConcurrentWriteContext`

Signed-off-by: tabokie <xy.tao@outlook.com>