### PR TITLE
factor out low level details for debugging purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The writing of one log batch can be broken down into three steps:
 2. Write to log file
 3. Apply to memtable
 
-At step 2, to batch concurrent requests, each writing thread must enter a queue. The first in line automatically becomes the queue leader, responsible for writing the entire batch to the log file.
+At step 2, to group concurrent requests, each writing thread must enter a queue. The first in line automatically becomes the queue leader, responsible for writing the entire group to the log file.
 
 Both synchronous and non-sync writes are supported. When one write in a batch is marked synchronous, the batch leader will call [`fdatasync()`](https://linux.die.net/man/2/fdatasync) after writing. This way, buffered data is guaranteed to be flushed out onto the storage.
 

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -66,21 +66,6 @@ pub enum Cmd {
         #[structopt(short, long, use_delimiter = true)]
         raft_groups: Vec<u64>,
     },
-
-    /// repair log entry holes by fill in empty message
-    Autofill {
-        /// Path of raft-engine storage directory
-        #[structopt(short, long)]
-        path: String,
-
-        /// queue name
-        #[structopt(short, long, possible_values = &["append", "rewrite", "all"])]
-        queue: String,
-
-        /// raft_group ids(optional), format: raft_groups_id1,raft_group_id2....
-        #[structopt(short, long, use_delimiter = true)]
-        raft_groups: Vec<u64>,
-    },
 }
 
 fn convert_queue(queue: &str) -> Option<LogQueue> {
@@ -100,11 +85,6 @@ impl ControlOpt {
 
         let cmd = self.cmd.as_ref().unwrap();
         match cmd {
-            Cmd::Autofill {
-                path,
-                queue,
-                raft_groups,
-            } => self.auto_fill(path, queue, raft_groups),
             Cmd::Dump {
                 file,
                 path,
@@ -125,11 +105,6 @@ impl ControlOpt {
             } => self.truncate(path, mode, queue, raft_groups),
             Cmd::Check { path } => self.check(path),
         }
-    }
-
-    fn auto_fill(&self, path: &str, queue: &str, raft_groups: &[u64]) -> Result<()> {
-        let p = PathBuf::from(path);
-        Engine::auto_fill(p.as_path(), convert_queue(queue), &raft_groups.to_vec())
     }
 
     fn help() {

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -18,11 +18,12 @@ struct ControlOpt {
 pub enum Cmd {
     /// dump out all operations in log files
     Dump {
-        #[structopt(short, long = "path", help = "Path of raft-engine storage directory")]
+        #[structopt(
+            short,
+            long = "path",
+            help = "Path of log file directory or specific log file"
+        )]
         path: String,
-
-        #[structopt(short = "seq", long, help = "The sequence number of file to dump")]
-        seq: Option<u64>,
 
         /// raft_group ids(optional), format: raft_groups_id1,raft_group_id2....
         #[structopt(short, long, use_delimiter = true)]
@@ -73,11 +74,7 @@ impl ControlOpt {
 
         let cmd = self.cmd.as_ref().unwrap();
         match cmd {
-            Cmd::Dump {
-                path,
-                seq,
-                raft_groups,
-            } => self.dump(path, *seq, raft_groups),
+            Cmd::Dump { path, raft_groups } => self.dump(path, raft_groups),
             Cmd::Truncate {
                 path,
                 mode,
@@ -92,8 +89,8 @@ impl ControlOpt {
         Self::clap().print_help().ok();
     }
 
-    fn dump(&self, path: &str, seq: Option<u64>, raft_groups: &[u64]) -> Result<()> {
-        let r = Engine::dump(Path::new(path), seq, &raft_groups.to_vec())?;
+    fn dump(&self, path: &str, raft_groups: &[u64]) -> Result<()> {
+        let r = Engine::dump(Path::new(path), &raft_groups.to_vec())?;
 
         if r.is_empty() {
             println!("No data");

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,32 +11,52 @@ const MIN_RECOVERY_THREADS: usize = 1;
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum RecoveryMode {
-    AbsoluteConsistency = 0,
-    TolerateTailCorruption = 1,
-    TolerateAnyCorruption = 2,
+    AbsoluteConsistency,
+    TolerateTailCorruption,
+    TolerateAnyCorruption,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Config {
+    /// Directory to store log files. Will create on startup if not exists.
+    ///
+    /// Default: ""
     pub dir: String,
+
+    /// How to deal with file corruption during recovery.
+    ///
+    /// Default: "tolerate-tail-corruption".
     pub recovery_mode: RecoveryMode,
+    /// Minimum I/O size for reading log files during recovery.
+    ///
+    /// Default: "4KB". Minimum: "512B".
+    pub recovery_read_block_size: ReadableSize,
+    /// The number of threads used to scan and recovery log files.
+    ///
+    /// Default: 4. Minimum: 1.
+    pub recovery_threads: usize,
+
+    /// Compress a log batch if its size exceeds this value. Setting it to zero
+    /// disables compression.
+    ///
+    /// Default: "8KB"
+    pub batch_compression_threshold: ReadableSize,
+    /// Incrementally sync log files after specified bytes have been written.
+    /// Setting it to zero disables incremental sync.
+    ///
+    /// Default: "4MB"
     pub bytes_per_sync: ReadableSize,
+    /// Target file size for rotating log files.
+    ///
+    /// Default: "128MB"
     pub target_file_size: ReadableSize,
 
-    /// Only purge if disk file size is greater than `purge_threshold`.
-    pub purge_threshold: ReadableSize,
-
-    /// Compress a log batch if its size is greater than `batch_compression_threshold`.
+    /// Purge main log queue if its file size exceeds this value.
     ///
-    /// Set to `0` will disable compression.
-    pub batch_compression_threshold: ReadableSize,
-
-    /// Read block size for recovery. Default value: "4KB". Min value: "512B".
-    pub recovery_read_block_size: ReadableSize,
-    /// Parallel recovery concurrency. Default value: 4. Min value: 1.
-    pub recovery_threads: usize,
+    /// Default: "10GB"
+    pub purge_threshold: ReadableSize,
 }
 
 impl Default for Config {
@@ -44,12 +64,12 @@ impl Default for Config {
         Config {
             dir: "".to_owned(),
             recovery_mode: RecoveryMode::TolerateTailCorruption,
-            bytes_per_sync: ReadableSize::kb(256),
-            target_file_size: ReadableSize::mb(128),
-            purge_threshold: ReadableSize::gb(10),
-            batch_compression_threshold: ReadableSize::kb(8),
             recovery_read_block_size: ReadableSize::kb(16),
             recovery_threads: 4,
+            batch_compression_threshold: ReadableSize::kb(8),
+            bytes_per_sync: ReadableSize::mb(4),
+            target_file_size: ReadableSize::mb(128),
+            purge_threshold: ReadableSize::gb(10),
         }
     }
 }
@@ -58,6 +78,9 @@ impl Config {
     pub fn sanitize(&mut self) -> Result<()> {
         if self.purge_threshold.0 < self.target_file_size.0 {
             return Err(box_err!("purge-threshold < target-file-size"));
+        }
+        if self.bytes_per_sync.0 == 0 {
+            self.bytes_per_sync = ReadableSize(u64::MAX);
         }
         let min_recovery_read_block_size = ReadableSize(MIN_RECOVERY_READ_BLOCK_SIZE as u64);
         if self.recovery_read_block_size < min_recovery_read_block_size {

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,10 +142,13 @@ mod tests {
         let soft_error = r#"
             recovery-read-block-size = "1KB"
             recovery-threads = 0
+            bytes-per-sync = "0KB"
         "#;
         let soft_load: Config = toml::from_str(soft_error).unwrap();
-        let mut soft_sanitized = soft_load.clone();
+        let mut soft_sanitized = soft_load;
         soft_sanitized.sanitize().unwrap();
-        assert_ne!(soft_load, soft_sanitized);
+        assert!(soft_sanitized.recovery_read_block_size.0 >= MIN_RECOVERY_READ_BLOCK_SIZE as u64);
+        assert!(soft_sanitized.recovery_threads >= MIN_RECOVERY_THREADS);
+        assert_eq!(soft_sanitized.bytes_per_sync.0, u64::MAX);
     }
 }

--- a/src/consistency.rs
+++ b/src/consistency.rs
@@ -11,7 +11,7 @@ use crate::Result;
 pub struct ConsistencyChecker {
     // Raft group id -> first index, last index
     raft_groups: HashMap<u64, (u64, u64)>,
-    // Raft group id -> last unaffected index
+    // Raft group id -> last valid index
     corrupted: HashMap<u64, u64>,
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -17,7 +17,7 @@ use crate::file_pipe_log::{FilePipeLog, FilePipeLogBuilder};
 use crate::log_batch::{Command, LogBatch, LogItem, MessageExt};
 use crate::memtable::{EntryIndex, MemTableAccessor, MemTableRecoverContext};
 use crate::metrics::*;
-use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue, PipeLog};
+use crate::pipe_log::{FileBlockHandle, FileId, LogQueue, PipeLog};
 use crate::purge::{PurgeHook, PurgeManager};
 use crate::write_barrier::{WriteBarrier, Writer};
 use crate::{Error, GlobalStats, Result};
@@ -307,8 +307,8 @@ impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
         )
     }
 
-    pub fn dump(path: &Path, seq: Option<FileSeq>, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
-        Self::dump_with_file_builder(path, seq, raft_groups, Arc::new(DefaultFileBuilder))
+    pub fn dump(path: &Path, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
+        Self::dump_with_file_builder(path, raft_groups, Arc::new(DefaultFileBuilder))
     }
 }
 
@@ -362,7 +362,6 @@ where
     #[allow(unused_variables)]
     pub fn dump_with_file_builder(
         path: &Path,
-        seq: Option<FileSeq>,
         raft_groups: &[u64],
         file_builder: Arc<B>,
     ) -> Result<Vec<LogItem>> {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -110,7 +110,7 @@ where
     B: FileBuilder,
     P: PipeLog,
 {
-    /// Write the content of LogBatch into the engine and return written bytes.
+    /// Write the content of `log_batch` into the engine and return written bytes.
     /// If `sync` is true, the write will be followed by a call to `fdatasync` on
     /// the log file.
     pub fn write(&self, log_batch: &mut LogBatch, mut sync: bool) -> Result<usize> {
@@ -206,8 +206,8 @@ where
         Ok(None)
     }
 
-    /// Purge expired logs files and return a set of Raft group ids
-    /// which needs to be compacted ASAP.
+    /// Purges expired logs files and returns a set of Raft group ids that need
+    /// to be compacted.
     pub fn purge_expired_files(&self) -> Result<Vec<u64>> {
         let _t = StopWatch::new(&ENGINE_PURGE_EXPIRED_FILES_DURATION_HISTOGRAM);
 
@@ -217,7 +217,7 @@ where
         self.purge_manager.purge_expired_files()
     }
 
-    /// Return count of fetched entries.
+    /// Returns count of fetched entries.
     pub fn fetch_entries_to<M: MessageExt>(
         &self,
         region_id: u64,
@@ -255,8 +255,8 @@ where
         None
     }
 
-    /// Like `cut_logs` but the range could be very large. Return the deleted count.
-    /// Generally, `from` can be passed in `0`.
+    /// Deletes log entries before `index` in the specified Raft group. Returns
+    /// the number of deleted entries.
     pub fn compact_to(&self, region_id: u64, index: u64) -> u64 {
         let _t = StopWatch::new(&ENGINE_COMPACT_DURATION_HISTOGRAM);
         let first_index = match self.first_index(region_id) {
@@ -291,30 +291,31 @@ impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
         Self::consistency_check_with_file_builder(path, Arc::new(DefaultFileBuilder))
     }
 
-    // Repair log entry holes by fill in empty message
-    /// queue: accept "append", "rewrite", "all"
-    #[allow(unused_variables)]
-    pub fn auto_fill(path: &std::path::Path, queue: &str, raft_groups: &[u64]) -> Result<()> {
-        todo!()
-    }
-
-    // Trunate all files unsafely
-    /// mode: accept "front", "back", "all"
-    /// queue: accept "append", "rewrite", "all"
-    #[allow(unused_variables)]
-    pub fn truncate(
+    pub fn auto_fill(
         path: &std::path::Path,
-        mode: &str,
-        queue: &str,
+        queue: Option<LogQueue>,
         raft_groups: &[u64],
     ) -> Result<()> {
-        todo!()
+        Self::auto_fill_with_file_builder(path, queue, raft_groups, Arc::new(DefaultFileBuilder))
     }
 
-    // Dump all all operations in log files
-    #[allow(unused_variables)]
+    pub fn unsafe_truncate(
+        path: &std::path::Path,
+        mode: &str,
+        queue: Option<LogQueue>,
+        raft_groups: &[u64],
+    ) -> Result<()> {
+        Self::unsafe_truncate_with_file_builder(
+            path,
+            mode,
+            queue,
+            raft_groups,
+            Arc::new(DefaultFileBuilder),
+        )
+    }
+
     pub fn dump(path: &std::path::Path, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
-        todo!()
+        Self::dump_with_file_builder(path, raft_groups, Arc::new(DefaultFileBuilder))
     }
 }
 
@@ -351,9 +352,42 @@ where
         list.sort_unstable();
         Ok(list)
     }
+
+    /// Repairs log entry holes by filling in empty messages.
+    #[allow(unused_variables)]
+    pub fn auto_fill_with_file_builder(
+        path: &std::path::Path,
+        queue: Option<LogQueue>,
+        raft_groups: &[u64],
+        file_builder: Arc<B>,
+    ) -> Result<()> {
+        todo!();
+    }
+
+    /// Truncates Raft groups to remove possible corruptions.
+    #[allow(unused_variables)]
+    pub fn unsafe_truncate_with_file_builder(
+        path: &std::path::Path,
+        mode: &str,
+        queue: Option<LogQueue>,
+        raft_groups: &[u64],
+        file_builder: Arc<B>,
+    ) -> Result<()> {
+        todo!();
+    }
+
+    /// Dumps all operations.
+    #[allow(unused_variables)]
+    pub fn dump_with_file_builder(
+        path: &std::path::Path,
+        raft_groups: &[u64],
+        file_builder: Arc<B>,
+    ) -> Result<Vec<LogItem>> {
+        todo!()
+    }
 }
 
-pub fn read_entry_from_file<M, P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<M::Entry>
+pub(crate) fn read_entry_from_file<M, P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<M::Entry>
 where
     M: MessageExt,
     P: PipeLog,
@@ -364,7 +398,7 @@ where
     Ok(e)
 }
 
-pub fn read_entry_bytes_from_file<P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<Vec<u8>>
+pub(crate) fn read_entry_bytes_from_file<P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<Vec<u8>>
 where
     P: PipeLog,
 {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::marker::PhantomData;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use std::u64;
@@ -287,20 +288,12 @@ where
 }
 
 impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
-    pub fn consistency_check(path: &std::path::Path) -> Result<Vec<(u64, u64)>> {
+    pub fn consistency_check(path: &Path) -> Result<Vec<(u64, u64)>> {
         Self::consistency_check_with_file_builder(path, Arc::new(DefaultFileBuilder))
     }
 
-    pub fn auto_fill(
-        path: &std::path::Path,
-        queue: Option<LogQueue>,
-        raft_groups: &[u64],
-    ) -> Result<()> {
-        Self::auto_fill_with_file_builder(path, queue, raft_groups, Arc::new(DefaultFileBuilder))
-    }
-
     pub fn unsafe_truncate(
-        path: &std::path::Path,
+        path: &Path,
         mode: &str,
         queue: Option<LogQueue>,
         raft_groups: &[u64],
@@ -314,7 +307,7 @@ impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
         )
     }
 
-    pub fn dump(path: &std::path::Path, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
+    pub fn dump(path: &Path, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
         Self::dump_with_file_builder(path, raft_groups, Arc::new(DefaultFileBuilder))
     }
 }
@@ -323,10 +316,10 @@ impl<B> Engine<B, FilePipeLog<B>>
 where
     B: FileBuilder,
 {
-    /// Returns a list of corrupted Raft groups, including their id and last unaffected
+    /// Returns a list of corrupted Raft groups, including their ids and last valid
     /// log index. Head or tail corruption might not be detected.
     pub fn consistency_check_with_file_builder(
-        path: &std::path::Path,
+        path: &Path,
         file_builder: Arc<B>,
     ) -> Result<Vec<(u64, u64)>> {
         if !path.exists() {
@@ -353,21 +346,10 @@ where
         Ok(list)
     }
 
-    /// Repairs log entry holes by filling in empty messages.
-    #[allow(unused_variables)]
-    pub fn auto_fill_with_file_builder(
-        path: &std::path::Path,
-        queue: Option<LogQueue>,
-        raft_groups: &[u64],
-        file_builder: Arc<B>,
-    ) -> Result<()> {
-        todo!();
-    }
-
     /// Truncates Raft groups to remove possible corruptions.
     #[allow(unused_variables)]
     pub fn unsafe_truncate_with_file_builder(
-        path: &std::path::Path,
+        path: &Path,
         mode: &str,
         queue: Option<LogQueue>,
         raft_groups: &[u64],
@@ -379,7 +361,7 @@ where
     /// Dumps all operations.
     #[allow(unused_variables)]
     pub fn dump_with_file_builder(
-        path: &std::path::Path,
+        path: &Path,
         raft_groups: &[u64],
         file_builder: Arc<B>,
     ) -> Result<Vec<LogItem>> {
@@ -1040,7 +1022,7 @@ mod tests {
             type Reader<R: Seek + Read + Send> = TestFile<R>;
             type Writer<W: Seek + Write + Send> = TestFile<W>;
 
-            fn build_reader<R>(&self, _path: &std::path::Path, inner: R) -> Result<Self::Reader<R>>
+            fn build_reader<R>(&self, _path: &Path, inner: R) -> Result<Self::Reader<R>>
             where
                 R: Seek + Read + Send,
             {
@@ -1049,7 +1031,7 @@ mod tests {
 
             fn build_writer<W>(
                 &self,
-                _path: &std::path::Path,
+                _path: &Path,
                 inner: W,
                 _create: bool,
             ) -> Result<Self::Writer<W>>

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -17,7 +17,7 @@ use crate::file_pipe_log::{FilePipeLog, FilePipeLogBuilder};
 use crate::log_batch::{Command, LogBatch, LogItem, MessageExt};
 use crate::memtable::{EntryIndex, MemTableAccessor, MemTableRecoverContext};
 use crate::metrics::*;
-use crate::pipe_log::{FileBlockHandle, FileId, LogQueue, PipeLog};
+use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue, PipeLog};
 use crate::purge::{PurgeHook, PurgeManager};
 use crate::write_barrier::{WriteBarrier, Writer};
 use crate::{Error, GlobalStats, Result};
@@ -307,8 +307,8 @@ impl Engine<DefaultFileBuilder, FilePipeLog<DefaultFileBuilder>> {
         )
     }
 
-    pub fn dump(path: &Path, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
-        Self::dump_with_file_builder(path, raft_groups, Arc::new(DefaultFileBuilder))
+    pub fn dump(path: &Path, seq: Option<FileSeq>, raft_groups: &[u64]) -> Result<Vec<LogItem>> {
+        Self::dump_with_file_builder(path, seq, raft_groups, Arc::new(DefaultFileBuilder))
     }
 }
 
@@ -362,6 +362,7 @@ where
     #[allow(unused_variables)]
     pub fn dump_with_file_builder(
         path: &Path,
+        seq: Option<FileSeq>,
         raft_groups: &[u64],
         file_builder: Arc<B>,
     ) -> Result<Vec<LogItem>> {

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -288,7 +288,7 @@ impl<B: FileBuilder> LogFileWriter<B> {
         Ok(())
     }
 
-    pub fn write(&mut self, buf: &[u8], target_file_size: usize) -> Result<()> {
+    pub fn write(&mut self, buf: &[u8], target_size_hint: usize) -> Result<()> {
         let new_written = self.written + buf.len();
         if self.capacity < new_written {
             let _t = StopWatch::new(&LOG_ALLOCATE_DURATION_HISTOGRAM);
@@ -296,7 +296,7 @@ impl<B: FileBuilder> LogFileWriter<B> {
                 new_written - self.capacity,
                 std::cmp::min(
                     FILE_ALLOCATE_SIZE,
-                    target_file_size.saturating_sub(self.capacity),
+                    target_size_hint.saturating_sub(self.capacity),
                 ),
             );
             self.fd.allocate(self.capacity, alloc)?;

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -356,13 +356,8 @@ impl<B: FileBuilder> LogFileReader<B> {
     }
 
     pub fn read(&mut self, handle: FileBlockHandle) -> Result<Vec<u8>> {
-        if handle.offset != self.offset as u64 {
-            self.reader.seek(SeekFrom::Start(handle.offset))?;
-            self.offset = handle.offset as usize;
-        }
         let mut buf = vec![0; handle.len];
-        let size = self.reader.read(&mut buf)?;
-        self.offset += size;
+        let size = self.read_to(handle.offset, &mut buf)?;
         buf.truncate(size);
         Ok(buf)
     }

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -2,6 +2,7 @@
 
 use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::os::unix::io::RawFd;
+use std::path::Path;
 use std::sync::Arc;
 
 use fail::fail_point;
@@ -12,6 +13,14 @@ use nix::sys::stat::Mode;
 use nix::sys::uio::{pread, pwrite};
 use nix::unistd::{close, ftruncate, lseek, Whence};
 use nix::NixPath;
+
+use crate::file_builder::FileBuilder;
+use crate::metrics::*;
+use crate::Result;
+
+use super::format::LogFileHeader;
+
+const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
 
 /// A `LogFd` is a RAII file that provides basic I/O functionality.
 ///
@@ -214,5 +223,105 @@ impl Seek for LogFile {
             SeekFrom::End(i) => self.offset = (self.inner.file_size()? as i64 + i) as usize,
         }
         Ok(self.offset as u64)
+    }
+}
+
+pub fn build_file_writer<B: FileBuilder>(
+    builder: &B,
+    path: &Path,
+    fd: Arc<LogFd>,
+    create: bool,
+) -> Result<LogFileWriter<B>> {
+    let raw_writer = LogFile::new(fd.clone());
+    let writer = builder.build_writer(path, raw_writer, create)?;
+    LogFileWriter::open(fd, writer)
+}
+
+/// Append-only writer for log file.
+pub struct LogFileWriter<B: FileBuilder> {
+    fd: Arc<LogFd>,
+    writer: B::Writer<LogFile>,
+
+    written: usize,
+    capacity: usize,
+    last_sync: usize,
+}
+
+impl<B: FileBuilder> LogFileWriter<B> {
+    fn open(fd: Arc<LogFd>, writer: B::Writer<LogFile>) -> Result<Self> {
+        let file_size = fd.file_size()?;
+        let mut f = Self {
+            fd,
+            writer,
+            written: file_size,
+            capacity: file_size,
+            last_sync: file_size,
+        };
+        if file_size < LogFileHeader::len() {
+            f.write_header()?;
+        } else {
+            f.writer.seek(std::io::SeekFrom::Start(file_size as u64))?;
+        }
+        Ok(f)
+    }
+
+    fn write_header(&mut self) -> Result<()> {
+        self.writer.seek(std::io::SeekFrom::Start(0))?;
+        self.written = 0;
+        let mut buf = Vec::with_capacity(LogFileHeader::len());
+        LogFileHeader::default().encode(&mut buf)?;
+        self.write(&buf, 0)
+    }
+
+    pub fn close(&mut self) -> Result<()> {
+        // Necessary to truncate extra zeros from fallocate().
+        self.truncate()?;
+        self.sync()
+    }
+
+    pub fn truncate(&mut self) -> Result<()> {
+        if self.written < self.capacity {
+            self.fd.truncate(self.written)?;
+            self.capacity = self.written;
+        }
+        Ok(())
+    }
+
+    pub fn write(&mut self, buf: &[u8], target_file_size: usize) -> Result<()> {
+        let new_written = self.written + buf.len();
+        if self.capacity < new_written {
+            let _t = StopWatch::new(&LOG_ALLOCATE_DURATION_HISTOGRAM);
+            let alloc = std::cmp::max(
+                new_written - self.capacity,
+                std::cmp::min(
+                    FILE_ALLOCATE_SIZE,
+                    target_file_size.saturating_sub(self.capacity),
+                ),
+            );
+            self.fd.allocate(self.capacity, alloc)?;
+            self.capacity += alloc;
+        }
+        self.writer.write_all(buf)?;
+        self.written = new_written;
+        Ok(())
+    }
+
+    pub fn sync(&mut self) -> Result<()> {
+        if self.last_sync < self.written {
+            let _t = StopWatch::new(&LOG_SYNC_DURATION_HISTOGRAM);
+            self.fd.sync()?;
+            self.last_sync = self.written;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    pub fn since_last_sync(&self) -> usize {
+        self.written - self.last_sync
+    }
+
+    #[inline]
+    pub fn offset(&self) -> usize {
+        self.written
     }
 }

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -11,12 +11,16 @@ pub use pipe_builder::{DualPipesBuilder as FilePipeLogBuilder, ReplayMachine};
 
 /// Public utilities used only for debugging purposes.
 pub mod debug {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
+    use super::format::FileNameExt;
     use super::log_file::{LogFd, LogFileReader, LogFileWriter};
+    use super::reader::LogItemBatchFileReader;
     use crate::file_builder::FileBuilder;
-    use crate::Result;
+    use crate::log_batch::LogItem;
+    use crate::pipe_log::FileId;
+    use crate::{Error, Result};
 
     #[allow(dead_code)]
     pub fn build_file_writer<B: FileBuilder>(
@@ -37,5 +41,101 @@ pub mod debug {
     pub fn build_file_reader<B: FileBuilder>(builder: &B, path: &Path) -> Result<LogFileReader<B>> {
         let fd = Arc::new(LogFd::open(path)?);
         super::log_file::build_file_reader(builder, path, fd)
+    }
+
+    pub struct LogItemReader<B: FileBuilder> {
+        builder: Arc<B>,
+        files: Vec<(FileId, PathBuf)>,
+        batch_reader: LogItemBatchFileReader<B>,
+        items: Vec<LogItem>,
+    }
+
+    impl<B: FileBuilder> LogItemReader<B> {
+        pub fn new_file_reader(builder: Arc<B>, file: &Path) -> Result<Self> {
+            if !file.is_file() {
+                return Err(Error::InvalidArgument(format!(
+                    "Not a file: {}",
+                    file.display()
+                )));
+            }
+            let file_name = file.file_name().unwrap().to_str().unwrap();
+            let file_id = FileId::parse_file_name(file_name);
+            if file_id.is_none() {
+                return Err(Error::InvalidArgument(format!(
+                    "Invalid log file name: {}",
+                    file_name
+                )));
+            }
+            Ok(Self {
+                builder,
+                files: vec![(file_id.unwrap(), file.into())],
+                batch_reader: LogItemBatchFileReader::new(0),
+                items: Vec::new(),
+            })
+        }
+
+        pub fn new_directory_reader(builder: Arc<B>, dir: &Path) -> Result<Self> {
+            if !dir.is_dir() {
+                return Err(Error::InvalidArgument(format!(
+                    "Not a directory: {}",
+                    dir.display()
+                )));
+            }
+            let files = std::fs::read_dir(dir)?
+                .filter_map(|e| {
+                    if let Ok(e) = e {
+                        let p = e.path();
+                        if p.is_file() {
+                            if let Some(file_id) =
+                                FileId::parse_file_name(p.file_name().unwrap().to_str().unwrap())
+                            {
+                                return Some((file_id, p));
+                            }
+                        }
+                    }
+                    None
+                })
+                .collect();
+            Ok(Self {
+                builder,
+                files,
+                batch_reader: LogItemBatchFileReader::new(0),
+                items: Vec::new(),
+            })
+        }
+
+        pub fn next(&mut self) -> Option<Result<LogItem>> {
+            if self.items.is_empty() {
+                let next_batch = self.batch_reader.next();
+                match next_batch {
+                    Ok(Some(b)) => {
+                        self.items.append(&mut b.into_items());
+                    }
+                    Ok(None) => {
+                        if let Err(e) = self.find_next_readable_file() {
+                            self.batch_reader.reset();
+                            return Some(Err(e));
+                        }
+                    }
+                    Err(e) => {
+                        self.batch_reader.reset();
+                        return Some(Err(e));
+                    }
+                }
+            }
+            self.items.pop().map(Ok)
+        }
+
+        fn find_next_readable_file(&mut self) -> Result<()> {
+            while let Some((file_id, path)) = self.files.pop() {
+                self.batch_reader
+                    .open(file_id, build_file_reader(self.builder.as_ref(), &path)?)?;
+                if let Some(b) = self.batch_reader.next()? {
+                    self.items.append(&mut b.into_items());
+                    break;
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -8,3 +8,34 @@ mod reader;
 
 pub use pipe::DualPipes as FilePipeLog;
 pub use pipe_builder::{DualPipesBuilder as FilePipeLogBuilder, ReplayMachine};
+
+/// Public utilities used only for debugging purposes.
+pub mod debug {
+    use std::path::Path;
+    use std::sync::Arc;
+
+    use super::log_file::{LogFd, LogFileReader, LogFileWriter};
+    use crate::file_builder::FileBuilder;
+    use crate::Result;
+
+    #[allow(dead_code)]
+    pub fn build_file_writer<B: FileBuilder>(
+        builder: &B,
+        path: &Path,
+        create: bool,
+    ) -> Result<LogFileWriter<B>> {
+        let fd = if create {
+            LogFd::create(path)?
+        } else {
+            LogFd::open(path)?
+        };
+        let fd = Arc::new(fd);
+        super::log_file::build_file_writer(builder, path, fd, create)
+    }
+
+    #[allow(dead_code)]
+    pub fn build_file_reader<B: FileBuilder>(builder: &B, path: &Path) -> Result<LogFileReader<B>> {
+        let fd = Arc::new(LogFd::open(path)?);
+        super::log_file::build_file_reader(builder, path, fd)
+    }
+}

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-mod builder;
 mod format;
 mod log_file;
-mod pipe_log;
+mod pipe;
+mod pipe_builder;
 mod reader;
 
-pub use builder::{DualPipesBuilder as FilePipeLogBuilder, ReplayMachine};
-pub use pipe_log::DualPipes as FilePipeLog;
+pub use pipe::DualPipes as FilePipeLog;
+pub use pipe_builder::{DualPipesBuilder as FilePipeLogBuilder, ReplayMachine};

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -11,6 +11,7 @@ pub use pipe_builder::{DualPipesBuilder as FilePipeLogBuilder, ReplayMachine};
 
 /// Public utilities used only for debugging purposes.
 pub mod debug {
+    use std::collections::VecDeque;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
 
@@ -43,14 +44,16 @@ pub mod debug {
         super::log_file::build_file_reader(builder, path, fd)
     }
 
+    #[allow(dead_code)]
     pub struct LogItemReader<B: FileBuilder> {
         builder: Arc<B>,
-        files: Vec<(FileId, PathBuf)>,
+        files: VecDeque<(FileId, PathBuf)>,
         batch_reader: LogItemBatchFileReader<B>,
-        items: Vec<LogItem>,
+        items: VecDeque<LogItem>,
     }
 
     impl<B: FileBuilder> LogItemReader<B> {
+        #[allow(dead_code)]
         pub fn new_file_reader(builder: Arc<B>, file: &Path) -> Result<Self> {
             if !file.is_file() {
                 return Err(Error::InvalidArgument(format!(
@@ -68,12 +71,13 @@ pub mod debug {
             }
             Ok(Self {
                 builder,
-                files: vec![(file_id.unwrap(), file.into())],
+                files: vec![(file_id.unwrap(), file.into())].into(),
                 batch_reader: LogItemBatchFileReader::new(0),
-                items: Vec::new(),
+                items: VecDeque::new(),
             })
         }
 
+        #[allow(dead_code)]
         pub fn new_directory_reader(builder: Arc<B>, dir: &Path) -> Result<Self> {
             if !dir.is_dir() {
                 return Err(Error::InvalidArgument(format!(
@@ -81,7 +85,7 @@ pub mod debug {
                     dir.display()
                 )));
             }
-            let files = std::fs::read_dir(dir)?
+            let mut files: Vec<_> = std::fs::read_dir(dir)?
                 .filter_map(|e| {
                     if let Ok(e) = e {
                         let p = e.path();
@@ -96,20 +100,22 @@ pub mod debug {
                     None
                 })
                 .collect();
+            files.sort_by_key(|pair| pair.0);
             Ok(Self {
                 builder,
-                files,
+                files: files.into(),
                 batch_reader: LogItemBatchFileReader::new(0),
-                items: Vec::new(),
+                items: VecDeque::new(),
             })
         }
 
+        #[allow(dead_code)]
         pub fn next(&mut self) -> Option<Result<LogItem>> {
             if self.items.is_empty() {
                 let next_batch = self.batch_reader.next();
                 match next_batch {
                     Ok(Some(b)) => {
-                        self.items.append(&mut b.into_items());
+                        self.items.extend(b.into_items());
                     }
                     Ok(None) => {
                         if let Err(e) = self.find_next_readable_file() {
@@ -123,19 +129,99 @@ pub mod debug {
                     }
                 }
             }
-            self.items.pop().map(Ok)
+            self.items.pop_front().map(Ok)
         }
 
         fn find_next_readable_file(&mut self) -> Result<()> {
-            while let Some((file_id, path)) = self.files.pop() {
+            while let Some((file_id, path)) = self.files.pop_front() {
                 self.batch_reader
                     .open(file_id, build_file_reader(self.builder.as_ref(), &path)?)?;
                 if let Some(b) = self.batch_reader.next()? {
-                    self.items.append(&mut b.into_items());
+                    self.items.extend(b.into_items());
                     break;
                 }
             }
             Ok(())
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::file_builder::DefaultFileBuilder;
+        use crate::log_batch::{Command, LogBatch};
+        use crate::pipe_log::{FileBlockHandle, LogQueue};
+        use crate::test_util::generate_entries;
+        use raft::eraftpb::Entry;
+
+        #[test]
+        fn test_debug_file_basic() {
+            let dir = tempfile::Builder::new()
+                .prefix("test_debug_file_basic")
+                .tempdir()
+                .unwrap();
+            let mut file_id = FileId {
+                queue: LogQueue::Rewrite,
+                seq: 7,
+            };
+            let builder = Arc::new(DefaultFileBuilder);
+            let entry_data = vec![b'x'; 1024];
+
+            let mut batches = vec![vec![LogBatch::default()]];
+            let mut batch = LogBatch::default();
+            batch
+                .add_entries::<Entry>(7, &generate_entries(1, 11, Some(&entry_data)))
+                .unwrap();
+            batch.add_command(7, Command::Clean);
+            batch.put(7, b"key".to_vec(), b"value".to_vec());
+            batch.delete(7, b"key2".to_vec());
+            batches.push(vec![batch.clone()]);
+            let mut batch2 = LogBatch::default();
+            batch2.put(8, b"key3".to_vec(), b"value".to_vec());
+            batch2
+                .add_entries::<Entry>(8, &generate_entries(5, 15, Some(&entry_data)))
+                .unwrap();
+            batches.push(vec![batch, batch2]);
+
+            for bs in batches.iter_mut() {
+                let file_path = file_id.build_file_path(dir.path());
+                // Write a file.
+                let mut writer =
+                    build_file_writer(builder.as_ref(), &file_path, true /*create*/).unwrap();
+                for batch in bs.iter_mut() {
+                    let offset = writer.offset() as u64;
+                    let len = batch.finish_populate(1 /*compression_threshold*/).unwrap();
+                    writer
+                        .write(batch.encoded_bytes(), 0 /*target_file_hint*/)
+                        .unwrap();
+                    batch.finish_write(FileBlockHandle {
+                        id: file_id,
+                        offset,
+                        len,
+                    });
+                }
+                writer.close().unwrap();
+                // Read and verify.
+                let mut reader =
+                    LogItemReader::new_file_reader(builder.clone(), &file_path).unwrap();
+                for batch in bs {
+                    for item in batch.clone().drain() {
+                        assert_eq!(item, reader.next().unwrap().unwrap());
+                    }
+                }
+                assert!(reader.next().is_none());
+                file_id.seq += 1;
+            }
+            // Read directory and verify.
+            let mut reader = LogItemReader::new_directory_reader(builder, dir.path()).unwrap();
+            for bs in batches.iter() {
+                for batch in bs {
+                    for item in batch.clone().drain() {
+                        assert_eq!(item, reader.next().unwrap().unwrap());
+                    }
+                }
+            }
+            assert!(reader.next().is_none())
         }
     }
 }

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -16,7 +16,7 @@ use crate::pipe_log::{FileId, FileSeq, LogQueue};
 use crate::Result;
 
 use super::format::FileNameExt;
-use super::log_file::{LogFd, LogFile};
+use super::log_file::{build_file_reader, LogFd};
 use super::pipe::{DualPipes, SinglePipe};
 use super::reader::LogItemBatchFileReader;
 
@@ -195,8 +195,7 @@ impl<B: FileBuilder> DualPipesBuilder<B> {
                     let is_last_file = index == chunk_count - 1 && i == file_count - 1;
                     reader.open(
                         FileId { queue, seq: f.seq },
-                        file_builder.build_reader(&f.path, LogFile::new(f.fd.clone()))?,
-                        f.fd.file_size()?,
+                        build_file_reader(file_builder.as_ref(), &f.path, f.fd.clone())?,
                     )?;
                     loop {
                         match reader.next() {

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -17,7 +17,7 @@ use crate::Result;
 
 use super::format::FileNameExt;
 use super::log_file::{LogFd, LogFile};
-use super::pipe_log::{DualPipes, SinglePipe};
+use super::pipe::{DualPipes, SinglePipe};
 use super::reader::LogItemBatchFileReader;
 
 pub trait ReplayMachine: Send + Default {

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -68,22 +68,26 @@ impl<B: FileBuilder> DualPipesBuilder<B> {
         let (mut min_rewrite_id, mut max_rewrite_id) = (u64::MAX, 0);
         fs::read_dir(path)?.for_each(|e| {
             if let Ok(e) = e {
-                match FileId::parse_file_name(e.file_name().to_str().unwrap()) {
-                    Some(FileId {
-                        queue: LogQueue::Append,
-                        seq,
-                    }) => {
-                        min_append_id = std::cmp::min(min_append_id, seq);
-                        max_append_id = std::cmp::max(max_append_id, seq);
+                // TODO: test case
+                let p = e.path();
+                if p.is_file() {
+                    match FileId::parse_file_name(p.file_name().unwrap().to_str().unwrap()) {
+                        Some(FileId {
+                            queue: LogQueue::Append,
+                            seq,
+                        }) => {
+                            min_append_id = std::cmp::min(min_append_id, seq);
+                            max_append_id = std::cmp::max(max_append_id, seq);
+                        }
+                        Some(FileId {
+                            queue: LogQueue::Rewrite,
+                            seq,
+                        }) => {
+                            min_rewrite_id = std::cmp::min(min_rewrite_id, seq);
+                            max_rewrite_id = std::cmp::max(max_rewrite_id, seq);
+                        }
+                        _ => {}
                     }
-                    Some(FileId {
-                        queue: LogQueue::Rewrite,
-                        seq,
-                    }) => {
-                        min_rewrite_id = std::cmp::min(min_rewrite_id, seq);
-                        max_rewrite_id = std::cmp::max(max_rewrite_id, seq);
-                    }
-                    _ => {}
                 }
             }
         });

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -68,7 +68,6 @@ impl<B: FileBuilder> DualPipesBuilder<B> {
         let (mut min_rewrite_id, mut max_rewrite_id) = (u64::MAX, 0);
         fs::read_dir(path)?.for_each(|e| {
             if let Ok(e) = e {
-                // TODO: test case
                 let p = e.path();
                 if p.is_file() {
                     match FileId::parse_file_name(p.file_name().unwrap().to_str().unwrap()) {

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -50,6 +50,7 @@ impl<B: FileBuilder> LogItemBatchFileReader<B> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub fn reset(&mut self) {
         self.file_id = None;
         self.reader = None;
@@ -60,12 +61,12 @@ impl<B: FileBuilder> LogItemBatchFileReader<B> {
     }
 
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
-        if self.valid_offset < LOG_BATCH_HEADER_LEN {
-            return Err(Error::Corruption(
-                "attempt to read file with broken header".to_owned(),
-            ));
-        }
         if self.valid_offset < self.size {
+            if self.valid_offset < LOG_BATCH_HEADER_LEN {
+                return Err(Error::Corruption(
+                    "attempt to read file with broken header".to_owned(),
+                ));
+            }
             let (footer_offset, compression_type, len) = LogBatch::decode_header(&mut self.peek(
                 self.valid_offset,
                 LOG_BATCH_HEADER_LEN,

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -50,6 +50,15 @@ impl<B: FileBuilder> LogItemBatchFileReader<B> {
         Ok(())
     }
 
+    pub fn reset(&mut self) {
+        self.file_id = None;
+        self.reader = None;
+        self.size = 0;
+        self.buffer.clear();
+        self.buffer_offset = 0;
+        self.valid_offset = 0;
+    }
+
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
         if self.valid_offset < LOG_BATCH_HEADER_LEN {
             return Err(Error::Corruption(

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -1,16 +1,16 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::io::{Read, Seek};
-
+use crate::file_builder::FileBuilder;
 use crate::log_batch::{LogBatch, LogItemBatch, LOG_BATCH_HEADER_LEN};
 use crate::pipe_log::{FileBlockHandle, FileId};
 use crate::{Error, Result};
 
 use super::format::LogFileHeader;
+use super::log_file::LogFileReader;
 
-pub struct LogItemBatchFileReader<R: Read + Seek> {
+pub struct LogItemBatchFileReader<B: FileBuilder> {
     file_id: Option<FileId>,
-    file: Option<R>,
+    reader: Option<LogFileReader<B>>,
     size: usize,
 
     buffer: Vec<u8>,
@@ -22,11 +22,11 @@ pub struct LogItemBatchFileReader<R: Read + Seek> {
     read_block_size: usize,
 }
 
-impl<R: Read + Seek> LogItemBatchFileReader<R> {
+impl<B: FileBuilder> LogItemBatchFileReader<B> {
     pub fn new(read_block_size: usize) -> Self {
         Self {
             file_id: None,
-            file: None,
+            reader: None,
             size: 0,
 
             buffer: Vec::new(),
@@ -37,10 +37,10 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
         }
     }
 
-    pub fn open(&mut self, file_id: FileId, file: R, size: usize) -> Result<()> {
+    pub fn open(&mut self, file_id: FileId, reader: LogFileReader<B>) -> Result<()> {
         self.file_id = Some(file_id);
-        self.file = Some(file);
-        self.size = size;
+        self.size = reader.file_size()?;
+        self.reader = Some(reader);
         self.buffer.clear();
         self.buffer_offset = 0;
         self.valid_offset = 0;
@@ -88,17 +88,16 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
 
     fn peek(&mut self, offset: usize, size: usize, prefetch: usize) -> Result<&[u8]> {
         debug_assert!(offset >= self.buffer_offset);
-        let f = self.file.as_mut().unwrap();
+        let reader = self.reader.as_mut().unwrap();
         let end = self.buffer_offset + self.buffer.len();
         if offset > end {
             self.buffer_offset = offset;
             self.buffer
                 .resize(std::cmp::max(size + prefetch, self.read_block_size), 0);
-            f.seek(std::io::SeekFrom::Start(self.buffer_offset as u64))?;
-            let read = f.read(&mut self.buffer)?;
+            let read = reader.read_to(self.buffer_offset as u64, &mut self.buffer)?;
             if read < size {
                 return Err(Error::Corruption(format!(
-                    "unexpected eof at {}",
+                    "Unexpected eof at {}",
                     self.buffer_offset + read
                 )));
             }
@@ -113,10 +112,10 @@ impl<R: Read + Seek> LogItemBatchFileReader<R> {
                     prev_len + std::cmp::max(should_read, self.read_block_size),
                     0,
                 );
-                let read = f.read(&mut self.buffer[prev_len..])?;
+                let read = reader.read_to(read_offset as u64, &mut self.buffer[prev_len..])?;
                 if read + prefetch < should_read {
                     return Err(Error::Corruption(format!(
-                        "unexpected eof at {}",
+                        "Unexpected eof at {}",
                         read_offset + read,
                     )));
                 }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -358,6 +358,11 @@ impl LogItemBatch {
         }
     }
 
+    // TODO: Clean up these interfaces.
+    pub fn into_items(self) -> Vec<LogItem> {
+        self.items
+    }
+
     pub fn iter(&self) -> std::slice::Iter<LogItem> {
         self.items.iter()
     }


### PR DESCRIPTION
Factor out and export some interfaces for interacting with low level files:
- `build_file_writer`
- `build_file_reader`
- `LogItemReader`