### PR TITLE
fix bugs related to purge rewrite

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -843,7 +843,6 @@ mod tests {
             .purge_manager
             .needs_rewrite_log_files(LogQueue::Append));
         let will_force_compact = engine.purge_expired_files().unwrap();
-        engine.pipe_log.file_span(LogQueue::Append).0;
         // The region needs to be force compacted because the threshold is reached.
         assert!(!will_force_compact.is_empty());
         assert_eq!(will_force_compact[0], 1);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -842,11 +842,8 @@ mod tests {
         assert!(engine
             .purge_manager
             .needs_rewrite_log_files(LogQueue::Append));
-        let old_min_file_seq = engine.pipe_log.file_span(LogQueue::Append).0;
         let will_force_compact = engine.purge_expired_files().unwrap();
-        let new_min_file_seq = engine.pipe_log.file_span(LogQueue::Append).0;
-        // No entries are rewritten.
-        assert_eq!(new_min_file_seq, old_min_file_seq);
+        engine.pipe_log.file_span(LogQueue::Append).0;
         // The region needs to be force compacted because the threshold is reached.
         assert!(!will_force_compact.is_empty());
         assert_eq!(will_force_compact[0], 1);

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -210,8 +210,6 @@ where
     /// Purges expired logs files and returns a set of Raft group ids that need
     /// to be compacted.
     pub fn purge_expired_files(&self) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_PURGE_EXPIRED_FILES_DURATION_HISTOGRAM);
-
         // TODO: Move this to a dedicated thread.
         self.stats.flush_metrics();
 
