### PR TITLE
Record perf contexts to the write procedure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Add `is_empty` to `Engine` API.
 * Add metadata deletion capability to `FileSystem` trait. Users can implement `exists_metadata` and `delete_metadata` to clean up obsolete metadata from older versions of Raft Engine.
+* Add `PerfContext` which records detailed time breakdown of the write process to thread-local storage.
 
 ## [0.2.0] - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 * Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
 
+### New Features
+
+* Add `PerfContext` which records detailed time breakdown of the write process to thread-local storage.
+
 ### Public API Changes
 
 * Add `is_empty` to `Engine` API.
 * Add metadata deletion capability to `FileSystem` trait. Users can implement `exists_metadata` and `delete_metadata` to clean up obsolete metadata from older versions of Raft Engine.
-* Add `PerfContext` which records detailed time breakdown of the write process to thread-local storage.
 
 ## [0.2.0] - 2022-05-25
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -182,8 +182,9 @@ where
             let entered_time = writer.entered_time.unwrap();
             ENGINE_WRITE_PREPROCESS_DURATION_HISTOGRAM
                 .observe(entered_time.saturating_duration_since(start).as_secs_f64());
-            perf_context.write_leader_wait_duration +=
+            perf_context.write_wait_duration +=
                 entered_time.saturating_duration_since(before_enter);
