### PR TITLE
tolerate fallocate failure and print IO error in debug form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* Unconditionally tolerate `fallocate` failures as a fix to its portability issue.
+* Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
 
 ## [0.2.0] - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-### Behavior Changes
+### Bug Fixes
 
-* Tolerate unsupported `fallocate` calls on Linux.
+* Unconditionally tolerate `fallocate` failures as a fix to its portability issue.
 
 ## [0.2.0] - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 
-### Bug Fixes
+### Behavior Changes
 
-* Fix `fallocate` portability issue by tolerating its failure unconditionally.
+* Tolerate unsupported `fallocate` calls on Linux.
 
 ## [0.2.0] - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* Fix `fallocate` portability issue by tolerating its failure unconditionally.
+
 ## [0.2.0] - 2022-05-25
 
 ### Bug Fixes

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -152,12 +152,16 @@ impl LogFd {
         });
         #[cfg(target_os = "linux")]
         {
-            let _ = fcntl::fallocate(
+            if let Err(e) = fcntl::fallocate(
                 self.0,
                 fcntl::FallocateFlags::empty(),
                 offset as i64,
                 size as i64,
-            );
+            ) {
+                if e != nix::Error::EOPNOTSUPP {
+                    return Err(from_nix_error(e, "fallocate"));
+                }
+            }
         }
         Ok(())
     }

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -159,10 +159,7 @@ impl LogFd {
                 size as i64,
             );
         }
-        #[cfg(not(target_os = "linux"))]
-        {
-            Ok(())
-        }
+        Ok(())
     }
 }
 

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -152,13 +152,12 @@ impl LogFd {
         });
         #[cfg(target_os = "linux")]
         {
-            fcntl::fallocate(
+            let _ = fcntl::fallocate(
                 self.0,
                 fcntl::FallocateFlags::empty(),
                 offset as i64,
                 size as i64,
-            )
-            .map_err(|e| from_nix_error(e, "fallocate"))
+            );
         }
         #[cfg(not(target_os = "linux"))]
         {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub enum Error {
     InvalidArgument(String),
     #[error("Corruption: {0}")]
     Corruption(String),
-    #[error("IO Error: {0}")]
+    #[error("IO Error: {0:?}")]
     Io(#[from] IoError),
     #[error("Codec Error: {0}")]
     Codec(#[from] CodecError),

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -5,12 +5,14 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::Arc;
 
+use log::warn;
+
+use crate::env::{FileSystem, Handle, WriteExt};
 use crate::metrics::*;
 use crate::pipe_log::FileBlockHandle;
 use crate::{Error, Result};
 
 use super::format::{LogFileFormat, Version};
-use crate::env::{FileSystem, Handle, WriteExt};
 
 /// Maximum number of bytes to allocate ahead.
 const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
@@ -97,7 +99,9 @@ impl<F: FileSystem> LogFileWriter<F> {
                     target_size_hint.saturating_sub(self.capacity),
                 ),
             );
-            self.writer.allocate(self.capacity, alloc)?;
+            if let Err(e) = self.writer.allocate(self.capacity, alloc) {
+                warn!("log file allocation failed: {}", e);
+            }
             self.capacity += alloc;
         }
         self.writer.write_all(buf)?;


### PR DESCRIPTION
`fallocate` is more performant but not supported on some platforms. This patch ignores its error.

Also fix the issue that `std::io::Error` doesn't print well for custom error kind.

Signed-off-by: tabokie <xy.tao@outlook.com>