@@ -259,7 +257,6 @@ where
     /// Deletes log entries before `index` in the specified Raft group. Returns
     /// the number of deleted entries.
     pub fn compact_to(&self, region_id: u64, index: u64) -> u64 {
-        let _t = StopWatch::new(&ENGINE_COMPACT_DURATION_HISTOGRAM);
         let first_index = match self.first_index(region_id) {
             Some(index) => index,
             None => return 0,

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -89,6 +89,7 @@ impl MemTable {
     pub fn merge_newer_neighbor(&mut self, rhs: &mut Self) {
         debug_assert_eq!(self.region_id, rhs.region_id);
         if let Some((rhs_first, _)) = rhs.span() {
+            // TODO: test case for rewrite holes.
             self.prepare_append(
                 rhs_first,
                 rhs.rewrite_count > 0, /*allow_hole*/
@@ -1105,7 +1106,7 @@ mod tests {
         memtable.put(k3.to_vec(), v3.to_vec(), FileId::new(LogQueue::Append, 3));
         memtable.consistency_check();
 
-        // Rewrite keys:
+        // Rewrite k1.
         memtable.rewrite_key(k1.to_vec(), Some(1), 50);
         let mut kvs = Vec::new();
         memtable.fetch_kvs_before(1, &mut kvs);
@@ -1113,7 +1114,7 @@ mod tests {
         memtable.fetch_rewritten_kvs(&mut kvs);
         assert_eq!(kvs.len(), 1);
         assert_eq!(kvs.pop().unwrap(), (k1.to_vec(), v1.to_vec()));
-        // 1. Key is deleted
+        // Rewrite deleted k1.
         memtable.delete(k1.as_ref());
         assert_eq!(memtable.global_stats.deleted_rewrite_entries(), 1);
         memtable.rewrite_key(k1.to_vec(), Some(1), 50);
@@ -1121,13 +1122,15 @@ mod tests {
         memtable.fetch_rewritten_kvs(&mut kvs);
         assert!(kvs.is_empty());
         assert_eq!(memtable.global_stats.deleted_rewrite_entries(), 2);
-        // 2. Key is newer
+        // Rewrite newer append k2/k3.
         memtable.rewrite_key(k2.to_vec(), Some(1), 50);
         memtable.fetch_rewritten_kvs(&mut kvs);
         assert!(kvs.is_empty());
-        assert_eq!(memtable.global_stats.deleted_rewrite_entries(), 3);
-        // 3. Multiple rewrites
-        assert!(catch_unwind_silent(|| memtable.rewrite_key(k3.to_vec(), None, 50)).is_err());
+        memtable.rewrite_key(k3.to_vec(), None, 50); // Rewrite encounters newer append.
+        memtable.fetch_rewritten_kvs(&mut kvs);
+        assert!(kvs.is_empty());
+        assert_eq!(memtable.global_stats.deleted_rewrite_entries(), 4);
+        // Rewrite k3 multiple times.
         memtable.rewrite_key(k3.to_vec(), Some(10), 50);
         memtable.rewrite_key(k3.to_vec(), None, 51);
         memtable.rewrite_key(k3.to_vec(), Some(11), 52);
@@ -1591,7 +1594,6 @@ mod tests {
 
     #[test]
     fn test_memtables_merge_neighbor() {
-        let file_id = FileId::new(LogQueue::Append, 10);
         let first_rid = 17;
         let mut last_rid = first_rid;
 
@@ -1600,6 +1602,9 @@ mod tests {
             LogItemBatch::with_capacity(0),
             LogItemBatch::with_capacity(0),
         ];
+        let files: Vec<_> = (0..batches.len())
+            .map(|i| FileId::new(LogQueue::Append, 10 + i as u64))
+            .collect();
 
         // put (key1, v1) => del (key1) => put (key1, v2)
         batches[0].put(last_rid, b"key1".to_vec(), b"val1".to_vec());
@@ -1613,9 +1618,9 @@ mod tests {
 
         // entries [1, 10) => compact 5 => entries [11, 20)
         last_rid += 1;
-        batches[0].add_entry_indexes(last_rid, generate_entry_indexes(1, 11, file_id));
+        batches[0].add_entry_indexes(last_rid, generate_entry_indexes(1, 11, files[0]));
         batches[1].add_command(last_rid, Command::Compact { index: 5 });
-        batches[2].add_entry_indexes(last_rid, generate_entry_indexes(11, 21, file_id));
+        batches[2].add_entry_indexes(last_rid, generate_entry_indexes(11, 21, files[2]));
 
         for b in batches.iter_mut() {
             b.finish_write(FileBlockHandle::dummy(LogQueue::Append));
@@ -1623,7 +1628,7 @@ mod tests {
 
         // reverse merge
         let mut ctxs = VecDeque::default();
-        for batch in batches.clone() {
+        for (batch, file_id) in batches.clone().into_iter().zip(files) {
             let mut ctx = MemTableRecoverContext::default();
             ctx.replay(batch, file_id).unwrap();
             ctxs.push_back(ctx);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -476,8 +476,15 @@ impl MemTable {
         }
     }
 
-    pub fn entries_count(&self) -> usize {
-        self.entry_indexes.len()
+    pub fn entries_count_before(&self, mut gate: FileId) -> usize {
+        gate.seq += 1;
+        let idx = self
+            .entry_indexes
+            .binary_search_by_key(&gate, |ei| ei.entries.unwrap().id);
+        match idx {
+            Ok(idx) => idx,
+            Err(idx) => idx,
+        }
     }
 
     pub fn region_id(&self) -> u64 {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -82,7 +82,7 @@ lazy_static! {
     pub static ref ENGINE_WRITE_SIZE_HISTOGRAM: Histogram = register_histogram!(
         "raft_engine_write_size",
         "Bucketed histogram of Raft Engine write size",
-        exponential_buckets(256.0, 1.8, 20).unwrap()
+        exponential_buckets(256.0, 1.8, 22).unwrap()
     )
     .unwrap();
     pub static ref LOG_ALLOCATE_DURATION_HISTOGRAM: Histogram = register_histogram!(
@@ -113,7 +113,7 @@ lazy_static! {
     pub static ref ENGINE_READ_ENTRY_COUNT_HISTOGRAM: Histogram = register_histogram!(
         "raft_engine_read_entry_count",
         "Bucketed histogram of Raft Engine read entry count",
-        exponential_buckets(1.0, 1.8, 20).unwrap()
+        exponential_buckets(1.0, 1.8, 22).unwrap()
     )
     .unwrap();
     pub static ref ENGINE_READ_MESSAGE_DURATION_HISTOGRAM: Histogram = register_histogram!(
@@ -126,7 +126,7 @@ lazy_static! {
     pub static ref ENGINE_PURGE_EXPIRED_FILES_DURATION_HISTOGRAM: Histogram = register_histogram!(
         "raft_engine_purge_expired_files_duration_seconds",
         "Bucketed histogram of Raft Engine purge expired files duration",
-        exponential_buckets(0.0001, 1.8, 20).unwrap()
+        exponential_buckets(0.001, 1.8, 22).unwrap()
     )
     .unwrap();
     pub static ref ENGINE_COMPACT_DURATION_HISTOGRAM: Histogram = register_histogram!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -123,16 +123,48 @@ lazy_static! {
     )
     .unwrap();
     // Misc.
-    pub static ref ENGINE_PURGE_EXPIRED_FILES_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "raft_engine_purge_expired_files_duration_seconds",
+    pub static ref ENGINE_PURGE_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "raft_engine_purge_duration_seconds",
         "Bucketed histogram of Raft Engine purge expired files duration",
         exponential_buckets(0.001, 1.8, 22).unwrap()
     )
     .unwrap();
-    pub static ref ENGINE_COMPACT_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "raft_engine_compact_duration_seconds",
-        "Bucketed histogram of Raft Engine compact duration",
-        exponential_buckets(0.00005, 1.8, 26).unwrap()
+    pub static ref ENGINE_REWRITE_APPEND_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "raft_engine_rewrite_append_duration_seconds",
+        "Bucketed histogram of Raft Engine rewrite append queue duration",
+        exponential_buckets(0.001, 1.8, 22).unwrap()
+    )
+    .unwrap();
+    pub static ref ENGINE_REWRITE_REWRITE_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "raft_engine_rewrite_rewrite_duration_seconds",
+        "Bucketed histogram of Raft Engine rewrite rewrite queue duration",
+        exponential_buckets(0.001, 1.8, 22).unwrap()
+    )
+    .unwrap();
+    pub static ref ENGINE_REWRITE_TOMBSTONES_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "raft_engine_rewrite_tombstones_duration_seconds",
+        "Bucketed histogram of Raft Engine rewrite tombstones duration",
+        exponential_buckets(0.001, 1.8, 22).unwrap()
+    )
+    .unwrap();
+    pub static ref ENGINE_PURGE_FILES_DURATION_HISTOGRAM: Histogram = register_histogram!(
+        "raft_engine_purge_files_duration_seconds",
+        "Bucketed histogram of Raft Engine purge files duration",
+        exponential_buckets(0.001, 1.8, 22).unwrap()
+    )
+    .unwrap();
+    pub static ref BACKGROUND_REWRITE_READ_ENTRY_COUNT: LogQueueCounterVec = register_static_int_counter_vec!(
+        LogQueueCounterVec,
+        "raft_engine_background_rewrite_read_entry_count",
+        "Total entries read during background rewrite",
+        &["type"]
+    )
+    .unwrap();
+    pub static ref BACKGROUND_REWRITE_WRITE_COUNT: LogQueueCounterVec = register_static_int_counter_vec!(
+        LogQueueCounterVec,
+        "raft_engine_background_rewrite_write_count",
+        "Total writes during background rewrite",
+        &["type"]
     )
     .unwrap();
     pub static ref BACKGROUND_REWRITE_BYTES: LogQueueCounterVec = register_static_int_counter_vec!(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -141,36 +141,10 @@ lazy_static! {
         exponential_buckets(0.001, 1.8, 22).unwrap()
     )
     .unwrap();
-    pub static ref ENGINE_REWRITE_TOMBSTONES_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "raft_engine_rewrite_tombstones_duration_seconds",
-        "Bucketed histogram of Raft Engine rewrite tombstones duration",
-        exponential_buckets(0.001, 1.8, 22).unwrap()
-    )
-    .unwrap();
-    pub static ref ENGINE_PURGE_FILES_DURATION_HISTOGRAM: Histogram = register_histogram!(
-        "raft_engine_purge_files_duration_seconds",
-        "Bucketed histogram of Raft Engine purge files duration",
-        exponential_buckets(0.001, 1.8, 22).unwrap()
-    )
-    .unwrap();
-    pub static ref BACKGROUND_REWRITE_READ_ENTRY_COUNT: LogQueueCounterVec = register_static_int_counter_vec!(
-        LogQueueCounterVec,
-        "raft_engine_background_rewrite_read_entry_count",
-        "Total entries read during background rewrite",
-        &["type"]
-    )
-    .unwrap();
-    pub static ref BACKGROUND_REWRITE_WRITE_COUNT: LogQueueCounterVec = register_static_int_counter_vec!(
-        LogQueueCounterVec,
-        "raft_engine_background_rewrite_write_count",
-        "Total writes during background rewrite",
-        &["type"]
-    )
-    .unwrap();
-    pub static ref BACKGROUND_REWRITE_BYTES: LogQueueCounterVec = register_static_int_counter_vec!(
-        LogQueueCounterVec,
+    pub static ref BACKGROUND_REWRITE_BYTES: LogQueueHistogramVec = register_static_histogram_vec!(
+        LogQueueHistogramVec,
         "raft_engine_background_rewrite_bytes",
-        "Total bytes written during background rewrite",
+        "Bucketed histogram of bytes written during background rewrite",
         &["type"]
     )
     .unwrap();

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -22,7 +22,7 @@ const FORCE_COMPACT_RATIO: f64 = 0.2;
 // Only rewrite region with oldest 70% logs.
 const REWRITE_RATIO: f64 = 0.7;
 // Only rewrite region with stale logs less than this threshold.
-const MAX_REWRITE_ENTRIES_PER_REGION: usize = 32;
+const MAX_REWRITE_ENTRIES_PER_REGION: usize = 64;
 const MAX_REWRITE_BATCH_BYTES: usize = 1024 * 1024;
 
 pub struct PurgeManager<P>
@@ -187,7 +187,6 @@ where
                 let sparse = t.entries_count() < MAX_REWRITE_ENTRIES_PER_REGION;
                 if f < compact_watermark && !sparse {
                     should_compact.push(t.region_id());
-                    return true;
                 } else if f < rewrite_watermark {
                     return sparse;
                 }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -124,10 +124,7 @@ fn test_pipe_log_listeners() {
     engine.purge_expired_files().unwrap();
     assert_eq!(hook.0[&LogQueue::Append].purged(), 8);
 
-    // All things in a region will in one write batch.
-    assert_eq!(hook.0[&LogQueue::Rewrite].files(), 3);
-    assert_eq!(hook.0[&LogQueue::Rewrite].appends(), 2);
-    assert_eq!(hook.0[&LogQueue::Rewrite].applys(), 2);
+    let rewrite_files = hook.0[&LogQueue::Rewrite].files();
 
     // Append 5 logs for region 1, 5 logs for region 2.
     for i in 21..=30 {
@@ -150,7 +147,7 @@ fn test_pipe_log_listeners() {
 
     engine.purge_expired_files().unwrap();
     assert_eq!(hook.0[&LogQueue::Append].purged(), 13);
-    assert_eq!(hook.0[&LogQueue::Rewrite].purged(), 3);
+    assert_eq!(hook.0[&LogQueue::Rewrite].purged(), rewrite_files as u64);
 
     // Write region 3 without applying.
     let apply_memtable_region_3_fp = "memtable_accessor::apply::region_3";


### PR DESCRIPTION
~It's possible that certain raft groups are not compacted due to upper level issues. Those laggers will block the garbage collection progress indefinitely. After this patch, they will be rewritten regardless of the amount of their containing entries.~

Fix three bugs found during stability tests:
- Log entry hole between rewrite files crashed recovery
- Rewrite of a rewritten key could encounter a newer append and causes panic
- Rewrite log batch size exceeds i32::MAX and fails compression