### PR TITLE
fix issue in append_compact_purge example

### DIFF
--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -51,11 +51,11 @@ fn main() {
     loop {
         for _ in 0..1024 {
             let region = rand_regions.next().unwrap();
-            let state = engine
+            let mut state = engine
                 .get_message::<RaftLocalState>(region, b"last_index")
                 .unwrap()
                 .unwrap_or_else(|| init_state.clone());
-
+            state.last_index += 1; // manually update the state
             let mut e = entry.clone();
             e.index = state.last_index + 1;
             batch.add_entries::<MessageExtTyped>(region, &[e]).unwrap();

--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -55,9 +55,10 @@ fn main() {
                 .get_message::<RaftLocalState>(region, b"last_index")
                 .unwrap()
                 .unwrap_or_else(|| init_state.clone());
+
             state.last_index += 1; // manually update the state
             let mut e = entry.clone();
-            e.index = state.last_index + 1;
+            e.index = state.last_index;
             batch.add_entries::<MessageExtTyped>(region, &[e]).unwrap();
             batch
                 .put_message(region, b"last_index".to_vec(), &state)


### PR DESCRIPTION
## Brief description

This commit is used to close #239.

Signed-off-by: Lucasliang <nkcs_lykx@hotmail.com>

## Codes update
```Rust
diff --git a/examples/append_compact_purge.rs b/examples/append_compact_purge.rs
index b9ebc1a..0565e44 100644
--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -51,11 +51,11 @@ fn main() {
     loop {
         for _ in 0..1024 {
             let region = rand_regions.next().unwrap();
-            let state = engine
+            let mut state = engine
                 .get_message::<RaftLocalState>(region, b"last_index")
                 .unwrap()
                 .unwrap_or_else(|| init_state.clone());
-
+            state.last_index += 1; // manually update the state
             let mut e = entry.clone();
             e.index = state.last_index + 1;
             batch.add_entries::<MessageExtTyped>(region, &[e]).unwrap();
```

## Prints for bugfix
With this patch, the logging of `append_compact_purge` will contain:
```shell
[EXAMPLE] compact 298 to 192
[EXAMPLE] compact 56 to 631
[EXAMPLE] compact 262 to 321
[EXAMPLE] compact 80 to 758
[EXAMPLE] compact 177 to 800
[EXAMPLE] compact 150 to 803
[EXAMPLE] compact 257 to 365
[EXAMPLE] compact 66 to 700
[EXAMPLE] compact 151 to 841
[EXAMPLE] compact 205 to 628
```
And the above prints are expected.