### PR TITLE
simplify `delete_metadata` trait method

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1694,8 +1694,10 @@ mod tests {
             Ok(())
         }
 
-        fn delete_metadata<P: AsRef<Path>>(&self, path: P) -> std::io::Result<bool> {
-            Ok(self.inner.delete_metadata(&path)? | self.update_metadata(path.as_ref(), true))
+        fn delete_metadata<P: AsRef<Path>>(&self, path: P) -> std::io::Result<()> {
+            self.inner.delete_metadata(&path)?;
+            self.update_metadata(path.as_ref(), true);
+            Ok(())
         }
 
         fn exists_metadata<P: AsRef<Path>>(&self, path: P) -> bool {

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -29,8 +29,8 @@ pub trait FileSystem: Send + Sync {
     /// going through user implemented cleanup procedure. This method is used to
     /// detect and cleanup the user metadata that is no longer mapped to a
     /// physical file.
-    fn delete_metadata<P: AsRef<Path>>(&self, _path: P) -> Result<bool> {
-        Ok(false)
+    fn delete_metadata<P: AsRef<Path>>(&self, _path: P) -> Result<()> {
+        Ok(())
     }
 
     /// Returns whether there is any user metadata associated with given `path`.

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -173,14 +173,11 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                     for seq in start..min_id {
                         let file_id = FileId { queue, seq };
                         let path = file_id.build_file_path(dir);
-                        match self.file_system.delete_metadata(&path) {
-                            Err(e) => {
-                                error!("failed to delete metadata of {}: {}.", path.display(), e);
-                                break;
-                            }
-                            Ok(true) => success += 1,
-                            _ => {}
+                        if let Err(e) = self.file_system.delete_metadata(&path) {
+                            error!("failed to delete metadata of {}: {}.", path.display(), e);
+                            break;
                         }
+                        success += 1;
                     }
                     warn!(
                         "deleted {} stale files of {:?} in range [{}, {}).",


### PR DESCRIPTION
There is no reason to return `exist` when we already have `exists_metadata` method.

Signed-off-by: tabokie <xy.tao@outlook.com>