### PR TITLE
share block handle between entry indexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ rayon = "1.5"
 rhai = { version = "1.4", features = ["sync"], optional = true }
 scopeguard = "1.1"
 serde = { version = "1.0", features = ["derive"] }
+strum = { version = "0.20", features = ["derive"] }
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -9,6 +9,7 @@ use crossbeam::utils::CachePadded;
 use fail::fail_point;
 use log::{error, warn};
 use parking_lot::{Mutex, MutexGuard, RwLock};
+use strum::EnumCount;
 
 use crate::config::Config;
 use crate::env::FileSystem;
@@ -283,7 +284,7 @@ impl<F: FileSystem> SinglePipe<F> {
 
 /// A [`PipeLog`] implementation that stores data in filesystem.
 pub struct DualPipes<F: FileSystem> {
-    pipes: [SinglePipe<F>; 2],
+    pipes: [SinglePipe<F>; LogQueue::COUNT],
 
     _dir_lock: File,
 }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -115,7 +115,7 @@ impl<T: std::cmp::PartialEq> StableVecDeque<T> {
             inner: VecDeque::with_capacity(capacity),
             // Test overflow handling.
             #[cfg(test)]
-            start_addr: StableAddress(0),
+            start_addr: StableAddress(u32::MAX),
             #[cfg(not(test))]
             start_addr: StableAddress(0),
         }

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -174,6 +174,11 @@ impl<T: std::cmp::PartialEq> StableVecDeque<T> {
             self.inner.shrink_to_fit();
         }
     }
+
+    #[inline]
+    fn heap_size(&self) -> usize {
+        self.inner.capacity() * std::mem::size_of::<T>()
+    }
 }
 
 impl std::ops::Add<usize> for StableAddress {
@@ -859,7 +864,11 @@ impl MemTable {
 
     fn heap_size(&self) -> usize {
         // FIXME: cover the map of kvs.
-        self.entry_indexes.capacity() * std::mem::size_of::<EntryIndex>()
+        let mut total = self.entry_handles.capacity() * std::mem::size_of::<EntryIndex>();
+        for i in 0..LogQueue::COUNT {
+            total += self.entries_handles[i].heap_size();
+        }
+        total
     }
 
     /// Returns the first and last log index of the entries in this table.

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -188,13 +188,6 @@ impl std::ops::Add<usize> for StableAddress {
     }
 }
 
-impl std::ops::Sub<usize> for StableAddress {
-    type Output = StableAddress;
-    fn sub(self, rhs: usize) -> Self::Output {
-        StableAddress(self.0.wrapping_sub(rhs as u32))
-    }
-}
-
 impl std::ops::Sub<StableAddress> for StableAddress {
     type Output = usize;
     fn sub(self, rhs: StableAddress) -> Self::Output {

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -869,7 +869,7 @@ impl MemTable {
 
     #[inline]
     fn get_entries_handle(&self, entry_handle: &EntryHandle) -> &EntriesHandle {
-        &self.entries_handles[entry_handle.queue as usize].at(entry_handle.entries_addr)
+        self.entries_handles[entry_handle.queue as usize].at(entry_handle.entries_addr)
     }
 
     #[cfg(test)]

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -83,7 +83,6 @@ struct EntriesHandle {
 }
 
 /// Relative location of one single entry.
-#[derive(Debug, Copy, Clone, PartialEq)]
 struct EntryHandle {
     /// The relative offset within its group of entries.
     offset: u32,

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -4,11 +4,13 @@
 
 use std::cmp::Ordering;
 
+use strum::EnumCount;
+
 use crate::Result;
 
 /// The type of log queue.
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, EnumCount)]
 pub enum LogQueue {
     Append = 0,
     Rewrite = 1,


### PR DESCRIPTION
Ref #205

stress results show 62.5% improvement compared to #206, 70% compared to v0.1.0:
```
# ./target/release/stress --path /data3/re_bench --time 60 --regions 1000 --write-threads 1 --purge-interval 0 --compact-count 0 --write-without-sync
Memory: 2625MiB
[write]
Throughput(QPS) = 32942.22
Latency(μs) min = 8, avg = 15.31, p50 = 12, p90 = 25, p95 = 30, p99 = 45, p99.9 = 105, max = 3681
Fairness = 100.0%
Write Bandwidth = 24.6MiB/s
```