+            debug_assert_eq!(writer.perf_context_diff.write_wait_duration, Duration::ZERO);
             perf_context += &writer.perf_context_diff;
             set_perf_context(perf_context);
             writer.finish()?

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -113,7 +113,7 @@ impl<F: FileSystem> LogFileWriter<F> {
         if self.last_sync < self.written {
             let _t = StopWatch::new((
                 &*LOG_SYNC_DURATION_HISTOGRAM,
-                perf_context!(log_rotate_nanos),
+                perf_context!(log_rotate_duration),
             ));
             self.writer.sync()?;
             self.last_sync = self.written;

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -10,7 +10,7 @@ use log::warn;
 use crate::env::{FileSystem, Handle, WriteExt};
 use crate::metrics::*;
 use crate::pipe_log::FileBlockHandle;
-use crate::{perf_context, Error, Result};
+use crate::{Error, Result};
 
 use super::format::{LogFileFormat, Version};
 
@@ -111,10 +111,7 @@ impl<F: FileSystem> LogFileWriter<F> {
 
     pub fn sync(&mut self) -> Result<()> {
         if self.last_sync < self.written {
-            let _t = StopWatch::new((
-                &*LOG_SYNC_DURATION_HISTOGRAM,
-                perf_context!(log_rotate_duration),
-            ));
+            let _t = StopWatch::new(&*LOG_SYNC_DURATION_HISTOGRAM);
             self.writer.sync()?;
             self.last_sync = self.written;
         }

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -156,7 +156,7 @@ impl<F: FileSystem> SinglePipe<F> {
     fn rotate_imp(&self, active_file: &mut MutexGuard<ActiveFile<F>>) -> Result<()> {
         let _t = StopWatch::new((
             &*LOG_ROTATE_DURATION_HISTOGRAM,
-            perf_context!(log_rotate_nanos),
+            perf_context!(log_rotate_duration),
         ));
         let seq = active_file.seq + 1;
         debug_assert!(seq > 1);

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -16,7 +16,7 @@ use crate::env::FileSystem;
 use crate::event_listener::EventListener;
 use crate::metrics::*;
 use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue, PipeLog};
-use crate::{Error, Result};
+use crate::{perf_context, Error, Result};
 
 use super::format::{FileNameExt, Version};
 use super::log_file::{build_file_reader, build_file_writer, FileHandler, LogFileWriter};
@@ -154,7 +154,10 @@ impl<F: FileSystem> SinglePipe<F> {
     ///
     /// This operation is atomic in face of errors.
     fn rotate_imp(&self, active_file: &mut MutexGuard<ActiveFile<F>>) -> Result<()> {
-        let _t = StopWatch::new(&LOG_ROTATE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new((
+            &*LOG_ROTATE_DURATION_HISTOGRAM,
+            perf_context!(log_rotate_nanos),
+        ));
         let seq = active_file.seq + 1;
         debug_assert!(seq > 1);
 

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -261,6 +261,7 @@ impl<F: FileSystem> SinglePipe<F> {
                 panic!("error when rotate [{:?}:{}]: {}", self.queue, seq, e);
             }
         } else if writer.since_last_sync() >= self.bytes_per_sync || force {
+            let _t = StopWatch::new(perf_context!(log_sync_duration));
             if let Err(e) = writer.sync() {
                 panic!("error when sync [{:?}:{}]: {}", self.queue, seq, e,);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use config::{Config, RecoveryMode};
 pub use engine::Engine;
 pub use errors::{Error, Result};
 pub use log_batch::{Command, LogBatch, MessageExt};
+pub use metrics::{get_perf_context, reset_perf_context, PerfContext};
 pub use util::ReadableSize;
 
 #[cfg(feature = "internals")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub use config::{Config, RecoveryMode};
 pub use engine::Engine;
 pub use errors::{Error, Result};
 pub use log_batch::{Command, LogBatch, MessageExt};
-pub use metrics::{get_perf_context, reset_perf_context, PerfContext};
+pub use metrics::{get_perf_context, set_perf_context, take_perf_context, PerfContext};
 pub use util::ReadableSize;
 
 #[cfg(feature = "internals")]

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -698,7 +698,7 @@ impl LogBatch {
     /// Internally, encodes and optionally compresses log entries. Sets the
     /// compression type to each entry index.
     pub(crate) fn finish_populate(&mut self, compression_threshold: usize) -> Result<usize> {
-        let _t = StopWatch::new(perf_context!(log_populating_nanos));
+        let _t = StopWatch::new(perf_context!(log_populating_duration));
         debug_assert!(self.buf_state == BufState::Open);
         if self.is_empty() {
             self.buf_state = BufState::Sealed(self.buf.len(), 0);

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -11,9 +11,10 @@ use protobuf::Message;
 use crate::codec::{self, NumberEncoder};
 use crate::file_pipe_log::Version;
 use crate::memtable::EntryIndex;
+use crate::metrics::StopWatch;
 use crate::pipe_log::{FileBlockHandle, FileId};
 use crate::util::{crc32, lz4};
-use crate::{Error, Result};
+use crate::{perf_context, Error, Result};
 
 pub(crate) const LOG_BATCH_HEADER_LEN: usize = 16;
 pub(crate) const LOG_BATCH_CHECKSUM_LEN: usize = 4;
@@ -697,6 +698,7 @@ impl LogBatch {
     /// Internally, encodes and optionally compresses log entries. Sets the
     /// compression type to each entry index.
     pub(crate) fn finish_populate(&mut self, compression_threshold: usize) -> Result<usize> {
+        let _t = StopWatch::new(perf_context!(log_populating_nanos));
         debug_assert!(self.buf_state == BufState::Open);
         if self.is_empty() {
             self.buf_state = BufState::Sealed(self.buf.len(), 0);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -3,7 +3,6 @@
 use std::{
     cell::{RefCell, RefMut},
     ops::AddAssign,
-    thread::LocalKey,
     time::{Duration, Instant},
 };
 
@@ -78,12 +77,19 @@ thread_local! {
     static TLS_PERF_CONTEXT: RefCell<PerfContext> = RefCell::new(PerfContext::default());
 }
 
-pub fn reset_perf_context() {
-    TLS_PERF_CONTEXT.with(|c| *c.borrow_mut() = PerfContext::default());
+/// Gets a copy of the thread-local PerfContext.
+pub fn get_perf_context() -> PerfContext {
+    TLS_PERF_CONTEXT.with(|c| c.borrow().clone())
 }
 
-pub fn get_perf_context() -> &'static LocalKey<RefCell<PerfContext>> {
-    &TLS_PERF_CONTEXT
+/// Resets the thread-local PerfContext and takes its old value.
+pub fn take_perf_context() -> PerfContext {
+    TLS_PERF_CONTEXT.with(|c| c.take())
+}
+
+/// Sets the value of the thread-local PerfContext.
+pub fn set_perf_context(perf_context: PerfContext) {
+    TLS_PERF_CONTEXT.with(|c| *c.borrow_mut() = perf_context);
 }
 
 pub(crate) struct PerfContextField<P> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -46,8 +46,8 @@ pub struct PerfContext {
     /// Time spent encoding and compressing log entries.
     pub log_populating_duration: Duration,
 
-    /// Time spent waiting for becoming the write leader.
-    pub write_leader_wait_duration: Duration,
+    /// Time spent waiting for the write group to form and get processed.
+    pub write_wait_duration: Duration,
 
     /// Time spent writing the logs to files.
     pub log_write_duration: Duration,
@@ -65,7 +65,7 @@ pub struct PerfContext {
 impl AddAssign<&'_ PerfContext> for PerfContext {
     fn add_assign(&mut self, rhs: &PerfContext) {
         self.log_populating_duration += rhs.log_populating_duration;
-        self.write_leader_wait_duration += rhs.write_leader_wait_duration;
+        self.write_wait_duration += rhs.write_wait_duration;
         self.log_write_duration += rhs.log_write_duration;
         self.log_rotate_duration += rhs.log_rotate_duration;
         self.log_sync_duration += rhs.log_sync_duration;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -109,8 +109,10 @@ macro_rules! perf_context {
 pub trait TimeMetric {
     fn observe(&self, duration: Duration);
 
-    fn observe_since(&self, earlier: Instant) {
-        self.observe(earlier.saturating_elapsed());
+    fn observe_since(&self, earlier: Instant) -> Duration {
+        let dur = earlier.saturating_elapsed();
+        self.observe(dur);
+        dur
     }
 }
 

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -65,7 +65,7 @@ where
     }
 
     pub fn purge_expired_files(&self) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_PURGE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_PURGE_DURATION_HISTOGRAM);
         let guard = self.force_rewrite_candidates.try_lock();
         if guard.is_none() {
             warn!("Unable to purge expired files: locked");
@@ -202,7 +202,7 @@ where
         compact_watermark: FileSeq,
         rewrite_candidates: &mut HashMap<u64, u32>,
     ) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_REWRITE_APPEND_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_REWRITE_APPEND_DURATION_HISTOGRAM);
         debug_assert!(compact_watermark <= rewrite_watermark);
         let mut should_compact = Vec::with_capacity(16);
 
@@ -239,7 +239,7 @@ where
 
     // Rewrites the entire rewrite queue into new log files.
     fn rewrite_rewrite_queue(&self) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_REWRITE_REWRITE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_REWRITE_REWRITE_DURATION_HISTOGRAM);
         self.pipe_log.rotate(LogQueue::Rewrite)?;
 
         let mut force_compact_regions = vec![];

--- a/src/write_barrier.rs
+++ b/src/write_barrier.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use fail::fail_point;
 use parking_lot::{Condvar, Mutex};
 
-use crate::{metrics::TimeMetric, perf_context, PerfContext};
+use crate::PerfContext;
 
 type Ptr<T> = Option<NonNull<T>>;
 
@@ -24,7 +24,7 @@ pub struct Writer<P, O> {
     output: Option<O>,
 
     pub(crate) sync: bool,
-    pub(crate) start_time: Instant,
+    pub(crate) entered_time: Option<Instant>,
     pub(crate) perf_context_diff: PerfContext,
 }
 
@@ -35,13 +35,13 @@ impl<P, O> Writer<P, O> {
     ///
     /// Data pointed by `payload` is mutably referenced by this writer. Do not
     /// access the payload by its original name during this writer's lifetime.
-    pub fn new(payload: &mut P, sync: bool, start_time: Instant) -> Self {
+    pub fn new(payload: &mut P, sync: bool) -> Self {
         Writer {
             next: Cell::new(None),
             payload: payload as *mut _,
             output: None,
             sync,
-            start_time,
+            entered_time: None,
             perf_context_diff: PerfContext::default(),
         }
     }
@@ -169,7 +169,6 @@ impl<P, O> WriteBarrier<P, O> {
     /// the leader of a set of writers, returns a [`WriteGroup`] that contains
     /// them, `writer` included.
     pub fn enter<'a>(&self, writer: &'a mut Writer<P, O>) -> Option<WriteGroup<'_, 'a, P, O>> {
-        let start = Instant::now();
         let node = unsafe { Some(NonNull::new_unchecked(writer)) };
         let mut inner = self.inner.lock();
         if let Some(tail) = inner.tail.get() {
@@ -191,7 +190,6 @@ impl<P, O> WriteBarrier<P, O> {
                 //
                 self.leader_cv.wait(&mut inner);
                 inner.pending_leader.set(None);
-                perf_context!(write_leader_wait_duration).observe_since(start);
             }
         } else {
             // leader of a empty write group. proceed directly.
@@ -244,7 +242,7 @@ mod tests {
         let mut processed_writers = 0;
 
         for _ in 0..4 {
-            let mut writer = Writer::new(&mut payload, false, Instant::now());
+            let mut writer = Writer::new(&mut payload, false);
             {
                 let mut wg = barrier.enter(&mut writer).unwrap();
                 leaders += 1;
@@ -296,7 +294,7 @@ mod tests {
                 self.ths.push(
                     ThreadBuilder::new()
                         .spawn(move || {
-                            let mut writer = Writer::new(&mut seq, false, Instant::now());
+                            let mut writer = Writer::new(&mut seq, false);
                             {
                                 let mut wg = barrier.enter(&mut writer).unwrap();
                                 leader_enter_tx.send(()).unwrap();
@@ -330,7 +328,7 @@ mod tests {
                 self.ths.push(
                     ThreadBuilder::new()
                         .spawn(move || {
-                            let mut writer = Writer::new(&mut seq, false, Instant::now());
+                            let mut writer = Writer::new(&mut seq, false);
                             start_thread.wait();
                             if let Some(mut wg) = barrier.enter(&mut writer) {
                                 leader_enter_tx_clone.send(()).unwrap();

--- a/src/write_barrier.rs
+++ b/src/write_barrier.rs
@@ -183,7 +183,7 @@ impl<P, O> WriteBarrier<P, O> {
                 return None;
             } else {
                 // leader of next write group.
-                let _t = StopWatch::new(perf_context!(write_leader_wait_nanos));
+                let _t = StopWatch::new(perf_context!(write_leader_wait_duration));
                 inner.pending_leader.set(node);
                 inner
                     .pending_index

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -511,10 +511,7 @@ fn test_concurrent_write_perf_context() {
     for th in ths {
         let (old, new) = th.join().unwrap();
         assert_ne!(old.log_populating_duration, new.log_populating_duration);
-        assert_ne!(
-            old.write_leader_wait_duration,
-            new.write_leader_wait_duration
-        );
+        assert_ne!(old.write_wait_duration, new.write_wait_duration);
         assert_ne!(old.log_write_duration, new.log_write_duration);
         assert_ne!(old.apply_duration, new.apply_duration);
     }


### PR DESCRIPTION
This PR tries to add RocksDB-like perf contexts to Raft Engine.

Now, I only add these statistics:

- `log_populating_nanos`
- `write_leader_wait_nanos`
- `log_write_nanos`
- `log_rotate_nanos`
- `log_sync_nanos`
- `write_apply_nanos`

I'm willing to know if there are other important metrics that is worth recording here.