### PR TITLE
Use BTreeMap for memtable put

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 #![feature(shrink_to)]
-#![feature(cell_update)]
+#![feature(map_first_last)]
 #![feature(generic_associated_types)]
 #![feature(test)]
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1708,4 +1708,28 @@ mod tests {
             sequential_global_stats.deleted_rewrite_entries(),
         );
     }
+
+    #[bench]
+    fn bench_memtable_single_put(b: &mut test::Bencher) {
+        let mut memtable = MemTable::new(0, Arc::new(GlobalStats::default()));
+        let key = b"some_key".to_vec();
+        let value = vec![7; 12];
+        b.iter(move || {
+            memtable.put(key.clone(), value.clone(), FileId::dummy(LogQueue::Append));
+        });
+    }
+
+    #[bench]
+    fn bench_memtable_triple_puts(b: &mut test::Bencher) {
+        let mut memtable = MemTable::new(0, Arc::new(GlobalStats::default()));
+        let key0 = b"some_key0".to_vec();
+        let key1 = b"some_key1".to_vec();
+        let key2 = b"some_key2".to_vec();
+        let value = vec![7; 12];
+        b.iter(move || {
+            memtable.put(key0.clone(), value.clone(), FileId::dummy(LogQueue::Append));
+            memtable.put(key1.clone(), value.clone(), FileId::dummy(LogQueue::Append));
+            memtable.put(key2.clone(), value.clone(), FileId::dummy(LogQueue::Append));
+        });
+    }
 }


### PR DESCRIPTION
BTreeMap has better cache locality (and possibly fewer instructions involved) for single key put scenario. Micro benchmarks shows 6% improvement:

```
vanilla:
test memtable::tests::bench_memtable_single_put             ... bench:         101 ns/iter (+/- 39)
test memtable::tests::bench_memtable_single_put             ... bench:          99 ns/iter (+/- 31)
test memtable::tests::bench_memtable_triple_puts            ... bench:         317 ns/iter (+/- 15)
test memtable::tests::bench_memtable_triple_puts            ... bench:         317 ns/iter (+/- 19)

btreemap:
test memtable::tests::bench_memtable_single_put             ... bench:          93 ns/iter (+/- 9)
test memtable::tests::bench_memtable_single_put             ... bench:          94 ns/iter (+/- 13)
test memtable::tests::bench_memtable_triple_puts            ... bench:         311 ns/iter (+/- 56)
test memtable::tests::bench_memtable_triple_puts            ... bench:         313 ns/iter (+/- 41)
```