### PR TITLE
offload in-memory `entry_len` field to disk

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -468,13 +468,15 @@ where
                 idx.entries.unwrap(),
                 LogBatch::decode_entries_block(
                     &pipe_log.read_bytes(idx.entries.unwrap())?,
-                    idx.entries.unwrap(),
                     idx.compression_type,
                 )?,
             );
         }
         let entries_block = cache.block.borrow();
-        let e = LogBatch::decode_entry::<M>(&entries_block, idx.entry_offset as usize)?;
+        let e = LogBatch::decode_entry_from_entries_block::<M>(
+            &entries_block,
+            idx.entry_offset as usize,
+        )?;
         assert_eq!(M::index(&e), idx.index);
         Ok(e)
     })
@@ -490,15 +492,15 @@ where
                 idx.entries.unwrap(),
                 LogBatch::decode_entries_block(
                     &pipe_log.read_bytes(idx.entries.unwrap())?,
-                    idx.entries.unwrap(),
                     idx.compression_type,
                 )?,
             );
         }
-        Ok(
-            LogBatch::decode_entry_block(&cache.block.borrow(), idx.entry_offset as usize)?
-                .to_owned(),
-        )
+        Ok(LogBatch::decode_entry_bytes_from_entries_block(
+            &cache.block.borrow(),
+            idx.entry_offset as usize,
+        )?
+        .to_owned())
     })
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -285,12 +285,14 @@ impl RhaiFilterMachine {
                                 let entries_buf = reader.read(ei.entries.unwrap())?;
                                 let block = LogBatch::decode_entries_block(
                                     &entries_buf,
-                                    ei.entries.unwrap(),
                                     ei.compression_type,
                                 )?;
                                 entries.push(
-                                    LogBatch::decode_entry_block(&block, ei.entry_offset as usize)?
-                                        .to_owned(),
+                                    LogBatch::decode_entry_bytes_from_entries_block(
+                                        &block,
+                                        ei.entry_offset as usize,
+                                    )?
+                                    .to_owned(),
                                 );
                             }
                             log_batch.add_raw_entries(item.raft_group_id, eis, entries)?;

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -289,8 +289,7 @@ impl RhaiFilterMachine {
                                     ei.compression_type,
                                 )?;
                                 entries.push(
-                                    block[ei.entry_offset as usize
-                                        ..(ei.entry_offset + ei.entry_len) as usize]
+                                    LogBatch::decode_entry_block(&block, ei.entry_offset as usize)?
                                         .to_owned(),
                                 );
                             }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -66,7 +66,7 @@ impl CompressionType {
     }
 }
 
-/// Format: u64 `count` | var_u64 `first_index` | [ u32 `entry_offset` ]
+/// Format: u32 `count` | var_u64 `first_index` | [ u32 `entry_offset` ]
 #[derive(Clone, Debug, PartialEq)]
 pub struct EntryIndexes(pub Vec<EntryIndex>);
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -991,10 +991,7 @@ impl ReplayMachine for MemTableRecoverContext {
     }
 
     fn merge(&mut self, mut rhs: Self, queue: LogQueue) -> Result<()> {
-        self.log_batch.merge(
-            &mut rhs.log_batch.clone(),
-            0, /* entry_offset_increment */
-        );
+        self.log_batch.merge(&mut rhs.log_batch.clone());
         match queue {
             LogQueue::Append => self.memtables.apply_append_writes(rhs.log_batch.drain()),
             LogQueue::Rewrite => self

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -37,8 +37,6 @@ pub struct EntryIndex {
 
     /// The relative offset within its group of entries.
     pub entry_offset: u32,
-    /// The encoded length within its group of entries.
-    pub entry_len: u32,
 }
 
 impl Default for EntryIndex {
@@ -48,7 +46,6 @@ impl Default for EntryIndex {
             entries: None,
             compression_type: CompressionType::None,
             entry_offset: 0,
-            entry_len: 0,
         }
     }
 }
@@ -60,7 +57,6 @@ impl EntryIndex {
             entries: e.entries,
             compression_type: e.compression_type,
             entry_offset: e.entry_offset,
-            entry_len: e.entry_len,
         }
     }
 }
