### PR TITLE
reseek after truncating log file

### DIFF
--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -242,15 +242,17 @@ impl Seek for LogFile {
 }
 
 impl WriteExt for LogFile {
-    fn truncate(&self, offset: usize) -> IoResult<()> {
-        self.inner.truncate(offset)
+    fn truncate(&mut self, offset: usize) -> IoResult<()> {
+        self.inner.truncate(offset)?;
+        self.offset = offset;
+        Ok(())
     }
 
-    fn sync(&self) -> IoResult<()> {
+    fn sync(&mut self) -> IoResult<()> {
         self.inner.sync()
     }
 
-    fn allocate(&self, offset: usize, size: usize) -> IoResult<()> {
+    fn allocate(&mut self, offset: usize, size: usize) -> IoResult<()> {
         self.inner.allocate(offset, size)
     }
 }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -31,7 +31,7 @@ pub trait Handle {
 
 /// WriteExt is writer extension api
 pub trait WriteExt {
-    fn truncate(&self, offset: usize) -> Result<()>;
-    fn sync(&self) -> Result<()>;
-    fn allocate(&self, offset: usize, size: usize) -> Result<()>;
+    fn truncate(&mut self, offset: usize) -> Result<()>;
+    fn sync(&mut self) -> Result<()>;
+    fn allocate(&mut self, offset: usize, size: usize) -> Result<()>;
 }

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -52,15 +52,15 @@ impl Seek for ObfuscatedWriter {
 }
 
 impl WriteExt for ObfuscatedWriter {
-    fn truncate(&self, offset: usize) -> IoResult<()> {
+    fn truncate(&mut self, offset: usize) -> IoResult<()> {
         self.0.truncate(offset)
     }
 
-    fn sync(&self) -> IoResult<()> {
+    fn sync(&mut self) -> IoResult<()> {
         self.0.sync()
     }
 
-    fn allocate(&self, offset: usize, size: usize) -> IoResult<()> {
+    fn allocate(&mut self, offset: usize, size: usize) -> IoResult<()> {
         self.0.allocate(offset, size)
     }
 }


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Previously `truncate` a written part will not reseek the file cursor. This could leave holes in log files.

This case is now captured by failpoint tests. It wasn't covered before because all writes were done atomically, there's no chance to truncate a written part.

Also make the recovery process more robust. If the data is opened with the wrong file system, log files won't be mistakenly deleted.