### PR TITLE
Unify the strategy of tolerating tail corruption when Version == V2.

### DIFF
--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -182,6 +182,13 @@ impl LogFileFormat {
                 data_layout: DataLayout::NoAlignment,
             });
         }
+        #[cfg(feature = "failpoints")]
+        {
+            // Set parsed abnormal DataLayout for `payload`.
+            fail::fail_point!("log_file_header::abnormal_decoded_payload", |_| Err(
+                Error::InvalidArgument("abnormal_decoded_payload".to_string())
+            ));
+        }
         if_chain::if_chain! {
             if payload_len > 0;
             if buf_len >= Self::header_len() + payload_len;

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -303,9 +303,10 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                     let is_last_file = index == chunk_count - 1 && i == file_count - 1;
                     match build_file_reader(file_system.as_ref(), f.handle.clone(), None) {
                         Err(e) => {
+                            let is_tail_fail = matches!(e, Error::InvalidArgument(_));
                             if recovery_mode == RecoveryMode::TolerateAnyCorruption
                               || recovery_mode == RecoveryMode::TolerateTailCorruption
-                                && is_last_file {
+                                && is_last_file && is_tail_fail {
                                 warn!(
                                     "File header is corrupted but ignored: {:?}:{}, {}",
                                     queue, f.seq, e

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -506,11 +506,32 @@ fn test_tail_corruption() {
         drop(engine);
         assert!(Engine::open_with_file_system(cfg, fs.clone()).is_ok());
     }
-    // DataLayout in header is corrupted for Version::V2, followed with records
+    // DataLayout in header is corrupted(decoding) for Version::V2, followed
+    // with records
+    {
+        let _f = FailGuard::new("log_file_header::abnormal_decoded_payload", "return");
+        let dir = tempfile::Builder::new()
+            .prefix("test_tail_corruption_7")
+            .tempdir()
+            .unwrap();
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            ..Default::default()
+        };
+        let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
+        drop(engine);
+        let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
+        append(&engine, rid, 1, 5, Some(&data));
+        drop(engine);
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_err());
+    }
+    // DataLayout in header is corrupted(encoding) for Version::V2, followed
+    // with records
     {
         let _f = FailGuard::new("log_file_header::corrupted_data_layout", "return");
         let dir = tempfile::Builder::new()
-            .prefix("test_tail_corruption_7")
+            .prefix("test_tail_corruption_8")
             .tempdir()
             .unwrap();
         let cfg = Config {

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -450,7 +450,7 @@ fn test_tail_corruption() {
         let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
         append(&engine, rid, 1, 5, Some(&data));
         drop(engine);
-        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_ok());
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_err());
     }
     // Version::V1 in header owns abnormal DataLayout.
     {


### PR DESCRIPTION
Supplemented bugfix for #249 , to unify the strategy on whether tolerating the tail corruption when `version == V2`.

Signed-off-by: Lucasliang <nkcs_lykx@hotmail.com>