@@ -70,7 +66,6 @@ struct ThinEntryIndex {
     entries: Option<FileBlockHandle>,
     compression_type: CompressionType,
     entry_offset: u32,
-    entry_len: u32,
 }
 
 impl From<&EntryIndex> for ThinEntryIndex {
@@ -79,7 +74,6 @@ impl From<&EntryIndex> for ThinEntryIndex {
             entries: e.entries,
             compression_type: e.compression_type,
             entry_offset: e.entry_offset,
-            entry_len: e.entry_len,
         }
     }
 }
@@ -485,7 +479,6 @@ impl MemTable {
         &self,
         begin: u64,
         end: u64,
-        max_size: Option<usize>,
         vec_idx: &mut Vec<EntryIndex>,
     ) -> Result<()> {
         if end <= begin {
@@ -507,16 +500,8 @@ impl MemTable {
         let end_pos = (end - begin) as usize + start_pos;
 
         let (first, second) = slices_in_range(&self.entry_indexes, start_pos, end_pos);
-        let mut total_size = 0;
         let mut index = begin;
         for idx in first.iter().chain(second) {
-            total_size += idx.entry_len;
-            // No matter max_size's value, fetch one entry at least.
-            if let Some(max_size) = max_size {
-                if total_size as usize > max_size && total_size > idx.entry_len {
-                    break;
-                }
-            }
             vec_idx.push(EntryIndex::from_thin(index, *idx));
             index += 1;
         }
@@ -549,7 +534,7 @@ impl MemTable {
         if self.rewrite_count > 0 {
             let first = self.first_index;
             let end = self.first_index + self.rewrite_count as u64;
-            self.fetch_entries_to(first, end, None, vec_idx)
+            self.fetch_entries_to(first, end, vec_idx)
         } else {
             Ok(())
         }
@@ -1006,7 +991,10 @@ impl ReplayMachine for MemTableRecoverContext {
     }
 
     fn merge(&mut self, mut rhs: Self, queue: LogQueue) -> Result<()> {
-        self.log_batch.merge(&mut rhs.log_batch.clone());
+        self.log_batch.merge(
+            &mut rhs.log_batch.clone(),
+            0, /* entry_offset_increment */
+        );
         match queue {
             LogQueue::Append => self.memtables.apply_append_writes(rhs.log_batch.drain()),
             LogQueue::Rewrite => self
@@ -1024,7 +1012,7 @@ mod tests {
     use crate::test_util::{catch_unwind_silent, generate_entry_indexes};
 
     impl MemTable {
-        pub fn max_file_seq(&self, queue: LogQueue) -> Option<FileSeq> {
+        fn max_file_seq(&self, queue: LogQueue) -> Option<FileSeq> {
             let entry = match queue {
                 LogQueue::Append if self.rewrite_count == self.entry_indexes.len() => None,
                 LogQueue::Append => self.entry_indexes.back(),
@@ -1042,7 +1030,7 @@ mod tests {
             }
         }
 
-        pub fn kvs_max_file_seq(&self, queue: LogQueue) -> Option<FileSeq> {
+        fn kvs_max_file_seq(&self, queue: LogQueue) -> Option<FileSeq> {
             self.kvs
                 .values()
                 .filter(|v| v.1.queue == queue)
@@ -1055,17 +1043,14 @@ mod tests {
                 })
         }
 
-        pub fn fetch_all(&self, vec_idx: &mut Vec<EntryIndex>) {
+        fn fetch_all(&self, vec_idx: &mut Vec<EntryIndex>) {
             if let Some((first, last)) = self.span() {
-                self.fetch_entries_to(first, last + 1, None, vec_idx)
-                    .unwrap();
+                self.fetch_entries_to(first, last + 1, vec_idx).unwrap();
             }
         }
 
-        fn entries_size(&self) -> usize {
-            self.entry_indexes
-                .iter()
-                .fold(0, |acc, e| acc + e.entry_len) as usize
+        fn entries_count(&self) -> usize {
+            self.entry_indexes.len()
         }
     }
 
@@ -1082,7 +1067,7 @@ mod tests {
             20,
             FileId::new(LogQueue::Append, 1),
         ));
-        assert_eq!(memtable.entries_size(), 10);
+        assert_eq!(memtable.entries_count(), 10);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 1);
         memtable.consistency_check();
@@ -1110,13 +1095,13 @@ mod tests {
             30,
             FileId::new(LogQueue::Append, 2),
         ));
-        assert_eq!(memtable.entries_size(), 20);
+        assert_eq!(memtable.entries_count(), 20);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 2);
         memtable.consistency_check();
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
 
         // Partial overlap Appending.
@@ -1130,13 +1115,13 @@ mod tests {
             35,
             FileId::new(LogQueue::Append, 3),
         ));
-        assert_eq!(memtable.entries_size(), 25);
+        assert_eq!(memtable.entries_count(), 25);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 3);
         memtable.consistency_check();
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
 
         // Full overlap Appending.
@@ -1148,13 +1133,13 @@ mod tests {
             40,
             FileId::new(LogQueue::Append, 4),
         ));
-        assert_eq!(memtable.entries_size(), 30);
+        assert_eq!(memtable.entries_count(), 30);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 4);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 4);
         memtable.consistency_check();
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
 
         let global_stats = Arc::clone(&memtable.global_stats);
@@ -1192,28 +1177,28 @@ mod tests {
             FileId::new(LogQueue::Append, 3),
         ));
 
-        assert_eq!(memtable.entries_size(), 25);
+        assert_eq!(memtable.entries_count(), 25);
         assert_eq!(memtable.first_index().unwrap(), 0);
         assert_eq!(memtable.last_index().unwrap(), 24);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 3);
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
         memtable.consistency_check();
 
         // Compact to 5.
         // Only index is needed to compact.
         assert_eq!(memtable.compact_to(5), 5);
