### PR TITLE
Add a thread local block cache to improve read performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Contributions are always welcome! Here are a few tips for making a PR:
 
 ```
 cargo fmt --all -- --check
-cargo clippy --all --all-features --all-targets -- -D clippy::all
-cargo test --all --features all_except_failpoints
-cargo test --test failpoints --all-features -- --test-threads 1
+cargo +nightly clippy --all --all-features --all-targets -- -D clippy::all
+cargo +nightly test --all --features all_except_failpoints
+cargo +nightly test --test failpoints --all-features -- --test-threads 1
 ```
 
 - For changes that might induce performance effects, please quote the targeted benchmark results in the PR description. In addition to micro-benchmarks, there is a standalone [stress test tool](https://github.com/tikv/raft-engine/tree/master/stress) which you can use to demonstrate the system performance.

--- a/ctl/src/main.rs
+++ b/ctl/src/main.rs
@@ -21,27 +21,26 @@ struct ControlOpt {
 
 #[derive(Debug, Parser)]
 pub enum Cmd {
-    /// dump out all operations in log files
+    /// Dump log entries in data file(s).
     Dump {
-        #[clap(
-            short,
-            long = "path",
-            help = "Path of log file directory or specific log file"
-        )]
+        /// Path of Raft Engine directory or specific log file.
+        #[clap(short, long)]
         path: String,
 
         #[clap(short, long, use_delimiter = true)]
         raft_groups: Vec<u64>,
     },
 
-    /// check log files for logical errors
+    /// Check data files for logical errors.
     Check {
+        /// Path of Raft Engine directory.
         #[clap(short, long)]
         path: String,
     },
 
-    /// run scripts to repair log files
+    /// Run Rhai script to repair data files.
     Repair {
+        /// Path of Raft Engine directory.
         #[clap(short, long)]
         path: String,
 
@@ -52,8 +51,16 @@ pub enum Cmd {
         )]
         queue: String,
 
-        #[clap(short, long, use_delimiter = true, help = "Path of Rhai script file")]
+        /// Path of Rhai script file.
+        #[clap(short, long)]
         script: String,
+    },
+
+    /// Try running `purge_expired_files` on existing data directory.
+    TryPurge {
+        /// Path of Raft Engine directory.
+        #[clap(short, long)]
+        path: String,
     },
 }
 
@@ -101,6 +108,16 @@ impl ControlOpt {
                     println!("Corrupted info are as follows:\nraft_group_id, last_intact_index\n");
                     r.iter().for_each(|(x, y)| println!("{:?}, {:?}", x, y))
                 }
+            }
+            Cmd::TryPurge { path } => {
+                let e = Engine::open(raft_engine::Config {
+                    dir: path,
+                    ..Default::default()
+                })?;
+                println!(
+                    "purge_expired_files() returns {:?}",
+                    e.purge_expired_files()?
+                );
             }
         }
         Ok(())

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1465,7 +1465,7 @@ mod tests {
             dir: dir.path().to_str().unwrap().to_owned(),
             ..Default::default()
         };
-        let engine = RaftLogEngine::open(cfg.clone()).unwrap();
+        let engine = RaftLogEngine::open(cfg).unwrap();
         for i in 0..10 {
             for rid in 1..=100 {
                 engine.append(rid, 1 + i * 10, 1 + i * 10 + 10, Some(&entry_data));

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,5 +1,6 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
+use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
@@ -390,23 +391,77 @@ where
     }
 }
 
