### PR TITLE
Support reading block based log format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ fail = "0.5"
 fs2 = "0.4"
 hashbrown = "0.12"
 hex = "0.4"
-if_chain = "1.0.2"
+if_chain = "1.0"
 lazy_static = "1.3"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ fail = "0.5"
 fs2 = "0.4"
 hashbrown = "0.12"
 hex = "0.4"
+if_chain = "1.0.2"
 lazy_static = "1.3"
 libc = "0.2"
 log = { version = "0.4", features = ["max_level_trace", "release_max_level_debug"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,6 +168,12 @@ impl Config {
                 ));
             }
         }
+        if !self.format_data_layout.is_enabled() {
+            return Err(box_err!(
+                "format_data_layout: {:?} is not support to be enabled",
+                self.format_data_layout
+            ));
+        }
         #[cfg(not(feature = "swap"))]
         if self.memory_limit.is_some() {
             warn!("memory-limit will be ignored because swap feature is not enabled");
@@ -285,7 +291,7 @@ mod tests {
     }
 
     #[test]
-    fn test_setting_on_alignment_mode() {
+    fn test_format_data_layout() {
         // "no-alignment" data_layout - default
         {
             let default_cfg = r#"
@@ -295,14 +301,22 @@ mod tests {
             load.sanitize().unwrap();
             assert_eq!(load.format_data_layout, DataLayout::NoAlignment);
         }
-        // "alignment"
+        // "align-with-integration"
         {
             let cfg = r#"
-                format-data-layout = "alignment"
+                format-data-layout = "align-with-integration"
             "#;
             let mut load: Config = toml::from_str(cfg).unwrap();
             load.sanitize().unwrap();
-            assert_eq!(load.format_data_layout, DataLayout::Alignment);
+            assert_eq!(load.format_data_layout, DataLayout::AlignWithIntegration);
+        }
+        // "align-with-fragments"
+        {
+            let cfg = r#"
+                format-data-layout = "align-with-fragments"
+            "#;
+            let mut load: Config = toml::from_str(cfg).unwrap();
+            assert!(load.sanitize().is_err());
         }
         // abnormal
         {
@@ -314,7 +328,7 @@ mod tests {
             assert_eq!(load.format_data_layout, DataLayout::NoAlignment);
 
             let abnormal_cfg_2 = r#"
-                format-data-layout = "alignments"
+                format-data-layout = "aligned-with-fragment"
             "#;
             assert!(toml::from_str::<Config>(abnormal_cfg_2).is_err());
         }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -459,7 +459,7 @@ where
             ..Default::default()
         };
         let recovery_mode = cfg.recovery_mode;
-        let file_format = LogFileFormat::new(cfg.format_version, DataLayout::default());
+        let file_format = LogFileFormat::new(cfg.format_version, DataLayout::NoAlignment);
         let read_block_size = cfg.recovery_read_block_size.0;
         let mut builder = FilePipeLogBuilder::new(cfg, file_system.clone(), Vec::new());
         builder.scan()?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -458,6 +458,7 @@ where
             ..Default::default()
         };
         let recovery_mode = cfg.recovery_mode;
+        let format_data_layout = cfg.format_data_layout;
         let read_block_size = cfg.recovery_read_block_size.0;
         let mut builder = FilePipeLogBuilder::new(cfg, file_system.clone(), Vec::new());
         builder.scan()?;
@@ -469,6 +470,7 @@ where
                 RecoveryConfig {
                     queue: LogQueue::Append,
                     mode: recovery_mode,
+                    data_layout: format_data_layout,
                     concurrency: 1,
                     read_block_size,
                 },
@@ -481,6 +483,7 @@ where
                 RecoveryConfig {
                     queue: LogQueue::Rewrite,
                     mode: recovery_mode,
+                    data_layout: format_data_layout,
                     concurrency: 1,
                     read_block_size,
                 },

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -443,7 +443,7 @@ where
         script: String,
         file_system: Arc<F>,
     ) -> Result<()> {
-        use crate::file_pipe_log::{RecoveryConfig, ReplayMachine};
+        use crate::file_pipe_log::{LogFileFormat, RecoveryConfig, ReplayMachine};
         use crate::pipe_log::DataLayout;
 
         if !path.exists() {
@@ -459,7 +459,7 @@ where
             ..Default::default()
         };
         let recovery_mode = cfg.recovery_mode;
-        let format_data_layout = DataLayout::default();
+        let file_format = LogFileFormat::new(cfg.format_version, DataLayout::default());
         let read_block_size = cfg.recovery_read_block_size.0;
         let mut builder = FilePipeLogBuilder::new(cfg, file_system.clone(), Vec::new());
         builder.scan()?;
@@ -471,7 +471,7 @@ where
                 RecoveryConfig {
                     queue: LogQueue::Append,
                     mode: recovery_mode,
-                    data_layout: format_data_layout,
+                    file_format,
                     concurrency: 1,
                     read_block_size,
                 },
@@ -484,7 +484,7 @@ where
                 RecoveryConfig {
                     queue: LogQueue::Rewrite,
                     mode: recovery_mode,
-                    data_layout: format_data_layout,
+                    file_format,
                     concurrency: 1,
                     read_block_size,
                 },

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -192,8 +192,8 @@ impl LogFileFormat {
                 // Here, we mark this special err, that is, corrupted `payload`,
                 // with InvalidArgument.
                 Err(Error::InvalidArgument(format!(
-                    "invalid data_layout in the header, len: {}",
-                    buf_len - Self::header_len()
+                    "invalid dataload in the header, len: {}, expected len: {}",
+                    buf_len - Self::header_len(), Self::payload_len(version)
                 )))
             }
         }

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -267,6 +267,7 @@ mod tests {
                 (100 & LOG_FILE_HEADER_VERSION_MASK) /* abnormal version */
                     | ((DataLayout::AlignWithFragments as u64) << 56)
             };
+            buf.extend_from_slice(LOG_FILE_MAGIC_HEADER);
             assert!(buf.encode_u64(format_content).is_ok());
             assert!(LogFileFormat::decode(&mut &buf[..]).is_err());
         }
@@ -277,6 +278,7 @@ mod tests {
                 (Version::V2.to_u64().unwrap() & LOG_FILE_HEADER_VERSION_MASK) | ((100_u64) << 56)
                 /* abnormal data_layout */
             };
+            buf.extend_from_slice(LOG_FILE_MAGIC_HEADER);
             assert!(buf.encode_u64(format_content).is_ok());
             assert!(LogFileFormat::decode(&mut &buf[..]).is_err());
         }

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -256,6 +256,7 @@ impl LogFileFormat {
 mod tests {
     use super::*;
     use crate::pipe_log::LogFileContext;
+    use crate::test_util::catch_unwind_silent;
 
     #[test]
     fn test_check_paddings_is_valid() {
@@ -389,10 +390,7 @@ mod tests {
         // header with Version::V2 and DataLayout::Alignment(0)
         {
             let file_format = LogFileFormat::new(Version::V2, DataLayout::Alignment(0));
-            assert_eq!(
-                LogFileFormat::new(Version::V2, DataLayout::NoAlignment),
-                enc_dec_file_format(file_format).unwrap()
-            );
+            catch_unwind_silent(|| enc_dec_file_format(file_format)).unwrap_err();
         }
     }
 

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -253,19 +253,11 @@ mod tests {
             assert!(file_format.encode(&mut buf).is_ok());
             LogFileFormat::decode(&mut &buf[..])
         }
-        // DataLayout::default() -> NoAlignment
-        {
-            let mut file_format = LogFileFormat::new(Version::default(), DataLayout::default());
-            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
-            file_format = LogFileFormat::new(Version::V2, DataLayout::default());
-            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
-        }
-        // DataLayout::Alignment
-        {
-            let mut file_format = LogFileFormat::new(Version::default(), DataLayout::Alignment);
-            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
-            file_format = LogFileFormat::new(Version::V2, DataLayout::Alignment);
-            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+        for version in Version::iter() {
+            for layout in DataLayout::iter() {
+                let file_format = LogFileFormat::new(version, layout);
+                assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+            }
         }
     }
 

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::codec::{self, NumberEncoder};
-use crate::pipe_log::{FileId, LogQueue, Version};
+use crate::pipe_log::{DataLayout, FileId, LogQueue, Version};
 use crate::{Error, Result};
 
 /// Width to format log sequence number.
@@ -19,6 +19,8 @@ const LOG_APPEND_SUFFIX: &str = ".raftlog";
 const LOG_REWRITE_SUFFIX: &str = ".rewrite";
 /// File header.
 const LOG_FILE_MAGIC_HEADER: &[u8] = b"RAFT-LOG-FILE-HEADER-9986AB3E47F320B394C8E84916EB0ED5";
+/// Mask of Version
+const LOG_FILE_HEADER_VERSION_MASK: u64 = 0x00FFFFFFFFFFFFFF;
 
 /// `FileNameExt` offers file name formatting extensions to [`FileId`].
 pub trait FileNameExt: Sized {
@@ -79,23 +81,38 @@ pub(super) fn lock_file_path<P: AsRef<Path>>(dir: P) -> PathBuf {
 }
 
 /// In-memory representation of `Format` in log files.
-#[derive(Clone, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 pub struct LogFileFormat {
     version: Version,
+    data_layout: DataLayout,
 }
 
 impl LogFileFormat {
+    pub fn new(version: Version, data_layout: DataLayout) -> Self {
+        Self {
+            version,
+            data_layout,
+        }
+    }
+
     /// Length of header written on storage.
     pub const fn len() -> usize {
         LOG_FILE_MAGIC_HEADER.len() + std::mem::size_of::<Version>()
     }
 
     pub fn from_version(version: Version) -> Self {
-        Self { version }
+        Self {
+            version,
+            data_layout: DataLayout::default(),
+        }
     }
 
     pub fn version(&self) -> Version {
         self.version
+    }
+
+    pub fn data_layout(&self) -> DataLayout {
+        self.data_layout
     }
 
     /// Decodes a slice of bytes into a `LogFileFormat`.
@@ -109,21 +126,32 @@ impl LogFileFormat {
             ));
         }
         buf.consume(LOG_FILE_MAGIC_HEADER.len());
-        let v = codec::decode_u64(buf)?;
-        if let Some(version) = Version::from_u64(v) {
-            Ok(Self { version })
-        } else {
-            Err(Error::Corruption(format!(
-                "unrecognized log file version: {}",
-                v
-            )))
+        // Raw content of LogFileFormat
+        let format_content = codec::decode_u64(buf)?;
+        let version = Version::from_u64(format_content & LOG_FILE_HEADER_VERSION_MASK);
+        let data_layout =
+            DataLayout::from_u8(((format_content & !LOG_FILE_HEADER_VERSION_MASK) >> 56) as u8);
+        if version.is_none() || data_layout.is_none() {
+            return Err(Error::Corruption(format!(
+                "unrecognized log file header, version: {}, data_layout: {}",
+                format_content & LOG_FILE_HEADER_VERSION_MASK,
+                ((format_content & !LOG_FILE_HEADER_VERSION_MASK) >> 56) as u8
+            )));
         }
+        Ok(Self {
+            version: version.unwrap(),
+            data_layout: data_layout.unwrap(),
+        })
     }
 
     /// Encodes this header and appends the bytes to the provided buffer.
     pub fn encode(&self, buf: &mut Vec<u8>) -> Result<()> {
         buf.extend_from_slice(LOG_FILE_MAGIC_HEADER);
-        buf.encode_u64(self.version.to_u64().unwrap())?;
+        let format_content: u64 = {
+            (self.version.to_u64().unwrap() & LOG_FILE_HEADER_VERSION_MASK)
+                | ((self.data_layout.to_u8() as u64) << 56)
+        };
+        buf.encode_u64(format_content)?;
         let corrupted = || {
             fail::fail_point!("log_file_header::corrupted", |_| true);
             false
@@ -176,19 +204,45 @@ mod tests {
     fn test_file_header() {
         let header1 = LogFileFormat::default();
         assert_eq!(header1.version().to_u64().unwrap(), 1);
+        assert_eq!(header1.data_layout().to_u8(), 0);
         let header2 = LogFileFormat::from_version(Version::default());
         assert_eq!(header2.version().to_u64(), header1.version().to_u64());
-        let header3 = LogFileFormat::from_version(Version::default());
+        assert_eq!(header1.data_layout().to_u8(), 0);
+        let header3 = LogFileFormat::from_version(header1.version());
         assert_eq!(header3.version(), header1.version());
+        assert_eq!(header1.data_layout().to_u8(), 0);
+    }
+
+    #[test]
+    fn test_encoding_decoding_file_format() {
+        fn enc_dec_file_format(file_format: LogFileFormat) -> Result<LogFileFormat> {
+            let mut buf = Vec::with_capacity(LogFileFormat::len());
+            assert!(file_format.encode(&mut buf).is_ok());
+            LogFileFormat::decode(&mut &buf[..])
+        }
+        // DataLayout::default() -> NoAlignment
+        {
+            let mut file_format = LogFileFormat::new(Version::default(), DataLayout::default());
+            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+            file_format = LogFileFormat::new(Version::V2, DataLayout::default());
+            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+        }
+        // DataLayout::Alignment
+        {
+            let mut file_format = LogFileFormat::new(Version::default(), DataLayout::Alignment);
+            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+            file_format = LogFileFormat::new(Version::V2, DataLayout::Alignment);
+            assert_eq!(file_format, enc_dec_file_format(file_format).unwrap());
+        }
     }
 
     #[test]
     fn test_file_context() {
         let mut file_context =
-            LogFileContext::new(FileId::dummy(LogQueue::Append), Version::default());
+            LogFileContext::new(FileId::dummy(LogQueue::Append), LogFileFormat::default());
         assert_eq!(file_context.get_signature(), None);
         file_context.id.seq = 10;
-        file_context.version = Version::V2;
+        file_context.format.version = Version::V2;
         assert_eq!(file_context.get_signature().unwrap(), 10);
         let abnormal_seq = (file_context.id.seq << 32) as u64 + 100_u64;
         file_context.id.seq = abnormal_seq;

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -20,7 +20,7 @@ use super::format::{LogFileFormat, LOG_FILE_HEADER_ALIGNMENT_SIZE};
 const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
 
 /// Default alignment size.
-pub(crate) const FILE_ALIGNMENT_SIZE: usize = 32768; // 16kb as default
+pub(crate) const FILE_ALIGNMENT_SIZE: usize = 32768; // 32kb as default
 
 /// Combination of `[Handle]` and `[Version]`, specifying a handler of a file.
 #[derive(Debug)]
@@ -240,9 +240,8 @@ impl<F: FileSystem> LogFileReader<F> {
         match self.format.data_layout() {
             DataLayout::AlignWithFragments | DataLayout::AlignWithIntegration => {
                 // Meet the prerequisite when `data_layout == AlignWithXXX`.
-                debug_assert!(offset == 0 || offset & (offset - 1) == 0);
-                let len = buf.len();
-                debug_assert!(len & (len - 1) == 0);
+                debug_assert!(offset % FILE_ALIGNMENT_SIZE as u64 == 0);
+                debug_assert!(buf.len() % FILE_ALIGNMENT_SIZE == 0);
             }
             _ => {}
         }

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -11,9 +11,10 @@ use log::warn;
 use crate::env::{FileSystem, Handle, WriteExt};
 use crate::metrics::*;
 use crate::pipe_log::{FileBlockHandle, LogFileContext};
+use crate::util::round_up;
 use crate::{Error, Result};
 
-use super::format::LogFileFormat;
+use super::format::{LogFileFormat, LOG_FILE_HEADER_ALIGNMENT_SIZE};
 
 /// Maximum number of bytes to allocate ahead.
 const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
@@ -246,7 +247,7 @@ impl<F: FileSystem> LogFileReader<F> {
             return Err(Error::Corruption("Invalid header of LogFile!".to_owned()));
         }
         // [2] Parse the header of the file.
-        let mut container = vec![0; header_len];
+        let mut container = vec![0; round_up(header_len, LOG_FILE_HEADER_ALIGNMENT_SIZE)];
         self.read_to(0, &mut container[..])?;
         self.format = LogFileFormat::decode(&mut container.as_slice())?;
         Ok(self.format)

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -253,7 +253,8 @@ impl<F: FileSystem> LogFileReader<F> {
         // [2] Parse the format of the file.
         let mut container =
             vec![0; LogFileFormat::header_len() + LogFileFormat::payload_len(Version::V2)];
-        self.read_to(0, &mut container[..])?;
+        let size = self.read_to(0, &mut container[..])?;
+        container.truncate(size);
         self.format = LogFileFormat::decode(&mut container.as_slice())?;
         Ok(self.format)
     }

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -100,11 +100,6 @@ impl<F: FileSystem> LogFileWriter<F> {
     }
 
     pub fn write(&mut self, buf: &[u8], target_size_hint: usize) -> Result<()> {
-        // @lucasliang, TODO:
-        // Implement the writing strategy for DataLayout::Alignment,
-        // considering that records in log files might be fragmented.
-        // Referring to the design of WAL in rocksdb:
-        // [https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log-File-Format].
         let new_written = self.written + buf.len();
         if self.capacity < new_written {
             let _t = StopWatch::new(&*LOG_ALLOCATE_DURATION_HISTOGRAM);

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -25,10 +25,10 @@ pub mod debug {
 
     use crate::env::FileSystem;
     use crate::log_batch::LogItem;
-    use crate::pipe_log::{FileId, Version};
+    use crate::pipe_log::FileId;
     use crate::{Error, Result};
 
-    use super::format::FileNameExt;
+    use super::format::{FileNameExt, LogFileFormat};
     use super::log_file::{LogFileReader, LogFileWriter};
     use super::reader::LogItemBatchFileReader;
 
@@ -38,7 +38,7 @@ pub mod debug {
     pub fn build_file_writer<F: FileSystem>(
         file_system: &F,
         path: &Path,
-        version: Version,
+        format: LogFileFormat,
         create: bool,
     ) -> Result<LogFileWriter<F>> {
         let fd = if create {
@@ -47,7 +47,7 @@ pub mod debug {
             file_system.open(path)?
         };
         let fd = Arc::new(fd);
-        super::log_file::build_file_writer(file_system, fd, version, create)
+        super::log_file::build_file_writer(file_system, fd, format, create)
     }
 
     /// Opens a log file for read.
@@ -212,11 +212,11 @@ pub mod debug {
                 let mut writer = build_file_writer(
                     file_system.as_ref(),
                     &file_path,
-                    Version::default(),
+                    LogFileFormat::default(),
                     true, /* create */
                 )
                 .unwrap();
-                let log_file_format = LogFileContext::new(file_id, Version::default());
+                let log_file_format = LogFileContext::new(file_id, LogFileFormat::default());
                 for batch in bs.iter_mut() {
                     let offset = writer.offset() as u64;
                     let len = batch
@@ -278,7 +278,7 @@ pub mod debug {
             let mut writer = build_file_writer(
                 file_system.as_ref(),
                 &empty_file_path,
-                Version::default(),
+                LogFileFormat::default(),
                 true, /* create */
             )
             .unwrap();

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -14,7 +14,9 @@ use crate::config::Config;
 use crate::env::FileSystem;
 use crate::event_listener::EventListener;
 use crate::metrics::*;
-use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogFileContext, LogQueue, PipeLog};
+use crate::pipe_log::{
+    DataLayout, FileBlockHandle, FileId, FileSeq, LogFileContext, LogQueue, PipeLog,
+};
 use crate::{perf_context, Error, Result};
 
 use super::format::{FileNameExt, LogFileFormat};
@@ -145,7 +147,11 @@ impl<F: FileSystem> SinglePipe<F> {
                 handle: fd,
                 context: LogFileContext::new(
                     file_id,
-                    LogFileFormat::new(cfg.format_version, cfg.format_data_layout),
+                    LogFileFormat::new(
+                        cfg.format_version,
+                        /* @lucasliang, TODO: should determined by whether DIO is open. */
+                        DataLayout::default(),
+                    ),
                 ),
             });
             first_seq
@@ -175,7 +181,11 @@ impl<F: FileSystem> SinglePipe<F> {
         let pipe = Self {
             queue,
             dir: cfg.dir.clone(),
-            file_format: LogFileFormat::new(cfg.format_version, cfg.format_data_layout),
+            file_format: LogFileFormat::new(
+                cfg.format_version,
+                /* @lucasliang, TODO: should determined by whether DIO is open. */
+                DataLayout::default(),
+            ),
             target_file_size: cfg.target_file_size.0 as usize,
             bytes_per_sync: cfg.bytes_per_sync.0 as usize,
             file_system,

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -147,7 +147,7 @@ impl<F: FileSystem> SinglePipe<F> {
             if fs_block_size > 0 && LogFileFormat::payload_len(cfg.format_version) > 0 {
                 DataLayout::Alignment(fs_block_size as u64)
             } else {
-                DataLayout::default()
+                DataLayout::NoAlignment
             }
         };
         let create_file = first_seq == 0;
@@ -700,7 +700,7 @@ mod tests {
         // fetch active file
         let file_context = pipe_log.fetch_active_file(LogQueue::Append);
         assert_eq!(file_context.format.version(), Version::default());
-        assert_eq!(file_context.format.data_layout(), DataLayout::default());
+        assert_eq!(file_context.format.data_layout(), DataLayout::NoAlignment);
         assert_eq!(file_context.id.seq, 3);
     }
 
@@ -960,7 +960,7 @@ mod tests {
         // fetch active file
         let file_context = pipe_log.fetch_active_file(LogQueue::Append);
         assert_eq!(file_context.format.version(), Version::V2);
-        assert_eq!(file_context.format.data_layout(), DataLayout::default());
+        assert_eq!(file_context.format.data_layout(), DataLayout::NoAlignment);
         assert_eq!(file_context.id.seq, 3);
     }
 }

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -137,11 +137,11 @@ impl<F: FileSystem> SinglePipe<F> {
     ) -> Result<Self> {
         let data_layout = {
             let force_set_aligned_layout = || {
-                // @lucasliang, TODO: needs to get the block_size from file_system.
+                // TODO: needs to get the block_size from file_system.
                 fail_point!("file_pipe_log::open::force_set_aligned_layout", |_| { 16 });
                 0
             };
-            // @lucasliang, TODO: also need to check whether DIO is open or not. If DIO
+            // TODO: also need to check whether DIO is open or not. If DIO
             // == `on`, we could set the data_layout with `Alignment(_)`.
             let fs_block_size = force_set_aligned_layout();
             if fs_block_size > 0 && LogFileFormat::payload_len(cfg.format_version) > 0 {

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -305,7 +305,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                     let is_last_file = index == chunk_count - 1 && i == file_count - 1;
                     match build_file_reader(file_system.as_ref(), f.handle.clone(), None) {
                         Err(e) => {
-                            let is_local_tail = f.handle.file_size()? <= LogFileFormat::len();
+                            let is_local_tail = f.handle.file_size()? <= LogFileFormat::header_len();
                             if recovery_mode == RecoveryMode::TolerateAnyCorruption
                               || recovery_mode == RecoveryMode::TolerateTailCorruption
                                 && is_last_file && is_local_tail {

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -8,7 +8,6 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::Arc;
 
-use fail::fail_point;
 use fs2::FileExt;
 use log::{error, info, warn};
 use rayon::prelude::*;
@@ -17,7 +16,7 @@ use crate::config::{Config, RecoveryMode};
 use crate::env::FileSystem;
 use crate::event_listener::EventListener;
 use crate::log_batch::LogItemBatch;
-use crate::pipe_log::{DataLayout, FileId, FileSeq, LogFileContext, LogQueue, Version};
+use crate::pipe_log::{DataLayout, FileId, FileSeq, LogFileContext, LogQueue};
 use crate::util::Factory;
 use crate::{Error, Result};
 
@@ -62,7 +61,7 @@ pub struct RecoveryConfig {
     pub mode: RecoveryMode,
     /// @lucasliang
     /// TODO: This opt should defined by whether open DIO or not.
-    pub data_layout: DataLayout,
+    pub file_format: LogFileFormat,
     pub concurrency: usize,
     pub read_block_size: u64,
 }
@@ -232,16 +231,12 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                 }
                 _ => (threads, threads),
             };
-        let get_read_block_size = || {
-            fail_point!("file_pipe_log::recover::reset_read_block_size", |_| 16);
-            self.cfg.recovery_read_block_size.0
-        };
         let append_recovery_cfg = RecoveryConfig {
             queue: LogQueue::Append,
             mode: self.cfg.recovery_mode,
-            data_layout: DataLayout::default(),
+            file_format: LogFileFormat::new(self.cfg.format_version, DataLayout::default()),
             concurrency: append_concurrency,
-            read_block_size: get_read_block_size(),
+            read_block_size: self.cfg.recovery_read_block_size.0,
         };
         let rewrite_recovery_cfg = RecoveryConfig {
             queue: LogQueue::Rewrite,
@@ -251,8 +246,8 @@ impl<F: FileSystem> DualPipesBuilder<F> {
         let append_files = &mut self.append_files;
         let rewrite_files = &mut self.rewrite_files;
         let file_system = self.file_system.clone();
-        // As the `recover_queue` would update the `Version` of each log file in
-        // `apend_files` and `rewrite_files`, we re-design the implementation on
+        // As the `recover_queue` would update the `LogFileFormat` of each log file
+        // in `apend_files` and `rewrite_files`, we re-design the implementation on
         // `recover_queue` to make it compatiable to concurrent processing
         // with ThreadPool.
         let (append, rewrite) = pool.join(
@@ -291,8 +286,10 @@ impl<F: FileSystem> DualPipesBuilder<F> {
         let queue = recovery_cfg.queue;
         let concurrency = recovery_cfg.concurrency;
         let recovery_mode = recovery_cfg.mode;
-        let format_data_layout = recovery_cfg.data_layout;
+        let file_format = recovery_cfg.file_format;
         let recovery_read_block_size = recovery_cfg.read_block_size as usize;
+        let default_format_len =
+            LogFileFormat::header_len() + LogFileFormat::payload_len(file_format.version());
 
         let max_chunk_size = std::cmp::max((files.len() + concurrency - 1) / concurrency, 1);
         let chunks = files.par_chunks_mut(max_chunk_size);
@@ -309,7 +306,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                     let is_last_file = index == chunk_count - 1 && i == file_count - 1;
                     match build_file_reader(file_system.as_ref(), f.handle.clone(), None) {
                         Err(e) => {
-                            let is_local_tail = f.handle.file_size()? <= LogFileFormat::header_len();
+                            let is_local_tail = f.handle.file_size()? <= default_format_len;
                             if recovery_mode == RecoveryMode::TolerateAnyCorruption
                               || recovery_mode == RecoveryMode::TolerateTailCorruption
                                 && is_last_file && is_local_tail {
@@ -318,7 +315,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                                     queue, f.seq, e
                                 );
                                 f.handle.truncate(0)?;
-                                f.format = Some(LogFileFormat::new(Version::default(), format_data_layout));
+                                f.format = Some(file_format);
                                 continue;
                             } else {
                                 error!(

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -59,6 +59,8 @@ impl<M: ReplayMachine + Default> Factory<M> for DefaultMachineFactory<M> {
 pub struct RecoveryConfig {
     pub queue: LogQueue,
     pub mode: RecoveryMode,
+    /// @lucasliang
+    /// TODO: This opt should defined by whether open DIO or not.
     pub data_layout: DataLayout,
     pub concurrency: usize,
     pub read_block_size: u64,
@@ -233,7 +235,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
         let append_recovery_cfg = RecoveryConfig {
             queue: LogQueue::Append,
             mode: self.cfg.recovery_mode,
-            data_layout: self.cfg.format_data_layout,
+            data_layout: DataLayout::default(),
             concurrency: append_concurrency,
             read_block_size: self.cfg.recovery_read_block_size.0,
         };

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -233,7 +233,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
         let append_recovery_cfg = RecoveryConfig {
             queue: LogQueue::Append,
             mode: self.cfg.recovery_mode,
-            file_format: LogFileFormat::new(self.cfg.format_version, DataLayout::default()),
+            file_format: LogFileFormat::new(self.cfg.format_version, DataLayout::NoAlignment),
             concurrency: append_concurrency,
             read_block_size: self.cfg.recovery_read_block_size.0,
         };

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -303,15 +303,9 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                     let is_last_file = index == chunk_count - 1 && i == file_count - 1;
                     match build_file_reader(file_system.as_ref(), f.handle.clone(), None) {
                         Err(e) => {
-                            let mut is_local_tail = f.handle.file_size()? <= LogFileFormat::header_len();
-                            // If we parsed and got an corrupted `payload` from this file,
-                            // we also should mark it `is_local_tail = true`.
-                            if let Error::InvalidArgument(_) = e {
-                                is_local_tail = true;
-                            }
                             if recovery_mode == RecoveryMode::TolerateAnyCorruption
                               || recovery_mode == RecoveryMode::TolerateTailCorruption
-                                && is_last_file && is_local_tail {
+                                && is_last_file {
                                 warn!(
                                     "File header is corrupted but ignored: {:?}:{}, {}",
                                     queue, f.seq, e

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -84,9 +84,9 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
                     0,
                 )?) {
                     Err(e) => {
-                        // In DataLayout::Alignment mode, tail data in the previous block may be aligned
-                        // with paddings, that is '0'. So, we need to skip these redundant content and
-                        // get the next valid header of `LogBatch`.
+                        // In DataLayout::Alignment mode, tail data in the previous block may be
+                        // aligned with paddings, that is '0'. So, we need to skip these
+                        // redundant content and get the next valid header of `LogBatch`.
                         if DataLayout::Alignment
                             == self.file_context.as_ref().unwrap().format.data_layout()
                         {

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -42,7 +42,7 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
 
     /// Opens a file that can be accessed through the given reader.
     pub fn open(&mut self, file_id: FileId, reader: LogFileReader<F>) -> Result<()> {
-        self.file_context = Some(LogFileContext::new(file_id, reader.file_format().version()));
+        self.file_context = Some(LogFileContext::new(file_id, *reader.file_format()));
         self.size = reader.file_size()?;
         self.reader = Some(reader);
         self.buffer.clear();
@@ -151,8 +151,6 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     }
 
     pub fn file_format(&self) -> Option<LogFileFormat> {
-        self.reader
-            .as_ref()
-            .map(|reader| reader.file_format().clone())
+        self.reader.as_ref().map(|reader| *reader.file_format())
     }
 }

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -7,7 +7,7 @@ use crate::util::{round_down, round_up};
 use crate::{Error, Result};
 
 use super::format::LogFileFormat;
-use super::log_file::{LogFileReader, FILE_ALIGNMENT_SIZE};
+use super::log_file::{get_system_block_size, LogFileReader};
 
 /// A reusable reader over [`LogItemBatch`]s in a log file.
 pub(super) struct LogItemBatchFileReader<F: FileSystem> {
@@ -67,58 +67,37 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
         if self.valid_offset < self.size {
             debug_assert!(self.file_context.is_some());
-            match self.file_context.as_ref().unwrap().format.data_layout() {
-                DataLayout::NoAlignment | DataLayout::AlignWithIntegration => {
-                    if self.valid_offset < LOG_BATCH_HEADER_LEN {
-                        return Err(Error::Corruption(
-                            "attempt to read file with broken header".to_owned(),
-                        ));
-                    }
-                    let (footer_offset, compression_type, len) = LogBatch::decode_header(
-                        &mut self.peek(self.valid_offset, LOG_BATCH_HEADER_LEN, 0)?,
-                    )?;
-                    if self.valid_offset + len > self.size {
-                        return Err(Error::Corruption("log batch header broken".to_owned()));
-                    }
-                    let file_context = self.file_context.as_ref().unwrap().clone();
-                    let handle = FileBlockHandle {
-                        id: file_context.id,
-                        offset: (self.valid_offset + LOG_BATCH_HEADER_LEN) as u64,
-                        len: footer_offset - LOG_BATCH_HEADER_LEN,
-                    };
-                    let item_batch = LogItemBatch::decode(
-                        &mut self.peek(
-                            self.valid_offset + footer_offset,
-                            len - footer_offset,
-                            LOG_BATCH_HEADER_LEN,
-                        )?,
-                        handle,
-                        compression_type,
-                        &file_context,
-                    )?;
-                    self.valid_offset += len;
-                    return Ok(Some(item_batch));
-                }
-                DataLayout::AlignWithFragments => {
-                    // @TODO: lucasliang
-                    // Implement the reading strategy for DataLayout::AlignWithFragments,
-                    // considering that records in log files might be fragmented.
-                    // Referring to the design of WAL in rocksdb:
-                    // [https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log-File-Format],
-                    // this strategy will introduce LogRecordType as the candidate
-                    // mark to remark each fragment of serialized LogBatchs in the log.
-                    //
-                    // Expected fragemented records should be aligned and typed with
-                    // `LogRecordType`, default with LogRecordType::Full. And we need
-                    // supply extra necessary structure to annotate each
-                    // part of one fragmented record, i.e.
-                    //
-                    // | <------------------ 32kb --------------------> | 32kb | ...
-                    // |len(32bit)|type(8bit)| serialized LogBatch(...) |  ... | ...
-                    //
-                    panic!("attempt to read file with an unimplemented DataLayout");
-                }
+            if self.valid_offset < LOG_BATCH_HEADER_LEN {
+                return Err(Error::Corruption(
+                    "attempt to read file with broken header".to_owned(),
+                ));
             }
+            let (footer_offset, compression_type, len) = LogBatch::decode_header(&mut self.peek(
+                self.valid_offset,
+                LOG_BATCH_HEADER_LEN,
+                0,
+            )?)?;
+            if self.valid_offset + len > self.size {
+                return Err(Error::Corruption("log batch header broken".to_owned()));
+            }
+            let file_context = self.file_context.as_ref().unwrap().clone();
+            let handle = FileBlockHandle {
+                id: file_context.id,
+                offset: (self.valid_offset + LOG_BATCH_HEADER_LEN) as u64,
+                len: footer_offset - LOG_BATCH_HEADER_LEN,
+            };
+            let item_batch = LogItemBatch::decode(
+                &mut self.peek(
+                    self.valid_offset + footer_offset,
+                    len - footer_offset,
+                    LOG_BATCH_HEADER_LEN,
+                )?,
+                handle,
+                compression_type,
+                &file_context,
+            )?;
+            self.valid_offset += len;
+            return Ok(Some(item_batch));
         }
         Ok(None)
     }
@@ -130,6 +109,7 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     /// Returns a slice of internal buffer with specified size.
     fn peek(&mut self, offset: usize, size: usize, prefetch: usize) -> Result<&[u8]> {
         debug_assert!(offset >= self.buffer_offset);
+        let fs_block_size = get_system_block_size();
         let reader = self.reader.as_mut().unwrap();
         let end = self.buffer_offset + self.buffer.len();
         if offset > end {
@@ -141,10 +121,10 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
                         std::cmp::max(size + prefetch, self.read_block_size),
                     ),
                     _ => (
-                        round_down(self.buffer_offset, FILE_ALIGNMENT_SIZE),
+                        round_down(self.buffer_offset, fs_block_size),
                         round_up(
                             std::cmp::max(size + prefetch, self.read_block_size),
-                            FILE_ALIGNMENT_SIZE,
+                            fs_block_size,
                         ),
                     ),
                 }
@@ -176,10 +156,10 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
                             std::cmp::max(should_read, self.read_block_size),
                         ),
                         _ => (
-                            round_down(read_offset, FILE_ALIGNMENT_SIZE),
+                            round_down(read_offset, fs_block_size),
                             round_up(
                                 std::cmp::max(should_read, self.read_block_size),
-                                FILE_ALIGNMENT_SIZE,
+                                fs_block_size,
                             ),
                         ),
                     }

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -65,7 +65,6 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     /// Returns the next [`LogItemBatch`] in current opened file. Returns
     /// `None` if there is no more data or no opened file.
     pub fn next(&mut self) -> Result<Option<LogItemBatch>> {
-        // @lucasliang.
         // TODO: [Fulfilled in writing progress when DIO is open.]
         // We should also consider that there might exists broken blocks when DIO
         // is open, and the following reading strategy should tolerate reading broken

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -3,11 +3,11 @@
 use crate::env::FileSystem;
 use crate::log_batch::{LogBatch, LogItemBatch, LOG_BATCH_HEADER_LEN};
 use crate::pipe_log::{DataLayout, FileBlockHandle, FileId, LogFileContext};
-use crate::util::{round_down, round_up};
+use crate::util::round_up;
 use crate::{Error, Result};
 
 use super::format::LogFileFormat;
-use super::log_file::{get_system_block_size, LogFileReader};
+use super::log_file::LogFileReader;
 
 /// A reusable reader over [`LogItemBatch`]s in a log file.
 pub(super) struct LogItemBatchFileReader<F: FileSystem> {
@@ -43,12 +43,12 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
 
     /// Opens a file that can be accessed through the given reader.
     pub fn open(&mut self, file_id: FileId, reader: LogFileReader<F>) -> Result<()> {
+        self.valid_offset = reader.file_format().enc_len();
         self.file_context = Some(LogFileContext::new(file_id, *reader.file_format()));
         self.size = reader.file_size()?;
         self.reader = Some(reader);
         self.buffer.clear();
         self.buffer_offset = 0;
-        self.valid_offset = LogFileFormat::len();
         Ok(())
     }
 
@@ -70,7 +70,6 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
         // We should also consider that there might exists broken blocks when DIO
         // is open, and the following reading strategy should tolerate reading broken
         // blocks until it finds an accessible header of `LogBatch`.
-        let fs_block_size = get_system_block_size();
         while self.valid_offset < self.size {
             debug_assert!(self.file_context.is_some());
             let data_layout = self.file_context.as_ref().unwrap().format.data_layout();
@@ -80,32 +79,43 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
                 ));
             }
             let (footer_offset, compression_type, len) = {
-                match LogBatch::decode_header(&mut self.peek(
-                    self.valid_offset,
-                    match data_layout {
-                        DataLayout::NoAlignment => LOG_BATCH_HEADER_LEN,
-                        DataLayout::Alignment => {
-                            // In DataLayout::Alignment mode, tail data in this block maybe
-                            // contain an valid header of the adjacent LogBatch or paddings
-                            // with `0`.
-                            round_up(self.valid_offset, fs_block_size) - self.valid_offset
-                                + LOG_BATCH_HEADER_LEN
-                        }
-                    },
-                    0,
-                )?) {
-                    Err(e) => {
-                        // In DataLayout::Alignment mode, tail data in the previous block may be
-                        // aligned with paddings, that is '0'. So, we need to skip these
-                        // redundant content and get the next valid header of `LogBatch`.
-                        if DataLayout::Alignment == data_layout {
-                            self.valid_offset = round_up(self.valid_offset, fs_block_size);
-                            continue;
-                        } else {
-                            return Err(e);
+                match data_layout {
+                    DataLayout::NoAlignment | DataLayout::Alignment(0) => {
+                        let (offset, t, l) = LogBatch::decode_header(&mut self.peek(
+                            self.valid_offset,
+                            LOG_BATCH_HEADER_LEN,
+                            0,
+                        )?)?;
+                        (offset, t, l)
+                    }
+                    DataLayout::Alignment(fs_block_size) => {
+                        // In DataLayout::Alignment mode, tail data in this block maybe
+                        // contain an valid header of the adjacent LogBatch or paddings
+                        // with `0`.
+                        match LogBatch::decode_header(&mut self.peek(
+                            self.valid_offset,
+                            round_up(self.valid_offset, fs_block_size as usize) - self.valid_offset
+                                + LOG_BATCH_HEADER_LEN,
+                            0,
+                        )?) {
+                            Err(e) => {
+                                // In DataLayout::Alignment mode, tail data in the previous block
+                                // may be aligned with paddings, that is '0'. So, we need to
+                                // skip these redundant content and get the next valid header
+                                // of `LogBatch`.
+                                let aligned_next_offset =
+                                    round_up(self.valid_offset, fs_block_size as usize);
+                                if self.valid_offset == aligned_next_offset {
+                                    // If we continued with aligned offset and get a parsed err,
+                                    // it means that the header is broken.
+                                    return Err(e);
+                                }
+                                self.valid_offset = aligned_next_offset;
+                                continue;
+                            }
+                            Ok((offset, t, l)) => (offset, t, l),
                         }
                     }
-                    Ok((offset, t, l)) => (offset, t, l),
                 }
             };
             if self.valid_offset + len > self.size {
@@ -140,28 +150,13 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     /// Returns a slice of internal buffer with specified size.
     fn peek(&mut self, offset: usize, size: usize, prefetch: usize) -> Result<&[u8]> {
         debug_assert!(offset >= self.buffer_offset);
-        let fs_block_size = get_system_block_size();
         let reader = self.reader.as_mut().unwrap();
         let end = self.buffer_offset + self.buffer.len();
         if offset > end {
             self.buffer_offset = offset;
-            let (calibrate_offset, calibrate_len) = {
-                match self.file_context.as_ref().unwrap().format.data_layout() {
-                    DataLayout::NoAlignment => (
-                        self.buffer_offset,
-                        std::cmp::max(size + prefetch, self.read_block_size),
-                    ),
-                    _ => (
-                        round_down(self.buffer_offset, fs_block_size),
-                        round_up(
-                            std::cmp::max(size + prefetch, self.read_block_size),
-                            fs_block_size,
-                        ),
-                    ),
-                }
-            };
-            self.buffer.resize(calibrate_len, 0);
-            let read = reader.read_to(calibrate_offset as u64, &mut self.buffer)?;
+            self.buffer
+                .resize(std::cmp::max(size + prefetch, self.read_block_size), 0);
+            let read = reader.read_to(self.buffer_offset as u64, &mut self.buffer)?;
             if read < size {
                 return Err(Error::Corruption(format!(
                     "Unexpected eof at {}",
@@ -169,47 +164,24 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
                 )));
             }
             self.buffer.truncate(read);
-            // Calibrate the first redundant part read from the log file by
-            // removing it when `cfg.format_data_layout = DataLayout::Alignment`.
-            if calibrate_offset != self.buffer_offset {
-                self.buffer.drain(..self.buffer_offset - calibrate_offset);
-            }
             Ok(&self.buffer[..size])
         } else {
             let should_read = (offset + size + prefetch).saturating_sub(end);
             if should_read > 0 {
                 let read_offset = self.buffer_offset + self.buffer.len();
                 let prev_len = self.buffer.len();
-                let (calibrate_offset, calibrate_len) = {
-                    match self.file_context.as_ref().unwrap().format.data_layout() {
-                        DataLayout::NoAlignment => (
-                            read_offset,
-                            std::cmp::max(should_read, self.read_block_size),
-                        ),
-                        _ => (
-                            round_down(read_offset, fs_block_size),
-                            round_up(
-                                std::cmp::max(should_read, self.read_block_size),
-                                fs_block_size,
-                            ),
-                        ),
-                    }
-                };
-                self.buffer.resize(prev_len + calibrate_len, 0);
-                let read = reader.read_to(calibrate_offset as u64, &mut self.buffer[prev_len..])?;
+                self.buffer.resize(
+                    prev_len + std::cmp::max(should_read, self.read_block_size),
+                    0,
+                );
+                let read = reader.read_to(read_offset as u64, &mut self.buffer[prev_len..])?;
                 if read + prefetch < should_read {
                     return Err(Error::Corruption(format!(
                         "Unexpected eof at {}",
-                        calibrate_offset + read,
+                        read_offset + read,
                     )));
                 }
                 self.buffer.truncate(prev_len + read);
-                // Calibrate the first redundant part read from the log file by
-                // removing it when `cfg.format_data_layout = DataLayout::Alignment`.
-                if read_offset != calibrate_offset {
-                    self.buffer
-                        .drain(prev_len..prev_len + read_offset - calibrate_offset);
-                }
             }
             Ok(&self.buffer[offset - self.buffer_offset..offset - self.buffer_offset + size])
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub mod internals {
     pub use crate::pipe_log::*;
     #[cfg(feature = "swap")]
     pub use crate::swappy_allocator::*;
+    pub use crate::util::{round_down, round_up};
     pub use crate::write_barrier::*;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use engine::Engine;
 pub use errors::{Error, Result};
 pub use log_batch::{Command, LogBatch, MessageExt};
 pub use metrics::{get_perf_context, set_perf_context, take_perf_context, PerfContext};
-pub use pipe_log::Version;
+pub use pipe_log::{DataLayout, Version};
 pub use util::ReadableSize;
 
 #[cfg(feature = "internals")]

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -125,12 +125,6 @@ pub enum DataLayout {
     Alignment(u64),
 }
 
-impl Default for DataLayout {
-    fn default() -> Self {
-        DataLayout::NoAlignment
-    }
-}
-
 impl DataLayout {
     pub fn from_u64(val: u64) -> Self {
         match val {

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -6,7 +6,6 @@ use std::cmp::Ordering;
 
 use fail::fail_point;
 use num_derive::{FromPrimitive, ToPrimitive};
-use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use strum::EnumIter;
 
@@ -117,12 +116,12 @@ impl Default for Version {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, EnumIter, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Clone, Copy, Debug, EnumIter, Eq, PartialEq)]
 pub enum DataLayout {
     NoAlignment,
-    AlignWithIntegration,
-    AlignWithFragments,
+    /// Alignment mode for DataLayout will make sense when DIO
+    /// is open.
+    Alignment,
 }
 
 impl Default for DataLayout {
@@ -135,8 +134,7 @@ impl DataLayout {
     pub fn from_u8(val: u8) -> Option<Self> {
         match val {
             0 => Some(DataLayout::NoAlignment),
-            1 => Some(DataLayout::AlignWithIntegration),
-            2 => Some(DataLayout::AlignWithFragments),
+            1 => Some(DataLayout::Alignment),
             _ => None,
         }
     }
@@ -144,18 +142,7 @@ impl DataLayout {
     pub fn to_u8(self) -> u8 {
         match self {
             DataLayout::NoAlignment => 0,
-            DataLayout::AlignWithIntegration => 1,
-            DataLayout::AlignWithFragments => 2,
-        }
-    }
-
-    pub fn is_enabled(&self) -> bool {
-        fail_point!("pipe_log::data_layout::force_enable", |_| { true });
-        match self {
-            DataLayout::NoAlignment => true,
-            DataLayout::AlignWithIntegration => true,
-            // @TODO: lucasliang, support for it
-            DataLayout::AlignWithFragments => false,
+            DataLayout::Alignment => 1,
         }
     }
 }

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -82,6 +82,7 @@ impl FileBlockHandle {
 }
 
 /// Version of log file format.
+#[repr(u64)]
 #[derive(
     Clone,
     Copy,
@@ -94,7 +95,6 @@ impl FileBlockHandle {
     Deserialize_repr,
     EnumIter,
 )]
-#[repr(u64)]
 pub enum Version {
     V1 = 1,
     V2 = 2,
@@ -116,9 +116,9 @@ impl Default for Version {
     }
 }
 
+#[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
-#[repr(u8)]
 pub enum DataLayout {
     NoAlignment,
     Alignment,
@@ -131,7 +131,7 @@ impl Default for DataLayout {
 }
 
 impl DataLayout {
-    pub fn from_u8(val: u8) -> Option<DataLayout> {
+    pub fn from_u8(val: u8) -> Option<Self> {
         match val {
             0 => Some(DataLayout::NoAlignment),
             1 => Some(DataLayout::Alignment),

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -115,13 +115,14 @@ impl Default for Version {
     }
 }
 
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, EnumIter, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DataLayout {
     NoAlignment,
-    /// Alignment mode for DataLayout will make sense when DIO
-    /// is open.
-    Alignment,
+    /// Alignment(block_size) mode in memory for DataLayout will make sense
+    /// when DIO is open.
+    ///
+    /// `block_size` will be dumped into the header of each log file.
+    Alignment(u64),
 }
 
 impl Default for DataLayout {
@@ -131,19 +132,22 @@ impl Default for DataLayout {
 }
 
 impl DataLayout {
-    pub fn from_u8(val: u8) -> Option<Self> {
+    pub fn from_u64(val: u64) -> Self {
         match val {
-            0 => Some(DataLayout::NoAlignment),
-            1 => Some(DataLayout::Alignment),
-            _ => None,
+            0 => DataLayout::NoAlignment,
+            aligned => DataLayout::Alignment(aligned),
         }
     }
 
-    pub fn to_u8(self) -> u8 {
+    pub fn to_u64(self) -> u64 {
         match self {
             DataLayout::NoAlignment => 0,
-            DataLayout::Alignment => 1,
+            DataLayout::Alignment(aligned) => aligned,
         }
+    }
+
+    pub const fn len() -> usize {
+        8 /* serialized in u64. */
     }
 }
 

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -117,11 +117,12 @@ impl Default for Version {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, EnumIter, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DataLayout {
     NoAlignment,
-    Alignment,
+    AlignWithIntegration,
+    AlignWithFragments,
 }
 
 impl Default for DataLayout {
@@ -134,7 +135,8 @@ impl DataLayout {
     pub fn from_u8(val: u8) -> Option<Self> {
         match val {
             0 => Some(DataLayout::NoAlignment),
-            1 => Some(DataLayout::Alignment),
+            1 => Some(DataLayout::AlignWithIntegration),
+            2 => Some(DataLayout::AlignWithFragments),
             _ => None,
         }
     }
@@ -142,7 +144,18 @@ impl DataLayout {
     pub fn to_u8(self) -> u8 {
         match self {
             DataLayout::NoAlignment => 0,
-            DataLayout::Alignment => 1,
+            DataLayout::AlignWithIntegration => 1,
+            DataLayout::AlignWithFragments => 2,
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        fail_point!("pipe_log::data_layout::force_enable", |_| { true });
+        match self {
+            DataLayout::NoAlignment => true,
+            DataLayout::AlignWithIntegration => true,
+            // @TODO: lucasliang, support for it
+            DataLayout::AlignWithFragments => false,
         }
     }
 }

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -136,7 +136,10 @@ impl DataLayout {
     pub fn to_u64(self) -> u64 {
         match self {
             DataLayout::NoAlignment => 0,
-            DataLayout::Alignment(aligned) => aligned,
+            DataLayout::Alignment(aligned) => {
+                debug_assert!(aligned > 0);
+                aligned
+            }
         }
     }
 

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -147,7 +147,7 @@ impl DataLayout {
     }
 
     pub const fn len() -> usize {
-        8 /* serialized in u64. */
+        std::mem::size_of::<u64>() /* serialized in u64. */
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -335,6 +335,16 @@ pub fn round_up(offset: usize, alignment: usize) -> usize {
     (offset + alignment - 1) / alignment * alignment
 }
 
+/// Return an aligned `offset`.
+///
+/// Example:
+/// * round_down(18, 4) => 16
+/// * round_down(64, 16) => 64
+#[inline]
+pub fn round_down(offset: usize, alignment: usize) -> usize {
+    offset / alignment * alignment
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -448,8 +458,13 @@ mod tests {
 
     #[test]
     fn test_rounding() {
+        // round_up
         assert_eq!(round_up(18, 4), 20);
         assert_eq!(round_up(64, 16), 64);
         assert_eq!(round_up(79, 4096), 4096);
+        // round_down
+        assert_eq!(round_down(18, 4), 16);
+        assert_eq!(round_down(64, 16), 64);
+        assert_eq!(round_down(79, 4096), 0);
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -327,9 +327,12 @@ pub trait Factory<Target>: Send + Sync {
 
 /// Return an aligned `offset`.
 ///
-/// Example:
-/// * round_up(18, 4) => 20
-/// * round_up(64, 16) => 64
+/// # Example:
+///
+/// ```
+/// assert_eq!(round_up(18, 4), 20);
+/// assert_eq!(round_up(64, 16), 64);
+/// ```
 #[inline]
 pub fn round_up(offset: usize, alignment: usize) -> usize {
     (offset + alignment - 1) / alignment * alignment
@@ -337,9 +340,12 @@ pub fn round_up(offset: usize, alignment: usize) -> usize {
 
 /// Return an aligned `offset`.
 ///
-/// Example:
-/// * round_down(18, 4) => 16
-/// * round_down(64, 16) => 64
+/// # Example:
+///
+/// ```
+/// assert_eq!(round_down(18, 4), 16);
+/// assert_eq!(round_down(64, 16), 64);
+/// ```
 #[allow(dead_code)]
 #[inline]
 pub fn round_down(offset: usize, alignment: usize) -> usize {

--- a/src/util.rs
+++ b/src/util.rs
@@ -330,6 +330,8 @@ pub trait Factory<Target>: Send + Sync {
 /// # Example:
 ///
 /// ```
+/// use raft_engine::internals::round_up;
+///
 /// assert_eq!(round_up(18, 4), 20);
 /// assert_eq!(round_up(64, 16), 64);
 /// ```
@@ -343,6 +345,8 @@ pub fn round_up(offset: usize, alignment: usize) -> usize {
 /// # Example:
 ///
 /// ```
+/// use raft_engine::internals::round_down;
+///
 /// assert_eq!(round_down(18, 4), 16);
 /// assert_eq!(round_down(64, 16), 64);
 /// ```

--- a/src/util.rs
+++ b/src/util.rs
@@ -340,6 +340,7 @@ pub fn round_up(offset: usize, alignment: usize) -> usize {
 /// Example:
 /// * round_down(18, 4) => 16
 /// * round_down(64, 16) => 64
+#[allow(dead_code)]
 #[inline]
 pub fn round_down(offset: usize, alignment: usize) -> usize {
     offset / alignment * alignment

--- a/src/util.rs
+++ b/src/util.rs
@@ -325,6 +325,16 @@ pub trait Factory<Target>: Send + Sync {
     fn new_target(&self) -> Target;
 }
 
+/// Return an aligned `offset`.
+///
+/// Example:
+/// * round_up(18, 4) => 20
+/// * round_up(64, 16) => 64
+#[inline]
+pub fn round_up(offset: usize, alignment: usize) -> usize {
+    (offset + alignment - 1) / alignment * alignment
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -434,5 +444,12 @@ mod tests {
     #[test]
     fn test_unhash() {
         assert_eq!(unhash_u64(hash_u64(777)), 777);
+    }
+
+    #[test]
+    fn test_rounding() {
+        assert_eq!(round_up(18, 4), 20);
+        assert_eq!(round_up(64, 16), 64);
+        assert_eq!(round_up(79, 4096), 4096);
     }
 }

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -15,9 +15,7 @@ use hdrhistogram::Histogram;
 use parking_lot_core::SpinWait;
 use raft::eraftpb::Entry;
 use raft_engine::internals::{EventListener, FileBlockHandle};
-use raft_engine::{
-    Command, Config, DataLayout, Engine, LogBatch, MessageExt, ReadableSize, Version,
-};
+use raft_engine::{Command, Config, Engine, LogBatch, MessageExt, ReadableSize, Version};
 use rand::{thread_rng, Rng, RngCore};
 
 type WriteBatch = LogBatch;
@@ -239,14 +237,6 @@ struct ControlOpt {
         help = "Format version of log files"
     )]
     format_version: String,
-
-    #[clap(
-        long = "format-data-layout",
-        takes_value = true,
-        default_value = "no-alignment",
-        help = "Format data layout of log files"
-    )]
-    format_data_layout: String,
 
     #[clap(
         long = "enable-log-recycle",
@@ -602,8 +592,6 @@ fn main() {
         ReadableSize::from_str(&opts.batch_compression_threshold).unwrap();
     config.enable_log_recycle = opts.enable_log_recycle;
     config.format_version = serde_json::from_str::<Version>(&opts.format_version).unwrap();
-    config.format_data_layout =
-        serde_json::from_str::<DataLayout>(&format!(r#""{}""#, opts.format_data_layout)).unwrap();
     args.time = Duration::from_secs(opts.time);
     args.regions = opts.regions;
     args.purge_interval = Duration::from_secs(opts.purge_interval);

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -15,7 +15,9 @@ use hdrhistogram::Histogram;
 use parking_lot_core::SpinWait;
 use raft::eraftpb::Entry;
 use raft_engine::internals::{EventListener, FileBlockHandle};
-use raft_engine::{Command, Config, Engine, LogBatch, MessageExt, ReadableSize, Version};
+use raft_engine::{
+    Command, Config, DataLayout, Engine, LogBatch, MessageExt, ReadableSize, Version,
+};
 use rand::{thread_rng, Rng, RngCore};
 
 type WriteBatch = LogBatch;
@@ -237,6 +239,12 @@ struct ControlOpt {
         help = "Format version of log files"
     )]
     format_version: String,
+
+    #[clap(
+        long = "alignment-mode",
+        help = "Align the data with default 32kb block size"
+    )]
+    alignment_mode: bool,
 
     #[clap(
         long = "enable-log-recycle",
@@ -592,6 +600,9 @@ fn main() {
         ReadableSize::from_str(&opts.batch_compression_threshold).unwrap();
     config.enable_log_recycle = opts.enable_log_recycle;
     config.format_version = serde_json::from_str::<Version>(&opts.format_version).unwrap();
+    if opts.alignment_mode {
+        config.format_data_layout = DataLayout::Alignment;
+    }
     args.time = Duration::from_secs(opts.time);
     args.regions = opts.regions;
     args.purge_interval = Duration::from_secs(opts.purge_interval);

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -241,10 +241,12 @@ struct ControlOpt {
     format_version: String,
 
     #[clap(
-        long = "alignment-mode",
-        help = "Align the data with default 32kb block size"
+        long = "format-data-layout",
+        takes_value = true,
+        default_value = "no-alignment",
+        help = "Format data layout of log files"
     )]
-    alignment_mode: bool,
+    format_data_layout: String,
 
     #[clap(
         long = "enable-log-recycle",
@@ -600,9 +602,8 @@ fn main() {
         ReadableSize::from_str(&opts.batch_compression_threshold).unwrap();
     config.enable_log_recycle = opts.enable_log_recycle;
     config.format_version = serde_json::from_str::<Version>(&opts.format_version).unwrap();
-    if opts.alignment_mode {
-        config.format_data_layout = DataLayout::Alignment;
-    }
+    config.format_data_layout =
+        serde_json::from_str::<DataLayout>(&format!(r#""{}""#, opts.format_data_layout)).unwrap();
     args.time = Duration::from_secs(opts.time);
     args.regions = opts.regions;
     args.purge_interval = Duration::from_secs(opts.purge_interval);

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -450,7 +450,7 @@ fn test_tail_corruption() {
         let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
         append(&engine, rid, 1, 5, Some(&data));
         drop(engine);
-        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_err());
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_ok());
     }
     // Version::V1 in header owns abnormal DataLayout.
     {

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -571,26 +571,27 @@ fn test_recycle_with_stale_logbatch_at_tail() {
 }
 
 #[test]
-fn test_build_with_unimplemented_datalayout() {
+fn test_build_with_alignment_datalayout() {
     let dir = tempfile::Builder::new()
         .prefix("test_build_with_unimplemented_datalayout")
         .tempdir()
         .unwrap();
     let data = vec![b'x'; 1024];
     let rid = 1;
-    let cfg_err = Config {
+    let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
         purge_threshold: ReadableSize::kb(4),
         format_data_layout: DataLayout::Alignment,
         ..Default::default()
     };
-    let engine = Engine::open(cfg_err.clone()).unwrap();
+    let engine = Engine::open(cfg.clone()).unwrap();
     append(&engine, rid, 1, 2, Some(&data)); // file_seq: 1
     append(&engine, rid, 2, 3, Some(&data));
     append(&engine, rid, 3, 4, Some(&data)); // file_seq: 2
     append(&engine, rid, 4, 5, Some(&data));
     append(&engine, rid, 5, 6, Some(&data)); // file_seq: 3
     drop(engine);
-    assert!(catch_unwind_silent(|| { Engine::open(cfg_err) }).is_err());
+    assert!(Engine::open(cfg).is_ok());
+    // assert!(catch_unwind_silent(|| { Engine::open(cfg_err) }).is_err());
 }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -618,8 +618,7 @@ fn test_build_engine_with_multi_datalayout() {
     }
     drop(engine);
     // File with DataLayout::Alignment
-    let _f1 = FailGuard::new("file_pipe_log::open::force_aligned_layout", "return");
-    let _f2 = FailGuard::new("file_pipe_log::open::force_set_fs_block_size", "return");
+    let _f = FailGuard::new("file_pipe_log::open::force_set_aligned_layout", "return");
     let cfg_v2 = Config {
         format_version: Version::V2,
         ..cfg
@@ -647,15 +646,14 @@ fn test_build_engine_with_datalayout_abnormal() {
         format_version: Version::V2,
         ..Default::default()
     };
-    let _f = FailGuard::new("file_pipe_log::open::force_aligned_layout", "return");
-    let _f1 = FailGuard::new("file_pipe_log::open::force_set_fs_block_size", "return");
+    let _f = FailGuard::new("file_pipe_log::open::force_set_aligned_layout", "return");
     let engine = Engine::open(cfg.clone()).unwrap();
     // Content durable with DataLayout::Alignment.
     append(&engine, 1, 1, 11, Some(&data));
     append(&engine, 2, 1, 11, Some(&data));
     {
         // Set failpoint to dump content with invalid paddings into log file.
-        let _f2 = FailGuard::new("file_pipe_log::append::force_abnormal_paddings", "return");
+        let _f1 = FailGuard::new("file_pipe_log::append::force_abnormal_paddings", "return");
         append(&engine, 3, 1, 11, Some(&data));
         drop(engine);
         assert!(Engine::open(cfg.clone()).is_err());

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -452,11 +452,56 @@ fn test_tail_corruption() {
         drop(engine);
         assert!(Engine::open_with_file_system(cfg, fs.clone()).is_err());
     }
-    // DataLayout in header is corrupted.
+    // Version::V1 in header owns abnormal DataLayout.
+    {
+        let _f = FailGuard::new("log_file_header::force_abnormal_data_layout", "return");
+        let dir = tempfile::Builder::new()
+            .prefix("test_tail_corruption_4")
+            .tempdir()
+            .unwrap();
+        let cfg_err = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            recovery_mode: RecoveryMode::AbsoluteConsistency,
+            ..Default::default()
+        };
+        let engine = Engine::open_with_file_system(cfg_err.clone(), fs.clone()).unwrap();
+        drop(engine);
+        assert!(Engine::open_with_file_system(cfg_err, fs.clone()).is_err());
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            ..Default::default()
+        };
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_ok());
+    }
+    // DataLayout in header is corrupted for Version::V2
     {
         let _f = FailGuard::new("log_file_header::corrupted_data_layout", "return");
         let dir = tempfile::Builder::new()
-            .prefix("test_tail_corruption_4")
+            .prefix("test_tail_corruption_5")
+            .tempdir()
+            .unwrap();
+        let cfg_err = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            recovery_mode: RecoveryMode::AbsoluteConsistency,
+            ..Default::default()
+        };
+        let engine = Engine::open_with_file_system(cfg_err.clone(), fs.clone()).unwrap();
+        drop(engine);
+        assert!(Engine::open_with_file_system(cfg_err, fs.clone()).is_err());
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            ..Default::default()
+        };
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_ok());
+    }
+    // DataLayout in header is abnormal for Version::V2
+    {
+        let _f = FailGuard::new("log_file_header::force_abnormal_data_layout", "return");
+        let dir = tempfile::Builder::new()
+            .prefix("test_tail_corruption_6")
             .tempdir()
             .unwrap();
         let cfg_err = Config {

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -577,7 +577,6 @@ fn test_build_engine_with_aligned_datalayout() {
         .tempdir()
         .unwrap();
     let data = vec![b'x'; 12827];
-    // Defaultly, File with DataLayout::NoAlignment.
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
@@ -585,12 +584,12 @@ fn test_build_engine_with_aligned_datalayout() {
         recovery_mode: RecoveryMode::AbsoluteConsistency,
         ..Default::default()
     };
+    // Defaultly, File with DataLayout::NoAlignment.
     let engine = Engine::open(cfg.clone()).unwrap();
     for rid in 1..=3 {
         append(&engine, rid, 1, 11, Some(&data));
     }
     drop(engine);
-
     // File with DataLayout::Alignment
     let _f1 = FailGuard::new("pipe_log::log_file::abnormal_block_size", "return");
     let _f2 = FailGuard::new("pipe_log::log_file_writer::force_rewrite_header", "return");

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -569,3 +569,28 @@ fn test_recycle_with_stale_logbatch_at_tail() {
     })
     .is_err());
 }
+
+#[test]
+fn test_build_with_unimplemented_datalayout() {
+    let dir = tempfile::Builder::new()
+        .prefix("test_build_with_unimplemented_datalayout")
+        .tempdir()
+        .unwrap();
+    let data = vec![b'x'; 1024];
+    let rid = 1;
+    let cfg_err = Config {
+        dir: dir.path().to_str().unwrap().to_owned(),
+        target_file_size: ReadableSize::kb(2),
+        purge_threshold: ReadableSize::kb(4),
+        format_data_layout: DataLayout::Alignment,
+        ..Default::default()
+    };
+    let engine = Engine::open(cfg_err.clone()).unwrap();
+    append(&engine, rid, 1, 2, Some(&data)); // file_seq: 1
+    append(&engine, rid, 2, 3, Some(&data));
+    append(&engine, rid, 3, 4, Some(&data)); // file_seq: 2
+    append(&engine, rid, 4, 5, Some(&data));
+    append(&engine, rid, 5, 6, Some(&data)); // file_seq: 3
+    drop(engine);
+    assert!(catch_unwind_silent(|| { Engine::open(cfg_err) }).is_err());
+}

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -571,17 +571,18 @@ fn test_recycle_with_stale_logbatch_at_tail() {
 }
 
 #[test]
-fn test_build_with_aligned_datalayout() {
+fn test_build_engine_with_aligned_datalayout() {
     let dir = tempfile::Builder::new()
-        .prefix("test_build_with_aligned_datalayout")
+        .prefix("test_build_engine_with_aligned_datalayout")
         .tempdir()
         .unwrap();
-    let data = vec![b'x'; (rand::random::<u64>() % 32768) as usize];
+    let data = vec![b'x'; (12827) as usize];
     // Defaultly, File with DataLayout::NoAlignment.
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
         purge_threshold: ReadableSize::kb(4),
+        recovery_mode: RecoveryMode::AbsoluteConsistency,
         ..Default::default()
     };
     let engine = Engine::open(cfg.clone()).unwrap();
@@ -593,8 +594,9 @@ fn test_build_with_aligned_datalayout() {
     // File with DataLayout::Alignment
     let _f1 = FailGuard::new("pipe_log::log_file::abnormal_block_size", "return");
     let _f2 = FailGuard::new("pipe_log::log_file_writer::force_rewrite_header", "return");
-    let engine = Engine::open(cfg.clone()).unwrap();
+    let _f3 = FailGuard::new("file_pipe_log::append::force_aligned_write", "return");
 
+    let engine = Engine::open(cfg.clone()).unwrap();
     for rid in 1..=3 {
         append(&engine, rid, 11, 20, Some(&data));
     }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -573,7 +573,7 @@ fn test_recycle_with_stale_logbatch_at_tail() {
 #[test]
 fn test_build_with_alignment_datalayout() {
     let dir = tempfile::Builder::new()
-        .prefix("test_build_with_unimplemented_datalayout")
+        .prefix("test_build_with_alignment_datalayout")
         .tempdir()
         .unwrap();
     let data = vec![b'x'; 1024];
@@ -593,5 +593,4 @@ fn test_build_with_alignment_datalayout() {
     append(&engine, rid, 5, 6, Some(&data)); // file_seq: 3
     drop(engine);
     assert!(Engine::open(cfg).is_ok());
-    // assert!(catch_unwind_silent(|| { Engine::open(cfg_err) }).is_err());
 }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -576,7 +576,7 @@ fn test_build_engine_with_aligned_datalayout() {
         .prefix("test_build_engine_with_aligned_datalayout")
         .tempdir()
         .unwrap();
-    let data = vec![b'x'; (12827) as usize];
+    let data = vec![b'x'; 12827];
     // Defaultly, File with DataLayout::NoAlignment.
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -571,26 +571,46 @@ fn test_recycle_with_stale_logbatch_at_tail() {
 }
 
 #[test]
-fn test_build_with_alignment_datalayout() {
+fn test_build_with_datalayout() {
     let dir = tempfile::Builder::new()
-        .prefix("test_build_with_alignment_datalayout")
+        .prefix("test_build_with_datalayout")
         .tempdir()
         .unwrap();
     let data = vec![b'x'; 1024];
     let rid = 1;
+    // DataLayout with default config => NoAlignment
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
         purge_threshold: ReadableSize::kb(4),
-        format_data_layout: DataLayout::Alignment,
         ..Default::default()
     };
     let engine = Engine::open(cfg.clone()).unwrap();
-    append(&engine, rid, 1, 2, Some(&data)); // file_seq: 1
+    append(&engine, rid, 1, 2, Some(&data));
     append(&engine, rid, 2, 3, Some(&data));
-    append(&engine, rid, 3, 4, Some(&data)); // file_seq: 2
-    append(&engine, rid, 4, 5, Some(&data));
-    append(&engine, rid, 5, 6, Some(&data)); // file_seq: 3
     drop(engine);
-    assert!(Engine::open(cfg).is_ok());
+    assert!(Engine::open(cfg.clone()).is_ok());
+    // DataLayout config => AlignWithIntegration
+    let cfg_integration = Config {
+        format_data_layout: DataLayout::AlignWithIntegration,
+        ..cfg.clone()
+    };
+    let engine = Engine::open(cfg_integration).unwrap();
+    append(&engine, rid, 3, 4, Some(&data));
+    append(&engine, rid, 4, 5, Some(&data));
+    append(&engine, rid, 5, 6, Some(&data));
+    append(&engine, rid, 6, 7, Some(&data));
+    drop(engine);
+    // DataLayout config => AlignWithFragments
+    let _f = FailGuard::new("pipe_log::data_layout::force_enable", "return");
+    let cfg_fragments = Config {
+        format_data_layout: DataLayout::AlignWithFragments,
+        ..cfg
+    };
+    let engine = Engine::open(cfg_fragments.clone()).unwrap();
+    append(&engine, rid, 7, 8, Some(&data));
+    append(&engine, rid, 8, 9, Some(&data));
+    append(&engine, rid, 9, 10, Some(&data));
+    drop(engine);
+    assert!(catch_unwind_silent(|| { Engine::open(cfg_fragments) }).is_err());
 }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -596,13 +596,15 @@ fn test_build_engine_with_aligned_datalayout() {
     drop(engine);
     // File with DataLayout::Alignment
     let _f1 = FailGuard::new("pipe_log::log_file::abnormal_block_size", "return");
-    let _f2 = FailGuard::new("pipe_log::log_file_writer::force_rewrite_header", "return");
-    let _f3 = FailGuard::new("file_pipe_log::append::force_aligned_write", "return");
-
-    let engine = Engine::open(cfg.clone()).unwrap();
+    let _f2 = FailGuard::new("file_pipe_log::append::force_aligned_write", "return");
+    let cfg_v2 = Config {
+        format_version: Version::V2,
+        ..cfg
+    };
+    let engine = Engine::open(cfg_v2.clone()).unwrap();
     for rid in 1..=3 {
         append(&engine, rid, 11, 20, Some(&data));
     }
     drop(engine);
-    assert!(Engine::open(cfg).is_ok());
+    assert!(Engine::open(cfg_v2).is_ok());
 }


### PR DESCRIPTION
## PR Description
 
For closing #246, this pr is set. This pr is used for building basics for the new DIO feature, including:
* [New] DataLayout, representing the arrangement on data (records), in alignment or not.
* Refactor LogFileFormat / LogFileContext.
* Add extra support in `stress` tool for the new `alignment-mode` reading.