-        assert_eq!(memtable.entries_size(), 20);
+        assert_eq!(memtable.entries_count(), 20);
         assert_eq!(memtable.first_index().unwrap(), 5);
         assert_eq!(memtable.last_index().unwrap(), 24);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 1);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 3);
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
         // Can't override compacted entries.
         assert!(
@@ -1228,21 +1213,21 @@ mod tests {
 
         // Compact to 20.
         assert_eq!(memtable.compact_to(20), 15);
-        assert_eq!(memtable.entries_size(), 5);
+        assert_eq!(memtable.entries_count(), 5);
         assert_eq!(memtable.first_index().unwrap(), 20);
         assert_eq!(memtable.last_index().unwrap(), 24);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 3);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 3);
         assert_eq!(
             memtable.global_stats.live_entries(LogQueue::Append),
-            memtable.entries_size()
+            memtable.entries_count()
         );
         memtable.consistency_check();
 
         // Compact to 20 or smaller index, nothing happens.
         assert_eq!(memtable.compact_to(20), 0);
         assert_eq!(memtable.compact_to(15), 0);
-        assert_eq!(memtable.entries_size(), 5);
+        assert_eq!(memtable.entries_count(), 5);
         assert_eq!(memtable.first_index().unwrap(), 20);
         assert_eq!(memtable.last_index().unwrap(), 24);
         memtable.consistency_check();