-pub(crate) fn read_entry_from_file<M, P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<M::Entry>
+struct BlockCache {
+    key: Cell<FileBlockHandle>,
+    block: RefCell<Vec<u8>>,
+}
+
+impl BlockCache {
+    fn new() -> Self {
+        BlockCache {
+            key: Cell::new(FileBlockHandle {
+                id: FileId::new(LogQueue::Append, 0),
+                offset: 0,
+                len: 0,
+            }),
+            block: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn insert(&self, key: FileBlockHandle, block: Vec<u8>) {
+        self.key.set(key);
+        self.block.replace(block);
+    }
+}
+
+thread_local! {
+    static BLOCK_CACHE: BlockCache = BlockCache::new();
+}
+
+pub(crate) fn read_entry_from_file<M, P>(pipe_log: &P, idx: &EntryIndex) -> Result<M::Entry>
 where
     M: MessageExt,
     P: PipeLog,
 {
-    let buf = pipe_log.read_bytes(ent_idx.entries.unwrap())?;
-    let e = LogBatch::parse_entry::<M>(&buf, ent_idx)?;
-    assert_eq!(M::index(&e), ent_idx.index);
-    Ok(e)
+    BLOCK_CACHE.with(|cache| {
+        if cache.key.get() != idx.entries.unwrap() {
+            cache.insert(
+                idx.entries.unwrap(),
+                LogBatch::decode_entries_block(
+                    &pipe_log.read_bytes(idx.entries.unwrap())?,
+                    idx.entries.unwrap(),
+                    idx.compression_type,
+                )?,
+            );
+        }
+        let e = parse_from_bytes(
+            &cache.block.borrow()
+                [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
+        )?;
+        assert_eq!(M::index(&e), idx.index);
+        Ok(e)
+    })
 }
 
-pub(crate) fn read_entry_bytes_from_file<P>(pipe_log: &P, ent_idx: &EntryIndex) -> Result<Vec<u8>>
+pub(crate) fn read_entry_bytes_from_file<P>(pipe_log: &P, idx: &EntryIndex) -> Result<Vec<u8>>
 where
     P: PipeLog,
 {
-    let entries_buf = pipe_log.read_bytes(ent_idx.entries.unwrap())?;
-    LogBatch::parse_entry_bytes(&entries_buf, ent_idx)
+    BLOCK_CACHE.with(|cache| {
+        if cache.key.get() != idx.entries.unwrap() {
+            cache.insert(
+                idx.entries.unwrap(),
+                LogBatch::decode_entries_block(
+                    &pipe_log.read_bytes(idx.entries.unwrap())?,
+                    idx.entries.unwrap(),
+                    idx.compression_type,
+                )?,
+            );
+        }
+        Ok(cache.block.borrow()
+            [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len]
+            .to_owned())
+    })
 }
 
 #[cfg(test)]
@@ -1394,5 +1449,35 @@ mod tests {
         // Corrupt the file header.
         f.set_len(1).unwrap();
         RaftLogEngine::open_with_file_system(cfg, Arc::new(ObfuscatedFileSystem::new())).unwrap();
+    }
+
+    #[cfg(feature = "nightly")]
+    #[bench]
+    fn bench_engine_fetch_entries(b: &mut test::Bencher) {
+        use rand::{thread_rng, Rng};
+
+        let dir = tempfile::Builder::new()
+            .prefix("bench_engine_fetch_entries")
+            .tempdir()
+            .unwrap();
+        let entry_data = vec![b'x'; 1024];
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            ..Default::default()
+        };
+        let engine = RaftLogEngine::open(cfg.clone()).unwrap();
+        for i in 0..10 {
+            for rid in 1..=100 {
+                engine.append(rid, 1 + i * 10, 1 + i * 10 + 10, Some(&entry_data));
+            }
+        }
+        let mut vec: Vec<Entry> = Vec::new();
+        b.iter(move || {
+            let region_id = thread_rng().gen_range(1..=100);
+            engine
+                .fetch_entries_to::<Entry>(region_id, 1, 101, None, &mut vec)
+                .unwrap();
+            vec.clear();
+        });
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -283,7 +283,16 @@ impl RhaiFilterMachine {
                             let mut entries = Vec::with_capacity(eis.len());
                             for ei in &eis {
                                 let entries_buf = reader.read(ei.entries.unwrap())?;
-                                entries.push(LogBatch::parse_entry_bytes(&entries_buf, ei)?);
+                                let block = LogBatch::decode_entries_block(
+                                    &entries_buf,
+                                    ei.entries.unwrap(),
+                                    ei.compression_type,
+                                )?;
+                                entries.push(
+                                    block[ei.entry_offset as usize
+                                        ..ei.entry_offset as usize + ei.entry_len]
+                                        .to_owned(),
+                                );
                             }
                             log_batch.add_raw_entries(item.raft_group_id, eis, entries)?;
                         }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -6,7 +6,6 @@ use std::{mem, u64};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use log::error;
-use protobuf::parse_from_bytes;
 use protobuf::Message;
 
 use crate::codec::{self, NumberEncoder};
@@ -472,6 +471,8 @@ impl LogItemBatch {
         Ok(())
     }
 
+    /// Decodes a `LogItemBatch` from bytes of footer. `entries` is the block
+    /// location of encoded entries.
     pub fn decode(
         buf: &mut SliceReader,
         entries: FileBlockHandle,
@@ -797,45 +798,24 @@ impl LogBatch {
         Ok((offset, compression_type, len >> 8))
     }
 
-    /// Decodes a specific log entry from the bytes of a group of entries.
-    /// Assumes the specified entry belongs to the group.
-    pub(crate) fn parse_entry<M: MessageExt>(buf: &[u8], idx: &EntryIndex) -> Result<M::Entry> {
-        let len = idx.entries.unwrap().len;
-        if len > 0 {
-            // protobuf message can be serialized to empty string.
-            verify_checksum(&buf[0..len])?;
-        }
-        match idx.compression_type {
-            CompressionType::None => Ok(parse_from_bytes(
-                &buf[idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
-            )?),
-            CompressionType::Lz4 => {
-                let decompressed = lz4::decompress_block(&buf[..len - LOG_BATCH_CHECKSUM_LEN])?;
-                Ok(parse_from_bytes(
-                    &decompressed
-                        [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
-                )?)
+    /// Unfolds bytes of multiple user entries from an encoded block.
+    pub(crate) fn decode_entries_block(
+        buf: &[u8],
+        handle: FileBlockHandle,
+        compression: CompressionType,
+    ) -> Result<Vec<u8>> {
+        if handle.len > 0 {
+            verify_checksum(&buf[0..handle.len])?;
+            match compression {
+                CompressionType::None => Ok(buf[..handle.len - LOG_BATCH_CHECKSUM_LEN].to_owned()),
+                CompressionType::Lz4 => {
+                    let decompressed =
+                        lz4::decompress_block(&buf[..handle.len - LOG_BATCH_CHECKSUM_LEN])?;
+                    Ok(decompressed)
+                }
             }
-        }
-    }
-
-    /// Decodes the bytes of a specific log entry from the bytes of a group of
-    /// entries. Assumes the specified entry belongs to the group.
-    pub(crate) fn parse_entry_bytes(buf: &[u8], idx: &EntryIndex) -> Result<Vec<u8>> {
-        let len = idx.entries.unwrap().len;
-        if len > 0 {
-            verify_checksum(&buf[0..len])?;
-        }
-        match idx.compression_type {
-            CompressionType::None => Ok(buf
-                [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len]
-                .to_owned()),
-            CompressionType::Lz4 => {
-                let decompressed = lz4::decompress_block(&buf[..len - LOG_BATCH_CHECKSUM_LEN])?;
-                Ok(decompressed
-                    [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len]
-                    .to_owned())
-            }
+        } else {
+            Ok(Vec::new())
         }
     }
 }
@@ -865,6 +845,7 @@ mod tests {
     use super::*;
     use crate::pipe_log::LogQueue;
     use crate::test_util::{catch_unwind_silent, generate_entries, generate_entry_indexes_opt};
+    use protobuf::parse_from_bytes;
     use raft::eraftpb::Entry;
 
     fn decode_entries_from_bytes<M: MessageExt>(
@@ -874,7 +855,16 @@ mod tests {
     ) -> Vec<M::Entry> {
         let mut entries = Vec::with_capacity(entry_indexes.len());
         for ei in entry_indexes {
-            entries.push(LogBatch::parse_entry::<M>(buf, ei).unwrap());
+            println!("{:?}", ei);
+            let block =
+                LogBatch::decode_entries_block(buf, ei.entries.unwrap(), ei.compression_type)
+                    .unwrap();
+            entries.push(
+                parse_from_bytes(
+                    &block[ei.entry_offset as usize..ei.entry_offset as usize + ei.entry_len],
+                )
+                .unwrap(),
+            );
         }
         entries
     }
@@ -1182,7 +1172,11 @@ mod tests {
         assert_eq!(encoded.len(), len);
         let decoded_item_batch = LogItemBatch::decode(
             &mut &encoded[offset..],
-            FileBlockHandle::dummy(LogQueue::Append),
+            FileBlockHandle {
+                id: FileId::dummy(LogQueue::Append),
+                offset: 0,
+                len: offset - LOG_BATCH_HEADER_LEN,
+            },
             compression_type,
         )
         .unwrap();

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -855,7 +855,6 @@ mod tests {
     ) -> Vec<M::Entry> {
         let mut entries = Vec::with_capacity(entry_indexes.len());
         for ei in entry_indexes {
-            println!("{:?}", ei);
             let block =
                 LogBatch::decode_entries_block(buf, ei.entries.unwrap(), ei.compression_type)
                     .unwrap();

--- a/tests/benches/bench_recovery.rs
+++ b/tests/benches/bench_recovery.rs
@@ -154,10 +154,10 @@ fn bench_recovery(c: &mut Criterion) {
         println!("config-{}: [{}] {}", i, name, cfg);
     }
 
+    fail::cfg("log_fd::open::fadvise_dontneed", "return").unwrap();
     for (i, (name, cfg)) in cfgs.iter().enumerate() {
         let dir = generate(cfg).unwrap();
         let path = dir.path().to_str().unwrap().to_owned();
-        fail::cfg("log_fd::open::fadvise_dontneed", "return").unwrap();
         let ecfg = EngineConfig {
             dir: path.clone(),
             batch_compression_threshold: cfg.batch_compression_threshold,
@@ -176,6 +176,7 @@ fn bench_recovery(c: &mut Criterion) {
             },
         );
     }
+    fail::remove("log_fd::open::fadvise_dontneed");
 }
 
 criterion_group! {


### PR DESCRIPTION
Micro-benchmark of fetching 100 entries from page cache:
```
Without block cache:
test engine::tests::bench_engine_fetch_entries              ... bench:     215,308 ns/iter (+/- 20,738)
test engine::tests::bench_engine_fetch_entries              ... bench:     215,171 ns/iter (+/- 25,321)

With block cache:
test engine::tests::bench_engine_fetch_entries              ... bench:      57,549 ns/iter (+/- 5,163)
test engine::tests::bench_engine_fetch_entries              ... bench:      54,762 ns/iter (+/- 4,250)
```