### PR TITLE
refactor: catch errno EINTR when reading and writing files instead of EAGAIN

### DIFF
--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -100,7 +100,7 @@ impl LogFd {
             });
             let bytes = match pread(self.0, &mut buf[readed..], offset as i64) {
                 Ok(bytes) => bytes,
-                Err(e) if e == Errno::EAGAIN => continue,
+                Err(e) if e == Errno::EINTR => continue,
                 Err(e) => return Err(from_nix_error(e, "pread")),
             };
             // EOF
@@ -121,7 +121,7 @@ impl LogFd {
         while written < content.len() {
             let bytes = match pwrite(self.0, &content[written..], offset as i64) {
                 Ok(bytes) => bytes,
-                Err(e) if e == Errno::EAGAIN => continue,
+                Err(e) if e == Errno::EINTR => continue,
                 Err(e) => return Err(from_nix_error(e, "pwrite")),
             };
             if bytes == 0 {


### PR DESCRIPTION
EAGAIN error code Appears only when the O_NONBLOCK option is set and there is no more content in the file to read.
If a read() is interrupted by a signal before it reads any data, it shall return -1 with errno set to [EINTR].