@@ -1258,13 +1243,9 @@ mod tests {
         // Fetch empty.
         memtable.fetch_all(&mut ents_idx);
         assert!(ents_idx.is_empty());
-        memtable
-            .fetch_entries_to(0, 0, None, &mut ents_idx)
-            .unwrap();
+        memtable.fetch_entries_to(0, 0, &mut ents_idx).unwrap();
         assert!(matches!(
-            memtable
-                .fetch_entries_to(0, 1, None, &mut ents_idx)
-                .unwrap_err(),
+            memtable.fetch_entries_to(0, 1, &mut ents_idx).unwrap_err(),
             Error::EntryNotFound
         ));
 
@@ -1304,9 +1285,7 @@ mod tests {
         // Out of range fetching.
         ents_idx.clear();
         assert!(matches!(
-            memtable
-                .fetch_entries_to(5, 15, None, &mut ents_idx)
-                .unwrap_err(),
+            memtable.fetch_entries_to(5, 15, &mut ents_idx).unwrap_err(),
             Error::EntryCompacted
         ));
 
@@ -1314,53 +1293,28 @@ mod tests {
         ents_idx.clear();
         assert!(matches!(
             memtable
-                .fetch_entries_to(20, 30, None, &mut ents_idx)
+                .fetch_entries_to(20, 30, &mut ents_idx)
                 .unwrap_err(),
             Error::EntryNotFound
         ));
 
         ents_idx.clear();
-        memtable
-            .fetch_entries_to(20, 25, None, &mut ents_idx)
-            .unwrap();
+        memtable.fetch_entries_to(20, 25, &mut ents_idx).unwrap();
         assert_eq!(ents_idx.len(), 5);
         assert_eq!(ents_idx[0].index, 20);
         assert_eq!(ents_idx[4].index, 24);
 
         ents_idx.clear();
-        memtable
-            .fetch_entries_to(10, 15, None, &mut ents_idx)
-            .unwrap();
+        memtable.fetch_entries_to(10, 15, &mut ents_idx).unwrap();
         assert_eq!(ents_idx.len(), 5);
         assert_eq!(ents_idx[0].index, 10);
         assert_eq!(ents_idx[4].index, 14);
 
         ents_idx.clear();
-        memtable
-            .fetch_entries_to(10, 25, None, &mut ents_idx)
-            .unwrap();
+        memtable.fetch_entries_to(10, 25, &mut ents_idx).unwrap();
         assert_eq!(ents_idx.len(), 15);
         assert_eq!(ents_idx[0].index, 10);
         assert_eq!(ents_idx[14].index, 24);
-
-        // Max size limitation range fetching.
-        // Only can fetch [10, 20) because of size limitation,
-        ents_idx.clear();
-        let max_size = Some(10);
-        memtable
-            .fetch_entries_to(10, 25, max_size, &mut ents_idx)
-            .unwrap();
-        assert_eq!(ents_idx.len(), 10);
-        assert_eq!(ents_idx[0].index, 10);
-        assert_eq!(ents_idx[9].index, 19);
-
-        // Even max size limitation is 0, at least fetch one entry.
-        ents_idx.clear();
-        memtable
-            .fetch_entries_to(20, 25, Some(0), &mut ents_idx)
-            .unwrap();
-        assert_eq!(ents_idx.len(), 1);
-        assert_eq!(ents_idx[0].index, 20);
     }
 
     #[test]
@@ -1433,7 +1387,7 @@ mod tests {
         // [20, 25) file_num = 3
         let ents_idx = generate_entry_indexes(0, 10, FileId::new(LogQueue::Rewrite, 1));
         memtable.rewrite(ents_idx, Some(1));
-        assert_eq!(memtable.entries_size(), 25);
+        assert_eq!(memtable.entries_count(), 25);
         memtable.consistency_check();
 
         let mut ents_idx = vec![];
@@ -1592,7 +1546,7 @@ mod tests {
         expected_append += 4 * 10 + 3;
         memtable.compact_to(10);
         expected_append -= 10;
-        assert_eq!(memtable.entries_size(), 30);
+        assert_eq!(memtable.entries_count(), 30);
         assert_eq!(memtable.min_file_seq(LogQueue::Append).unwrap(), 2);
         assert_eq!(memtable.max_file_seq(LogQueue::Append).unwrap(), 4);
         assert_eq!(

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -41,7 +41,6 @@ pub fn generate_entry_indexes_opt(
                 offset: 0,
                 len: 0,
             }),
-            entry_len: 1,
             ..Default::default()
         };
 

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -46,10 +46,6 @@ fn test_file_read_error() {
     let entry = vec![b'x'; 1024];
 
     let engine = Engine::open_with_file_system(cfg, fs).unwrap();
-    // Writing an empty message.
-    engine
-        .write(&mut generate_batch(1, 0, 1, None), true)
-        .unwrap();
     engine
         .write(&mut generate_batch(2, 1, 10, Some(&entry)), true)
         .unwrap();
@@ -66,9 +62,6 @@ fn test_file_read_error() {
 
     let mut entries = Vec::new();
     let _f = FailGuard::new("log_fd::read::err", "return");
-    engine
-        .fetch_entries_to::<MessageExtTyped>(1, 0, 1, None, &mut entries)
-        .unwrap();
     engine.get_message::<Entry>(1, b"k".as_ref()).unwrap();
     engine
         .fetch_entries_to::<MessageExtTyped>(2, 1, 10, None, &mut entries)


### PR DESCRIPTION
Signed-off-by: tabokie <xy.tao@outlook.com>

Ref #205 

Previously, we store the (offset, length) of each entry in memory. In this PR, the length field is encoded in on-disk data to reduce memory usage.

The size of `ThinEntryIndex` is now 40B compared to 64B in v0.1.0.