### PR TITLE
Reduce size of `EntryIndex`

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -537,6 +537,7 @@ mod tests {
                 &mut entries,
             )
             .unwrap();
+            assert_eq!(entries.len(), (end - start) as usize);
             assert_eq!(entries.first().unwrap().index, start);
             assert_eq!(
                 entries.last().unwrap().index,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -436,7 +436,7 @@ where
         }
         let e = parse_from_bytes(
             &cache.block.borrow()
-                [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len],
+                [idx.entry_offset as usize..(idx.entry_offset + idx.entry_len) as usize],
         )?;
         assert_eq!(M::index(&e), idx.index);
         Ok(e)
@@ -459,7 +459,7 @@ where
             );
         }
         Ok(cache.block.borrow()
-            [idx.entry_offset as usize..idx.entry_offset as usize + idx.entry_len]
+            [idx.entry_offset as usize..(idx.entry_offset + idx.entry_len) as usize]
             .to_owned())
     })
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,6 +23,8 @@ pub enum Error {
     EntryCompacted,
     #[error("Entry Not Found")]
     EntryNotFound,
+    #[error("Full")]
+    Full,
     #[error("Other Error: {0}")]
     Other(#[from] Box<dyn error::Error + Send + Sync>),
 }

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -136,7 +136,7 @@ impl<F: FileSystem> LogFileReader<F> {
     }
 
     pub fn read(&mut self, handle: FileBlockHandle) -> Result<Vec<u8>> {
-        let mut buf = vec![0; handle.len];
+        let mut buf = vec![0; handle.len as usize];
         let size = self.read_to(handle.offset, &mut buf)?;
         buf.truncate(size);
         Ok(buf)

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -290,7 +290,7 @@ impl RhaiFilterMachine {
                                 )?;
                                 entries.push(
                                     block[ei.entry_offset as usize
-                                        ..ei.entry_offset as usize + ei.entry_len]
+                                        ..(ei.entry_offset + ei.entry_len) as usize]
                                         .to_owned(),
                                 );
                             }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -68,7 +68,7 @@ type SliceReader<'a> = &'a [u8];
 pub struct EntryIndexes(pub Vec<EntryIndex>);
 
 impl EntryIndexes {
-    pub fn decode(buf: &mut SliceReader, entries_size: &mut usize) -> Result<Self> {
+    pub fn decode(buf: &mut SliceReader, entries_size: &mut u32) -> Result<Self> {
         let mut count = codec::decode_var_u64(buf)?;
         let mut entry_indexes = Vec::with_capacity(count as usize);
         let mut index = 0;
@@ -77,10 +77,10 @@ impl EntryIndexes {
         }
         while count > 0 {
             let t = codec::decode_var_u64(buf)?;
-            let entry_len = (t as usize) - *entries_size;
+            let entry_len = (t as u32) - *entries_size;
             let entry_index = EntryIndex {
                 index,
-                entry_offset: *entries_size as u64,
+                entry_offset: *entries_size as u32,
                 entry_len,
                 ..Default::default()
             };
@@ -99,7 +99,7 @@ impl EntryIndexes {
             buf.encode_var_u64(self.0[0].index)?;
         }
         for ei in self.0.iter() {
-            buf.encode_var_u64(ei.entry_offset + ei.entry_len as u64)?;
+            buf.encode_var_u64((ei.entry_offset + ei.entry_len) as u64)?;
         }
         Ok(())
     }
@@ -294,7 +294,7 @@ impl LogItem {
         Ok(())
     }
 
-    pub fn decode(buf: &mut SliceReader, entries_size: &mut usize) -> Result<LogItem> {
+    pub fn decode(buf: &mut SliceReader, entries_size: &mut u32) -> Result<LogItem> {
         let raft_group_id = codec::decode_var_u64(buf)?;
         let item_type = buf.read_u8()?;
         let content = match item_type {
@@ -343,7 +343,7 @@ pub(crate) type LogItemDrain<'a> = std::vec::Drain<'a, LogItem>;
 pub struct LogItemBatch {
     items: Vec<LogItem>,
     item_size: usize,
-    entries_size: usize,
+    entries_size: u32,
 }
 
 impl Default for LogItemBatch {
@@ -385,7 +385,7 @@ impl LogItemBatch {
         for item in &mut rhs.items {
             if let LogItemContent::EntryIndexes(entry_indexes) = &mut item.content {
                 for ei in entry_indexes.0.iter_mut() {
-                    ei.entry_offset += self.entries_size as u64;
+                    ei.entry_offset += self.entries_size;
                 }
             }
         }
@@ -428,7 +428,7 @@ impl LogItemBatch {
 
     pub fn add_entry_indexes(&mut self, region_id: u64, mut entry_indexes: Vec<EntryIndex>) {
         for ei in entry_indexes.iter_mut() {
-            ei.entry_offset = self.entries_size as u64;
+            ei.entry_offset = self.entries_size;
             self.entries_size += ei.entry_len;
         }
         let item = LogItem::new_entry_indexes(region_id, entry_indexes);
@@ -527,13 +527,19 @@ enum BufState {
 }
 
 /// A batch of log items.
-// Format:
-// header = { u56 len | u8 compression type | u64 item offset }
-// entries = { [entry..] (optionally compressed) | crc32 }
-// footer = { item batch }
-//
-// Call member function in this order:
-// (add log items) -> finish_populate -> encoded_bytes / finish_write
+///
+/// Encoding format:
+/// - header = { u56 len | u8 compression type | u64 item offset }
+/// - entries = { [entry..] (optionally compressed) | crc32 }
+/// - footer = { item batch }
+///
+/// Size restriction:
+/// - The total size of log entries must not exceed 2GiB.
+///
+/// Error will be raised if a to-be-added log item cannot fit within those
+/// limits.
+// Calling protocol:
+// Insert log items -> [`finish_populate`] -> [`finish_write`]
 #[derive(Clone)]
 pub struct LogBatch {
     item_batch: LogItemBatch,
@@ -561,10 +567,12 @@ impl LogBatch {
     }
 
     /// Moves all log items of `rhs` into `Self`, leaving `rhs` empty.
-    pub fn merge(&mut self, rhs: &mut Self) {
+    pub fn merge(&mut self, rhs: &mut Self) -> Result<()> {
         debug_assert!(self.buf_state == BufState::Open && rhs.buf_state == BufState::Open);
-
         if !rhs.buf.is_empty() {
+            if rhs.buf.len() + self.buf.len() - LOG_BATCH_HEADER_LEN > i32::MAX as usize {
+                return Err(Error::Full);
+            }
             self.buf_state = BufState::Incomplete;
             rhs.buf_state = BufState::Incomplete;
             self.buf.extend_from_slice(&rhs.buf[LOG_BATCH_HEADER_LEN..]);
@@ -574,6 +582,7 @@ impl LogBatch {
             rhs.buf_state = BufState::Open;
         }
         self.item_batch.merge(&mut rhs.item_batch);
+        Ok(())
     }
 
     /// Adds some protobuf log entries into the log batch.
@@ -586,17 +595,23 @@ impl LogBatch {
 
         let mut entry_indexes = Vec::with_capacity(entries.len());
         self.buf_state = BufState::Incomplete;
+        let old_buf_len = self.buf.len();
         for e in entries {
             let buf_offset = self.buf.len();
             e.write_to_vec(&mut self.buf)?;
+            if self.buf.len() > i32::MAX as usize {
+                self.buf.truncate(old_buf_len);
+                self.buf_state = BufState::Open;
+                return Err(Error::Full);
+            }
             entry_indexes.push(EntryIndex {
                 index: M::index(e),
-                entry_len: self.buf.len() - buf_offset,
+                entry_len: (self.buf.len() - buf_offset) as u32,
                 ..Default::default()
             });
         }
-        self.buf_state = BufState::Open;
         self.item_batch.add_entry_indexes(region_id, entry_indexes);
+        self.buf_state = BufState::Open;
         Ok(())
     }
 
@@ -613,10 +628,16 @@ impl LogBatch {
         debug_assert!(self.buf_state == BufState::Open);
 
         self.buf_state = BufState::Incomplete;
+        let old_buf_len = self.buf.len();
         for (ei, e) in entry_indexes.iter_mut().zip(entries.iter()) {
+            if e.len() + self.buf.len() > i32::MAX as usize {
+                self.buf.truncate(old_buf_len);
+                self.buf_state = BufState::Open;
+                return Err(Error::Full);
+            }
             let buf_offset = self.buf.len();
             self.buf.extend(e);
-            ei.entry_len = self.buf.len() - buf_offset;
+            ei.entry_len = (self.buf.len() - buf_offset) as u32;
         }
         self.buf_state = BufState::Open;
         self.item_batch.add_entry_indexes(region_id, entry_indexes);
@@ -731,7 +752,7 @@ impl LogBatch {
             handle.offset += LOG_BATCH_HEADER_LEN as u64;
             match self.buf_state {
                 BufState::Sealed(_, entries_len) => {
-                    debug_assert!(LOG_BATCH_HEADER_LEN + entries_len < handle.len);
+                    debug_assert!(LOG_BATCH_HEADER_LEN + entries_len < handle.len as usize);
                     handle.len = entries_len;
                 }
                 _ => unreachable!(),
@@ -750,7 +771,8 @@ impl LogBatch {
         self.item_batch.drain()
     }
 
-    /// Returns approximate encoded size of this log batch.
+    /// Returns approximate encoded size of this log batch. Might be larger
+    /// than the actual size.
     pub fn approximate_size(&self) -> usize {
         if self.is_empty() {
             0
@@ -860,7 +882,7 @@ mod tests {
                     .unwrap();
             entries.push(
                 parse_from_bytes(
-                    &block[ei.entry_offset as usize..ei.entry_offset as usize + ei.entry_len],
+                    &block[ei.entry_offset as usize..(ei.entry_offset + ei.entry_len) as usize],
                 )
                 .unwrap(),
             );
@@ -873,7 +895,7 @@ mod tests {
         fn encode_and_decode(entry_indexes: &mut Vec<EntryIndex>) -> EntryIndexes {
             let mut entries_size = 0;
             for idx in entry_indexes.iter_mut() {
-                idx.entry_offset = entries_size as u64;
+                idx.entry_offset = entries_size;
                 entries_size += idx.entry_len;
             }
             let entry_indexes = EntryIndexes(entry_indexes.clone());
@@ -973,7 +995,7 @@ mod tests {
             let mut entries_size = 0;
             if let LogItemContent::EntryIndexes(EntryIndexes(indexes)) = &mut item.content {
                 for index in indexes.iter_mut() {
-                    index.entry_offset = entries_size as u64;
+                    index.entry_offset = entries_size;
                     entries_size += index.entry_len;
                 }
             }
@@ -1159,7 +1181,7 @@ mod tests {
             kvs.push((k, v));
         }
 
-        batch1.merge(&mut batch2);
+        batch1.merge(&mut batch2).unwrap();
         assert!(batch2.is_empty());
 
         let len = batch1.finish_populate(0).unwrap();

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -584,10 +584,10 @@ impl LogBatch {
             self.buf.extend_from_slice(&rhs.buf[LOG_BATCH_HEADER_LEN..]);
             rhs.buf.shrink_to(MAX_LOG_BATCH_BUFFER_CAP);
             rhs.buf.truncate(LOG_BATCH_HEADER_LEN);
-            self.buf_state = BufState::Open;
-            rhs.buf_state = BufState::Open;
         }
         self.item_batch.merge(&mut rhs.item_batch);
+        self.buf_state = BufState::Open;
+        rhs.buf_state = BufState::Open;
         Ok(())
     }
 
@@ -653,8 +653,8 @@ impl LogBatch {
             self.buf.extend(e);
             ei.entry_len = (self.buf.len() - buf_offset) as u32;
         }
-        self.buf_state = BufState::Open;
         self.item_batch.add_entry_indexes(region_id, entry_indexes);
+        self.buf_state = BufState::Open;
         Ok(())
     }
 

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -570,7 +570,7 @@ impl LogBatch {
     pub fn merge(&mut self, rhs: &mut Self) -> Result<()> {
         debug_assert!(self.buf_state == BufState::Open && rhs.buf_state == BufState::Open);
         if !rhs.buf.is_empty() {
-            if rhs.buf.len() + self.buf.len() - LOG_BATCH_HEADER_LEN > i32::MAX as usize {
+            if rhs.buf.len() + self.buf.len() > i32::MAX as usize + LOG_BATCH_HEADER_LEN * 2 {
                 return Err(Error::Full);
             }
             self.buf_state = BufState::Incomplete;
@@ -599,7 +599,7 @@ impl LogBatch {
         for e in entries {
             let buf_offset = self.buf.len();
             e.write_to_vec(&mut self.buf)?;
-            if self.buf.len() > i32::MAX as usize {
+            if self.buf.len() > i32::MAX as usize + LOG_BATCH_HEADER_LEN {
                 self.buf.truncate(old_buf_len);
                 self.buf_state = BufState::Open;
                 return Err(Error::Full);
@@ -630,7 +630,7 @@ impl LogBatch {
         self.buf_state = BufState::Incomplete;
         let old_buf_len = self.buf.len();
         for (ei, e) in entry_indexes.iter_mut().zip(entries.iter()) {
-            if e.len() + self.buf.len() > i32::MAX as usize {
+            if e.len() + self.buf.len() > i32::MAX as usize + LOG_BATCH_HEADER_LEN {
                 self.buf.truncate(old_buf_len);
                 self.buf_state = BufState::Open;
                 return Err(Error::Full);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -53,6 +53,59 @@ impl Default for EntryIndex {
     }
 }
 
+impl EntryIndex {
+    fn from_thin(index: u64, e: ThinEntryIndex) -> Self {
+        Self {
+            index,
+            entries: e.entries,
+            compression_type: e.compression_type,
+            entry_offset: e.entry_offset,
+            entry_len: e.entry_len,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+struct ThinEntryIndex {
+    entries: Option<FileBlockHandle>,
+    compression_type: CompressionType,
+    entry_offset: u32,
+    entry_len: u32,
+}
+
+impl Default for ThinEntryIndex {
+    fn default() -> ThinEntryIndex {
+        ThinEntryIndex {
+            entries: None,
+            compression_type: CompressionType::None,
+            entry_offset: 0,
+            entry_len: 0,
+        }
+    }
+}
+
+impl From<EntryIndex> for ThinEntryIndex {
+    fn from(e: EntryIndex) -> Self {
+        Self {
+            entries: e.entries,
+            compression_type: e.compression_type,
+            entry_offset: e.entry_offset,
+            entry_len: e.entry_len,
+        }
+    }
+}
+
+impl From<&EntryIndex> for ThinEntryIndex {
+    fn from(e: &EntryIndex) -> Self {
+        Self {
+            entries: e.entries,
+            compression_type: e.compression_type,
+            entry_offset: e.entry_offset,
+            entry_len: e.entry_len,
+        }
+    }
+}
+
 /// In-memory storage for Raft Groups.
 ///
 /// Each Raft Group has its own `MemTable` to store all key value pairs and the
@@ -63,7 +116,9 @@ pub struct MemTable {
 
     /// Container of entries. Incoming entries are pushed to the back with
     /// ascending log indexes.
-    entry_indexes: VecDeque<EntryIndex>,
+    entry_indexes: VecDeque<ThinEntryIndex>,
+    /// The log index of the first entry.
+    first_index: u64,
     /// The amount of rewritten entries. Rewritten entries are the oldest
     /// entries and stored at the front of the container.
     rewrite_count: usize,
@@ -80,6 +135,7 @@ impl MemTable {
         MemTable {
             region_id,
             entry_indexes: VecDeque::with_capacity(SHRINK_CAPACITY_TARGET),
+            first_index: 0,
             rewrite_count: 0,
             kvs: BTreeMap::default(),
             global_stats,
@@ -211,7 +267,7 @@ impl MemTable {
 
             let ioffset = (index - first) as usize;
             let entry_index = self.entry_indexes[ioffset];
-            Some(entry_index)
+            Some(EntryIndex::from_thin(index, entry_index))
         } else {
             None
         }
@@ -237,8 +293,9 @@ impl MemTable {
                 false, /* allow_overwrite */
             );
             self.global_stats.add(LogQueue::Append, len);
-            // TODO: Optimize this.
-            self.entry_indexes.extend(entry_indexes);
+            for ei in entry_indexes.into_iter() {
+                self.entry_indexes.push_back(ei.into());
+            }
         }
     }
 
@@ -260,7 +317,9 @@ impl MemTable {
                 true, /* allow_overwrite */
             );
             self.global_stats.add(LogQueue::Rewrite, len);
-            self.entry_indexes.extend(entry_indexes);
+            for ei in entry_indexes.into_iter() {
+                self.entry_indexes.push_back(ei.into());
+            }
             self.rewrite_count = self.entry_indexes.len();
         }
     }
@@ -288,8 +347,8 @@ impl MemTable {
             return;
         }
 
-        let first = self.entry_indexes[0].index;
-        let last = self.entry_indexes[len - 1].index;
+        let first = self.first_index;
+        let last = self.first_index + len as u64 - 1;
         let rewrite_first = std::cmp::max(rewrite_indexes[0].index, first);
         let rewrite_last = std::cmp::min(rewrite_indexes[rewrite_indexes.len() - 1].index, last);
         let mut rewrite_len = (rewrite_last + 1).saturating_sub(rewrite_first) as usize;
@@ -324,7 +383,7 @@ impl MemTable {
                 break;
             }
 
-            *index = *rindex;
+            *index = rindex.into();
         }
 
         if gate.is_none() {
@@ -345,7 +404,7 @@ impl MemTable {
         if self.entry_indexes.is_empty() {
             return 0;
         }
-        let first = self.entry_indexes[0].index;
+        let first = self.first_index;
         if index <= first {
             return 0;
         }
@@ -455,11 +514,11 @@ impl MemTable {
         if len == 0 {
             return Err(Error::EntryNotFound);
         }
-        let first = self.entry_indexes[0].index;
+        let first = self.first_index;
         if begin < first {
             return Err(Error::EntryCompacted);
         }
-        let last = self.entry_indexes[len - 1].index;
+        let last = self.first_index + len as u64 - 1;
         if end > last + 1 {
             return Err(Error::EntryNotFound);
         }
@@ -468,19 +527,18 @@ impl MemTable {
         let end_pos = (end - begin) as usize + start_pos;
 
         let (first, second) = slices_in_range(&self.entry_indexes, start_pos, end_pos);
-        if let Some(max_size) = max_size {
-            let mut total_size = 0;
-            for idx in first.iter().chain(second) {
-                total_size += idx.entry_len;
-                // No matter max_size's value, fetch one entry at least.
+        let mut total_size = 0;
+        let mut index = begin;
+        for idx in first.iter().chain(second) {
+            total_size += idx.entry_len;
+            // No matter max_size's value, fetch one entry at least.
+            if let Some(max_size) = max_size {
                 if total_size as usize > max_size && total_size > idx.entry_len {
                     break;
                 }
-                vec_idx.push(*idx);
             }
-        } else {
-            vec_idx.extend_from_slice(first);
-            vec_idx.extend_from_slice(second);
+            vec_idx.push(EntryIndex::from_thin(index, *idx));
+            index += 1;
         }
         Ok(())
     }
@@ -492,18 +550,31 @@ impl MemTable {
         gate: FileSeq,
         vec_idx: &mut Vec<EntryIndex>,
     ) -> Result<()> {
-        let begin = self
-            .entry_indexes
-            .iter()
-            .find(|e| e.entries.unwrap().id.queue == LogQueue::Append);
-        let end = self
-            .entry_indexes
-            .iter()
-            .rev()
-            .find(|e| e.entries.unwrap().id.seq <= gate);
-        if let (Some(begin), Some(end)) = (begin, end) {
-            if begin.index <= end.index {
-                return self.fetch_entries_to(begin.index, end.index + 1, None, vec_idx);
+        if let Some((first, last)) = self.span() {
+            let mut index = first;
+            let mut front = None;
+            for ei in &self.entry_indexes {
+                if ei.entries.unwrap().id.queue == LogQueue::Append {
+                    front = Some(index);
+                    break;
+                }
+                index += 1;
+            }
+            let mut back = None;
+            if front.is_some() {
+                index = last;
+                for ei in self.entry_indexes.iter().rev() {
+                    if ei.entries.unwrap().id.seq <= gate {
+                        back = Some(index);
+                        break;
+                    }
+                    index -= 1;
+                }
+            };
+            if let (Some(front), Some(back)) = (front, back) {
+                if front <= back {
+                    return self.fetch_entries_to(front, back + 1, None, vec_idx);
+                }
             }
         }
         Ok(())
@@ -512,8 +583,8 @@ impl MemTable {
     /// Pulls all rewrite entries to the provided buffer.
     pub fn fetch_rewritten_entry_indexes(&self, vec_idx: &mut Vec<EntryIndex>) -> Result<()> {
         if self.rewrite_count > 0 {
-            let first = self.entry_indexes[0].index;
-            let end = self.entry_indexes[self.rewrite_count - 1].index + 1;
+            let first = self.first_index;
+            let end = self.first_index + self.rewrite_count as u64 - 1;
             self.fetch_entries_to(first, end, None, vec_idx)
         } else {
             Ok(())
@@ -590,12 +661,12 @@ impl MemTable {
 
     /// Returns the log index of the first log entry.
     pub fn first_index(&self) -> Option<u64> {
-        self.entry_indexes.front().map(|e| e.index)
+        self.span().map(|s| s.0)
     }
 
     /// Returns the log index of the last log entry.
     pub fn last_index(&self) -> Option<u64> {
-        self.entry_indexes.back().map(|e| e.index)
+        self.span().map(|s| s.1)
     }
 
     /// Returns the first and last log index of the entries in this table.
@@ -603,10 +674,7 @@ impl MemTable {
     fn span(&self) -> Option<(u64, u64)> {
         let len = self.entry_indexes.len();
         if len > 0 {
-            Some((
-                self.entry_indexes[0].index,
-                self.entry_indexes[len - 1].index,
-            ))
+            Some((self.first_index, self.first_index + len as u64 - 1))
         } else {
             None
         }
@@ -615,13 +683,13 @@ impl MemTable {
     #[cfg(test)]
     fn consistency_check(&self) {
         let mut seen_append = false;
-        let mut last_index = None;
+        // let mut last_index = None;
         for idx in self.entry_indexes.iter() {
             // Check 1: indexes are contiguous.
-            if let Some(last_index) = last_index {
-                assert_eq!(idx.index, last_index + 1);
-            }
-            last_index = Some(idx.index);
+            // if let Some(last_index) = last_index {
+            //     assert_eq!(idx.index, last_index + 1);
+            // }
+            // last_index = Some(idx.index);
             // Check 2: rewrites are at the front.
             let queue = idx.entries.unwrap().id.queue;
             if queue == LogQueue::Append {
@@ -1015,13 +1083,10 @@ mod tests {
         }
 
         pub fn fetch_all(&self, vec_idx: &mut Vec<EntryIndex>) {
-            if self.entry_indexes.is_empty() {
-                return;
+            if let Some((first, last)) = self.span() {
+                self.fetch_entries_to(first, last + 1, None, vec_idx)
+                    .unwrap();
             }
-
-            let begin = self.entry_indexes.front().unwrap().index;
-            let end = self.entry_indexes.back().unwrap().index + 1;
-            self.fetch_entries_to(begin, end, None, vec_idx).unwrap();
         }
 
         fn entries_size(&self) -> usize {
@@ -2036,6 +2101,6 @@ mod tests {
     #[test]
     fn test_entry_index_size() {
         println!("{}", std::mem::size_of::<FileBlockHandle>());
-        println!("{}", std::mem::size_of::<EntryIndex>());
+        println!("{}", std::mem::size_of::<ThinEntryIndex>());
     }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -72,17 +72,6 @@ struct ThinEntryIndex {
     entry_len: u32,
 }
 
-impl Default for ThinEntryIndex {
-    fn default() -> ThinEntryIndex {
-        ThinEntryIndex {
-            entries: None,
-            compression_type: CompressionType::None,
-            entry_offset: 0,
-            entry_len: 0,
-        }
-    }
-}
-
 impl From<&EntryIndex> for ThinEntryIndex {
     fn from(e: &EntryIndex) -> Self {
         Self {
@@ -657,14 +646,8 @@ impl MemTable {
     #[cfg(test)]
     fn consistency_check(&self) {
         let mut seen_append = false;
-        // let mut last_index = None;
         for idx in self.entry_indexes.iter() {
-            // Check 1: indexes are contiguous.
-            // if let Some(last_index) = last_index {
-            //     assert_eq!(idx.index, last_index + 1);
-            // }
-            // last_index = Some(idx.index);
-            // Check 2: rewrites are at the front.
+            // rewrites are at the front.
             let queue = idx.entries.unwrap().id.queue;
             if queue == LogQueue::Append {
                 seen_append = true;

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -83,17 +83,6 @@ impl Default for ThinEntryIndex {
     }
 }
 
-impl From<EntryIndex> for ThinEntryIndex {
-    fn from(e: EntryIndex) -> Self {
-        Self {
-            entries: e.entries,
-            compression_type: e.compression_type,
-            entry_offset: e.entry_offset,
-            entry_len: e.entry_len,
-        }
-    }
-}
-
 impl From<&EntryIndex> for ThinEntryIndex {
     fn from(e: &EntryIndex) -> Self {
         Self {
@@ -292,7 +281,7 @@ impl MemTable {
                 false, /* allow_overwrite */
             );
             self.global_stats.add(LogQueue::Append, len);
-            for ei in entry_indexes.into_iter() {
+            for ei in &entry_indexes {
                 self.entry_indexes.push_back(ei.into());
             }
         }
@@ -316,7 +305,7 @@ impl MemTable {
                 true, /* allow_overwrite */
             );
             self.global_stats.add(LogQueue::Rewrite, len);
-            for ei in entry_indexes.into_iter() {
+            for ei in &entry_indexes {
                 self.entry_indexes.push_back(ei.into());
             }
             self.rewrite_count = self.entry_indexes.len();
@@ -2081,11 +2070,5 @@ mod tests {
             memtable.put(key1.clone(), value.clone(), FileId::dummy(LogQueue::Append));
             memtable.put(key2.clone(), value.clone(), FileId::dummy(LogQueue::Append));
         });
-    }
-
-    #[test]
-    fn test_entry_index_size() {
-        println!("{}", std::mem::size_of::<FileBlockHandle>());
-        println!("{}", std::mem::size_of::<ThinEntryIndex>());
     }
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -36,9 +36,9 @@ pub struct EntryIndex {
     pub compression_type: CompressionType,
 
     /// The relative offset within its group of entries.
-    pub entry_offset: u64,
+    pub entry_offset: u32,
     /// The encoded length within its group of entries.
-    pub entry_len: usize,
+    pub entry_len: u32,
 }
 
 impl Default for EntryIndex {
@@ -2031,5 +2031,11 @@ mod tests {
             memtable.put(key1.clone(), value.clone(), FileId::dummy(LogQueue::Append));
             memtable.put(key2.clone(), value.clone(), FileId::dummy(LogQueue::Append));
         });
+    }
+
+    #[test]
+    fn test_entry_index_size() {
+        println!("{}", std::mem::size_of::<FileBlockHandle>());
+        println!("{}", std::mem::size_of::<EntryIndex>());
     }
 }

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -7,6 +7,7 @@ use std::cmp::Ordering;
 use crate::Result;
 
 /// The type of log queue.
+#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum LogQueue {
     Append = 0,

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -4,3 +4,33 @@ mod util;
 
 mod test_engine;
 mod test_io_error;
+
+use raft_engine::*;
+use util::*;
+
+#[test]
+fn test_log_batch_full() {
+    let _f = FailGuard::new("log_batch::1kb_entries_size_per_batch", "return");
+    let mut batch_1 = LogBatch::default();
+    let mut batch_2 = LogBatch::default();
+    let data = vec![b'x'; 800];
+    let entries = generate_entries(1, 2, Some(&data));
+    batch_1.add_entries::<MessageExtTyped>(1, &entries).unwrap();
+    batch_2.add_entries::<MessageExtTyped>(2, &entries).unwrap();
+
+    let mut batch_1_clone = batch_1.clone();
+    let mut batch_2_clone = batch_2.clone();
+    assert!(matches!(
+        batch_1_clone.merge(&mut batch_2_clone),
+        Err(Error::Full)
+    ));
+    assert_eq!(batch_1, batch_1_clone);
+    assert_eq!(batch_2, batch_2_clone);
+
+    let mut batch_1_clone = batch_1.clone();
+    assert!(matches!(
+        batch_1_clone.add_entries::<MessageExtTyped>(3, &entries),
+        Err(Error::Full)
+    ));
+    assert_eq!(batch_1, batch_1_clone);
+}


### PR DESCRIPTION
Ref #205

Some enhancements:
- Do not store log index inside `EntryIndex`.
- Reduce entry offset and entry len from u64 to u32. It won't cause regression because the length is already limited by compression (i32::MAX).

Size for one `EntryIndex` is reduced from 64 bytes to 48 bytes (25%).

stress benchmarks shows 18.7% improvement (compared to results in #207, normalized with write bandwidth):
```
Memory: 7003MiB
[write]
Throughput(QPS) = 32322.92
Latency(μs) min = 8, avg = 16.10, p50 = 13, p90 = 26, p95 = 31, p99 = 45, p99.9 = 79, max = 4867
Fairness = 100.0%
Write Bandwidth = 24.2MiB/s
```