### PR TITLE
Add metadata deletion capability to `FileSystem` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
 
+### Public API Changes
+
+* Add `delete` to `FileSystem` trait API.
+
 ## [0.2.0] - 2022-05-25
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Public API Changes
 
-* Add `delete` to `FileSystem` trait API.
+* Add metadata deletion capability to `FileSystem` trait. Users can implement `exists_metadata` and `delete_metadata` to clean up obsolete metadata from older versions of Raft Engine.
 
 ## [0.2.0] - 2022-05-25
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1618,6 +1618,7 @@ mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
+            purge_threshold: ReadableSize(1),
             ..Default::default()
         };
         let fs = Arc::new(ObfuscatedFileSystem::default());
@@ -1629,6 +1630,9 @@ mod tests {
         for rid in 1..=5 {
             engine.clean(rid);
         }
+        let (start, _) = engine.file_span(LogQueue::Append);
+        engine.purge_expired_files().unwrap();
+        assert!(start < engine.file_span(LogQueue::Append).0);
         assert_eq!(engine.file_count(None), fs.file_count());
         let engine = engine.reopen();
         assert_eq!(engine.file_count(None), fs.file_count());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1695,7 +1695,7 @@ mod tests {
         }
 
         fn delete_metadata<P: AsRef<Path>>(&self, path: P) -> std::io::Result<bool> {
-            Ok(self.inner.delete_metadata(&path)? || self.update_metadata(path.as_ref(), true))
+            Ok(self.inner.delete_metadata(&path)? | self.update_metadata(path.as_ref(), true))
         }
 
         fn exists_metadata<P: AsRef<Path>>(&self, path: P) -> bool {
@@ -1747,12 +1747,18 @@ mod tests {
         assert!(start < engine.file_span(LogQueue::Append).0);
         assert_eq!(engine.file_count(None), fs.inner.file_count());
         let (start, _) = engine.file_span(LogQueue::Append);
-        assert_eq!(fs.append_metadata.lock().unwrap().first().unwrap(), &start);
+        assert_eq!(
+            fs.append_metadata.lock().unwrap().iter().next().unwrap(),
+            &start
+        );
 
         let engine = engine.reopen();
         assert_eq!(engine.file_count(None), fs.inner.file_count());
         let (start, _) = engine.file_span(LogQueue::Append);
-        assert_eq!(fs.append_metadata.lock().unwrap().first().unwrap(), &start);
+        assert_eq!(
+            fs.append_metadata.lock().unwrap().iter().next().unwrap(),
+            &start
+        );
 
         // Simulate stale metadata.
         for i in start / 2..start {
@@ -1760,6 +1766,9 @@ mod tests {
         }
         let engine = engine.reopen();
         let (start, _) = engine.file_span(LogQueue::Append);
-        assert_eq!(fs.append_metadata.lock().unwrap().first().unwrap(), &start);
+        assert_eq!(
+            fs.append_metadata.lock().unwrap().iter().next().unwrap(),
+            &start
+        );
     }
 }

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -272,6 +272,10 @@ impl FileSystem for DefaultFileSystem {
         LogFd::open(path.as_ref())
     }
 
+    fn delete<P: AsRef<Path>>(&self, path: P) -> IoResult<()> {
+        std::fs::remove_file(path)
+    }
+
     fn new_reader(&self, handle: Arc<Self::Handle>) -> IoResult<Self::Reader> {
         Ok(LogFile::new(handle))
     }

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -17,9 +17,29 @@ pub trait FileSystem: Send + Sync {
     type Writer: Seek + Write + Send + WriteExt;
 
     fn create<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle>;
+
     fn open<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle>;
+
     fn delete<P: AsRef<Path>>(&self, path: P) -> Result<()>;
+
+    /// Deletes user implemented metadata associated with `path`. Returns
+    /// `true` if any metadata is deleted.
+    ///
+    /// In older versions of Raft Engine, physical files are deleted without
+    /// going through user implemented cleanup procedure. This method is used to
+    /// detect and cleanup the user metadata that is no longer mapped to a
+    /// physical file.
+    fn delete_metadata<P: AsRef<Path>>(&self, _path: P) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Returns whether there is any user metadata associated with given `path`.
+    fn exists_metadata<P: AsRef<Path>>(&self, _path: P) -> bool {
+        false
+    }
+
     fn new_reader(&self, handle: Arc<Self::Handle>) -> Result<Self::Reader>;
+
     fn new_writer(&self, handle: Arc<Self::Handle>) -> Result<Self::Writer>;
 }
 

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -18,6 +18,7 @@ pub trait FileSystem: Send + Sync {
 
     fn create<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle>;
     fn open<P: AsRef<Path>>(&self, path: P) -> Result<Self::Handle>;
+    fn delete<P: AsRef<Path>>(&self, path: P) -> Result<()>;
     fn new_reader(&self, handle: Arc<Self::Handle>) -> Result<Self::Reader>;
     fn new_writer(&self, handle: Arc<Self::Handle>) -> Result<Self::Writer>;
 }

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.inner.
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::path::Path;

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -1,7 +1,8 @@
-// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.inner.
 
 use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use crate::env::{DefaultFileSystem, FileSystem, WriteExt};
@@ -68,11 +69,23 @@ impl WriteExt for ObfuscatedWriter {
 /// `[ObfuscatedFileSystem]` is a special implementation of `[FileSystem]`,
 /// which is used for constructing and simulating an abnormal file system for
 /// `[Read]` and `[Write]`.
-pub struct ObfuscatedFileSystem(DefaultFileSystem);
+pub struct ObfuscatedFileSystem {
+    inner: DefaultFileSystem,
+    files: AtomicUsize,
+}
 
 impl Default for ObfuscatedFileSystem {
     fn default() -> Self {
-        ObfuscatedFileSystem(DefaultFileSystem)
+        ObfuscatedFileSystem {
+            inner: DefaultFileSystem,
+            files: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl ObfuscatedFileSystem {
+    pub fn file_count(&self) -> usize {
+        self.files.load(Ordering::Relaxed)
     }
 }
 
@@ -82,18 +95,30 @@ impl FileSystem for ObfuscatedFileSystem {
     type Writer = ObfuscatedWriter;
 
     fn create<P: AsRef<Path>>(&self, path: P) -> IoResult<Self::Handle> {
-        self.0.create(path)
+        let r = self.inner.create(path);
+        if r.is_ok() {
+            self.files.fetch_add(1, Ordering::Relaxed);
+        }
+        r
     }
 
     fn open<P: AsRef<Path>>(&self, path: P) -> IoResult<Self::Handle> {
-        self.0.open(path)
+        self.inner.open(path)
+    }
+
+    fn delete<P: AsRef<Path>>(&self, path: P) -> IoResult<()> {
+        let r = self.inner.delete(path);
+        if r.is_ok() {
+            self.files.fetch_sub(1, Ordering::Relaxed);
+        }
+        r
     }
 
     fn new_reader(&self, inner: Arc<Self::Handle>) -> IoResult<Self::Reader> {
-        Ok(ObfuscatedReader(self.0.new_reader(inner)?))
+        Ok(ObfuscatedReader(self.inner.new_reader(inner)?))
     }
 
     fn new_writer(&self, inner: Arc<Self::Handle>) -> IoResult<Self::Writer> {
-        Ok(ObfuscatedWriter(self.0.new_writer(inner)?))
+        Ok(ObfuscatedWriter(self.inner.new_writer(inner)?))
     }
 }

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -114,11 +114,11 @@ impl FileSystem for ObfuscatedFileSystem {
         r
     }
 
-    fn new_reader(&self, inner: Arc<Self::Handle>) -> IoResult<Self::Reader> {
-        Ok(ObfuscatedReader(self.inner.new_reader(inner)?))
+    fn new_reader(&self, handle: Arc<Self::Handle>) -> IoResult<Self::Reader> {
+        Ok(ObfuscatedReader(self.inner.new_reader(handle)?))
     }
 
-    fn new_writer(&self, inner: Arc<Self::Handle>) -> IoResult<Self::Writer> {
-        Ok(ObfuscatedWriter(self.inner.new_writer(inner)?))
+    fn new_writer(&self, handle: Arc<Self::Handle>) -> IoResult<Self::Writer> {
+        Ok(ObfuscatedWriter(self.inner.new_writer(handle)?))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@
 #![cfg_attr(feature = "swap", feature(nonnull_slice_from_raw_parts))]
 #![cfg_attr(feature = "swap", feature(slice_ptr_len))]
 #![cfg_attr(feature = "swap", feature(alloc_layout_extra))]
-// For testing only.
-#![cfg_attr(feature = "swap", feature(alloc_error_hook))]
-#![cfg_attr(feature = "swap", feature(cfg_sanitize))]
+#![cfg_attr(all(test, feature = "nightly"), feature(map_first_last))]
+#![cfg_attr(all(test, feature = "swap"), feature(alloc_error_hook))]
+#![cfg_attr(all(test, feature = "swap"), feature(cfg_sanitize))]
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 #![cfg_attr(feature = "swap", feature(nonnull_slice_from_raw_parts))]
 #![cfg_attr(feature = "swap", feature(slice_ptr_len))]
 #![cfg_attr(feature = "swap", feature(alloc_layout_extra))]
-#![cfg_attr(all(test, feature = "nightly"), feature(map_first_last))]
 #![cfg_attr(all(test, feature = "swap"), feature(alloc_error_hook))]
 #![cfg_attr(all(test, feature = "swap"), feature(cfg_sanitize))]
 

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -373,7 +373,7 @@ fn test_incomplete_purge() {
     let engine = Engine::open(cfg.clone()).unwrap();
 
     {
-        let _f = FailGuard::new("file_pipe_log::remove_file_failure", "return");
+        let _f = FailGuard::new("file_pipe_log::remove_file_skipped", "return");
         append(&engine, rid, 0, 20, Some(&data));
         let append_first = engine.file_span(LogQueue::Append).0;
         engine.compact_to(rid, 18);


### PR DESCRIPTION
User should be allowed to manage file deletion. For example, in TiKV, file encryption key can be deleted once the corresponding file is deleted.