### PR TITLE
trace memory of MemTables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ prometheus = { version = "0.13" }
 prometheus-static-metric = "0.5"
 protobuf = "2"
 rayon = "1.5"
-rhai = { version = "1.4", features = ["sync"], optional = true }
+rhai = { version = "~1.4", features = ["sync"], optional = true }
 scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Put this in your Cargo.toml:
 
 ```rust
 [dependencies]
-raft-engine = { git = "https://github.com/tikv/raft-engine", branch = "master" }
+raft-engine = "0.1.0"
 ```
 
 Available Cargo features:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Rust](https://github.com/tikv/raft-engine/workflows/Rust/badge.svg?branch=master)](https://github.com/tikv/raft-engine/actions/workflows/rust.yml)
 [![codecov](https://codecov.io/gh/tikv/raft-engine/branch/master/graph/badge.svg)](https://app.codecov.io/gh/tikv/raft-engine)
+[![Docs](https://docs.rs/raft-engine/badge.svg)](https://docs.rs/raft-engine)
+[![crates.io](https://img.shields.io/crates/v/raft-engine.svg)](https://crates.io/crates/raft-engine)
 
 Raft Engine is a persistent embedded storage engine with a log-structured design similar to [bitcask](https://github.com/basho/bitcask). It is built for [TiKV](https://github.com/tikv/tikv) to store [Multi-Raft](https://raft.github.io/) logs.
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,8 +3,9 @@
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::path::Path;
-use std::sync::Arc;
-use std::time::Instant;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread::{Builder as ThreadBuilder, JoinHandle};
+use std::time::{Duration, Instant};
 
 use log::{error, info};
 use protobuf::{parse_from_bytes, Message};
@@ -23,6 +24,8 @@ use crate::purge::{PurgeHook, PurgeManager};
 use crate::write_barrier::{WriteBarrier, Writer};
 use crate::{Error, GlobalStats, Result};
 
+const METRICS_FLUSH_INTERVAL: Duration = Duration::from_secs(30);
+
 pub struct Engine<F = DefaultFileSystem, P = FilePipeLog<F>>
 where
     F: FileSystem,
@@ -37,6 +40,9 @@ where
     purge_manager: PurgeManager<P>,
 
     write_barrier: WriteBarrier<LogBatch, Result<FileBlockHandle>>,
+
+    tx: Mutex<mpsc::Sender<()>>,
+    metrics_flusher: Option<JoinHandle<()>>,
 
     _phantom: PhantomData<F>,
 }
@@ -92,6 +98,19 @@ where
             listeners.clone(),
         );
 
+        let (tx, rx) = mpsc::channel();
+        let stats_clone = stats.clone();
+        let memtables_clone = memtables.clone();
+        let metrics_flusher = ThreadBuilder::new()
+            .name("raft-engine-metrics".into())
+            .spawn(move || loop {
+                stats_clone.flush_metrics();
+                memtables_clone.flush_metrics();
+                if rx.recv_timeout(METRICS_FLUSH_INTERVAL).is_ok() {
+                    break;
+                }
+            })?;
+
         Ok(Self {
             cfg,
             listeners,
@@ -100,6 +119,8 @@ where
             pipe_log,
             purge_manager,
             write_barrier: Default::default(),
+            tx: Mutex::new(tx),
+            metrics_flusher: Some(metrics_flusher),
             _phantom: PhantomData,
         })
     }
@@ -279,10 +300,18 @@ where
     pub fn get_used_size(&self) -> usize {
         self.pipe_log.total_size(LogQueue::Append) + self.pipe_log.total_size(LogQueue::Rewrite)
     }
+}
 
-    pub fn flush_metrics(&self) {
-        self.stats.flush_metrics();
-        self.memtables.flush_metrics();
+impl<F, P> Drop for Engine<F, P>
+where
+    F: FileSystem,
+    P: PipeLog,
+{
+    fn drop(&mut self) {
+        self.tx.lock().unwrap().send(()).unwrap();
+        if let Some(t) = self.metrics_flusher.take() {
+            t.join().unwrap();
+        }
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -103,10 +103,11 @@ where
         let memtables_clone = memtables.clone();
         let metrics_flusher = ThreadBuilder::new()
             .name("raft-engine-metrics".into())
-            .spawn(move || {
-                while rx.recv_timeout(METRICS_FLUSH_INTERVAL).is_err() {
-                    stats_clone.flush_metrics();
-                    memtables_clone.flush_metrics();
+            .spawn(move || loop {
+                stats_clone.flush_metrics();
+                memtables_clone.flush_metrics();
+                if rx.recv_timeout(METRICS_FLUSH_INTERVAL).is_ok() {
+                    break;
                 }
             })?;
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -102,7 +102,7 @@ where
         let stats_clone = stats.clone();
         let memtables_clone = memtables.clone();
         let metrics_flusher = ThreadBuilder::new()
-            .name("raft-engine-metrics".into())
+            .name("re-metrics".into())
             .spawn(move || loop {
                 stats_clone.flush_metrics();
                 memtables_clone.flush_metrics();

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -600,7 +600,7 @@ impl MemTable {
     }
 
     fn heap_size(&self) -> usize {
-        // TODO: cover the map of kvs.
+        // FIXME: cover the map of kvs.
         self.entry_indexes.capacity() * std::mem::size_of::<EntryIndex>()
     }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -13,6 +13,7 @@ use crate::log_batch::{
     Command, CompressionType, KeyValue, LogBatch, LogItemBatch, LogItemContent, LogItemDrain,
     OpType,
 };
+use crate::metrics::MEMORY_USAGE;
 use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue};
 use crate::util::slices_in_range;
 use crate::{Error, GlobalStats, Result};
@@ -598,6 +599,11 @@ impl MemTable {
         self.entry_indexes.back().map(|e| e.index)
     }
 
+    fn heap_size(&self) -> usize {
+        // FIXME: cover the map of kvs.
+        self.entry_indexes.capacity() * std::mem::size_of::<EntryIndex>()
+    }
+
     /// Returns the first and last log index of the entries in this table.
     #[inline]
     fn span(&self) -> Option<(u64, u64)> {
@@ -900,6 +906,16 @@ impl MemTableAccessor {
                 },
             }
         }
+    }
+
+    pub(crate) fn flush_metrics(&self) {
+        let mut total = 0;
+        for tables in &self.slots {
+            tables.read().values().for_each(|t| {
+                total += t.read().heap_size();
+            });
+        }
+        MEMORY_USAGE.set(total as i64);
     }
 
     #[inline]

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -600,7 +600,7 @@ impl MemTable {
     }
 
     fn heap_size(&self) -> usize {
-        // FIXME: cover the map of kvs.
+        // TODO: cover the map of kvs.
         self.entry_indexes.capacity() * std::mem::size_of::<EntryIndex>()
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -163,4 +163,9 @@ lazy_static! {
         &["type"]
     )
     .unwrap();
+    pub static ref MEMORY_USAGE: IntGauge = register_int_gauge!(
+        "raft_engine_memory_usage",
+        "Memory in bytes used by Raft engine",
+    )
+    .unwrap();
 }

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -16,7 +16,7 @@ use parking_lot_core::SpinWait;
 use raft::eraftpb::Entry;
 use raft_engine::internals::{EventListener, FileBlockHandle};
 use raft_engine::{Command, Config, Engine, LogBatch, MessageExt, ReadableSize};
-use rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng, RngCore};
 
 type WriteBatch = LogBatch;
 
@@ -395,8 +395,10 @@ fn spawn_write(
                 None
             };
             for _ in 0..args.write_entry_count {
+                let mut data = vec![0; args.entry_size];
+                thread_rng().fill_bytes(&mut data);
                 entry_batch.push(Entry {
-                    data: vec![thread_rng().gen::<u8>(); args.entry_size].into(),
+                    data: data.into(),
                     ..Default::default()
                 });
             }


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Ref #205 

Added a new method to flush internal metrics, including memory used by `MemTables`.