### PR TITLE
Extend `LogQueue` to support multiple append channels

### DIFF
--- a/ctl/src/lib.rs
+++ b/ctl/src/lib.rs
@@ -81,8 +81,8 @@ enum Cmd {
 
 fn convert_queue(queue: &str) -> Option<LogQueue> {
     match queue {
-        "append" => Some(LogQueue::Append),
-        "rewrite" => Some(LogQueue::Rewrite),
+        "append" => Some(LogQueue::DEFAULT),
+        "rewrite" => Some(LogQueue::REWRITE),
         "all" => None,
         _ => unreachable!(),
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1473,7 +1473,8 @@ mod tests {
             {
                 // open engine with format_version - Version::V1
                 let engine = RaftLogEngine::open(cfg_v1.clone()).unwrap();
-                engine.append(rid, 0, 20, Some(&data));
+                engine.append(rid, 0, 10, Some(&data));
+                engine.append(rid, 10, 20, Some(&data));
                 let append_first = engine.file_span(LogQueue::DEFAULT).0;
                 engine.compact_to(rid, 18);
                 engine.purge_expired_files().unwrap();
@@ -1486,7 +1487,8 @@ mod tests {
                 let engine = RaftLogEngine::open(cfg_v2.clone()).unwrap();
                 assert_eq!(engine.first_index(rid).unwrap(), 18);
                 assert_eq!(engine.last_index(rid).unwrap(), 19);
-                engine.append(rid, 20, 40, Some(&data));
+                engine.append(rid, 20, 30, Some(&data));
+                engine.append(rid, 30, 40, Some(&data));
                 let append_first = engine.file_span(LogQueue::DEFAULT).0;
                 engine.compact_to(rid, 38);
                 engine.purge_expired_files().unwrap();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -353,10 +353,11 @@ where
     }
 
     pub fn raft_groups(&self) -> Vec<u64> {
-        self.memtables.fold(vec![], |mut v, m| {
+        let mut v = Vec::with_capacity(128);
+        self.memtables.for_each(|m| {
             v.push(m.region_id());
-            v
-        })
+        });
+        v
     }
 
     /// Returns `true` if the engine contains no Raft Group. Empty Raft Group

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue};
+use crate::pipe_log::{FileBlockHandle, FileId, FilesView};
 
 /// `EventListener` contains a set of callback functions that will be notified
 /// on specific events inside Raft Engine.
@@ -27,11 +27,11 @@ pub trait EventListener: Sync + Send {
     /// [`MemTable`]: crate::memtable::MemTable
     fn post_apply_memtables(&self, _file_id: FileId) {}
 
-    /// Returns the oldest file sequence number that are not ready to be purged.
-    fn first_file_not_ready_for_purge(&self, _queue: LogQueue) -> Option<FileSeq> {
+    /// Returns a view of Append log files that can be purged.
+    fn latest_files_view_allowed_to_purge(&self) -> Option<FilesView> {
         None
     }
 
-    /// Called *after* a log file is purged.
+    /// Called *after* `PipeLog::purge_to`.
     fn post_purge(&self, _file_id: FileId) {}
 }

--- a/src/file_pipe_log/format.rs
+++ b/src/file_pipe_log/format.rs
@@ -53,12 +53,12 @@ impl FileNameExt for FileId {
             if let Ok(seq) = file_name[..LOG_SEQ_WIDTH].parse::<u64>() {
                 if file_name.ends_with(LOG_APPEND_SUFFIX) {
                     return Some(FileId {
-                        queue: LogQueue::Append,
+                        queue: LogQueue::DEFAULT,
                         seq,
                     });
                 } else if file_name.ends_with(LOG_REWRITE_SUFFIX) {
                     return Some(FileId {
-                        queue: LogQueue::Rewrite,
+                        queue: LogQueue::REWRITE,
                         seq,
                     });
                 }
@@ -69,16 +69,16 @@ impl FileNameExt for FileId {
 
     fn build_file_name(&self) -> String {
         match self.queue {
-            LogQueue::Append => format!(
-                "{:0width$}{}",
-                self.seq,
-                LOG_APPEND_SUFFIX,
-                width = LOG_SEQ_WIDTH
-            ),
-            LogQueue::Rewrite => format!(
+            LogQueue::REWRITE => format!(
                 "{:0width$}{}",
                 self.seq,
                 LOG_REWRITE_SUFFIX,
+                width = LOG_SEQ_WIDTH
+            ),
+            _ => format!(
+                "{:0width$}{}",
+                self.seq,
+                LOG_APPEND_SUFFIX,
                 width = LOG_SEQ_WIDTH
             ),
         }
@@ -226,7 +226,7 @@ mod tests {
     fn test_file_name() {
         let file_name: &str = "0000000000000123.raftlog";
         let file_id = FileId {
-            queue: LogQueue::Append,
+            queue: LogQueue::DEFAULT,
             seq: 123,
         };
         assert_eq!(FileId::parse_file_name(file_name).unwrap(), file_id,);
@@ -234,7 +234,7 @@ mod tests {
 
         let file_name: &str = "0000000000000123.rewrite";
         let file_id = FileId {
-            queue: LogQueue::Rewrite,
+            queue: LogQueue::REWRITE,
             seq: 123,
         };
         assert_eq!(FileId::parse_file_name(file_name).unwrap(), file_id,);
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn test_file_context() {
         let mut file_context =
-            LogFileContext::new(FileId::dummy(LogQueue::Append), Version::default());
+            LogFileContext::new(FileId::dummy(LogQueue::DEFAULT), Version::default());
         assert_eq!(file_context.get_signature(), None);
         file_context.id.seq = 10;
         file_context.version = Version::V2;

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -109,7 +109,7 @@ pub mod debug {
                     dir.display()
                 )));
             }
-            let files: Vec<_> = std::fs::read_dir(dir)?
+            let mut files: Vec<_> = std::fs::read_dir(dir)?
                 .filter_map(|e| {
                     if let Ok(e) = e {
                         let p = e.path();
@@ -124,8 +124,13 @@ pub mod debug {
                     None
                 })
                 .collect();
-            // FIXME: best effort sort.
-            // files.sort_by_key(|pair| pair.0);
+            files.sort_by(|a, b| {
+                if a.0.queue == b.0.queue {
+                    a.0.seq.cmp(&b.0.seq)
+                } else {
+                    a.0.queue.i().cmp(&b.0.queue.i())
+                }
+            });
             Ok(Self {
                 system,
                 files: files.into(),

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -109,7 +109,7 @@ pub mod debug {
                     dir.display()
                 )));
             }
-            let mut files: Vec<_> = std::fs::read_dir(dir)?
+            let files: Vec<_> = std::fs::read_dir(dir)?
                 .filter_map(|e| {
                     if let Ok(e) = e {
                         let p = e.path();
@@ -124,7 +124,8 @@ pub mod debug {
                     None
                 })
                 .collect();
-            files.sort_by_key(|pair| pair.0);
+            // FIXME: best effort sort.
+            // files.sort_by_key(|pair| pair.0);
             Ok(Self {
                 system,
                 files: files.into(),

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -185,7 +185,7 @@ pub mod debug {
                 .tempdir()
                 .unwrap();
             let mut file_id = FileId {
-                queue: LogQueue::Rewrite,
+                queue: LogQueue::REWRITE,
                 seq: 7,
             };
             let file_system = Arc::new(DefaultFileSystem);
@@ -271,10 +271,10 @@ pub mod debug {
             let unrelated_file_path = dir.path().join(Path::new("random_file"));
             let _unrelated_file = std::fs::File::create(&unrelated_file_path).unwrap();
             // A corrupted log file.
-            let corrupted_file_path = FileId::dummy(LogQueue::Append).build_file_path(dir.path());
+            let corrupted_file_path = FileId::dummy(LogQueue::DEFAULT).build_file_path(dir.path());
             let _corrupted_file = std::fs::File::create(&corrupted_file_path).unwrap();
             // An empty log file.
-            let empty_file_path = FileId::dummy(LogQueue::Rewrite).build_file_path(dir.path());
+            let empty_file_path = FileId::dummy(LogQueue::REWRITE).build_file_path(dir.path());
             let mut writer = build_file_writer(
                 file_system.as_ref(),
                 &empty_file_path,
@@ -306,7 +306,7 @@ pub mod debug {
                 .unwrap();
             let file_system = Arc::new(DefaultFileSystem);
 
-            let path = FileId::dummy(LogQueue::Append).build_file_path(dir.path());
+            let path = FileId::dummy(LogQueue::DEFAULT).build_file_path(dir.path());
 
             let formats = [
                 LogFileFormat::new(Version::V1, 0),

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -225,7 +225,7 @@ impl<F: FileSystem> SinglePipe<F> {
     /// Creates a new file for write, and rotates the active log file.
     ///
     /// This operation is atomic in face of errors.
-    fn rotate_imp(&self, active_file: &mut MutexGuard<ActiveFile<F>>) -> Result<()> {
+    fn rotate_imp(&self, active_file: &mut MutexGuard<ActiveFile<F>>) -> Result<FileId> {
         let _t = StopWatch::new((
             &*LOG_ROTATE_DURATION_HISTOGRAM,
             perf_context!(log_rotate_duration),
@@ -286,7 +286,7 @@ impl<F: FileSystem> SinglePipe<F> {
             files.fds.len()
         };
         self.flush_metrics(len);
-        Ok(())
+        Ok(file_id)
     }
 
     /// Synchronizes current states to related metrics.
@@ -391,7 +391,7 @@ impl<F: FileSystem> SinglePipe<F> {
         files.fds.len() * self.target_file_size
     }
 
-    fn rotate(&self) -> Result<()> {
+    fn rotate(&self) -> Result<FileId> {
         self.rotate_imp(&mut self.active_file.lock())
     }
 
@@ -535,7 +535,7 @@ impl<F: FileSystem> PipeLog for DualPipes<F> {
     }
 
     #[inline]
-    fn rotate(&self, queue: LogQueue) -> Result<()> {
+    fn rotate(&self, queue: LogQueue) -> Result<FileId> {
         self.pipes[queue.i() as usize].rotate()
     }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -66,7 +66,7 @@ impl RaftGroupState {
                     if self.count > 0 {
                         // hole
                         if first > self.first_index + self.count as u64 {
-                            if queue == LogQueue::Append {
+                            if queue == LogQueue::DEFAULT {
                                 return Err(Error::Corruption("Encountered hole".to_owned()));
                             } else {
                                 self.clear();
@@ -74,14 +74,14 @@ impl RaftGroupState {
                         }
                         // compacted
                         if first < self.first_index {
-                            if queue == LogQueue::Append {
+                            if queue == LogQueue::DEFAULT {
                                 return Err(Error::Corruption("Write to compacted".to_owned()));
                             } else {
                                 self.clear();
                             }
                         }
                         // non-contiguous rewrites
-                        if queue == LogQueue::Rewrite
+                        if queue == LogQueue::REWRITE
                             && self.first_index + (self.rewrite_count as u64) < first
                         {
                             return Err(Error::Corruption(
@@ -93,14 +93,14 @@ impl RaftGroupState {
                         // empty
                         self.first_index = first;
                         self.count = (last - first + 1) as usize;
-                        self.rewrite_count = if queue == LogQueue::Rewrite {
+                        self.rewrite_count = if queue == LogQueue::REWRITE {
                             self.count
                         } else {
                             0
                         };
                     } else {
                         self.count = (last - self.first_index + 1) as usize;
-                        if queue == LogQueue::Rewrite {
+                        if queue == LogQueue::REWRITE {
                             self.rewrite_count = self.count;
                         } else {
                             self.rewrite_count = (first - self.first_index) as usize;
@@ -175,7 +175,7 @@ impl RhaiFilter {
                         state.first_index as i64,
                         state.count as i64,
                         state.rewrite_count as i64,
-                        new_item_queue as i64,
+                        new_item_queue.i() as i64,
                         eis.first().unwrap().index as i64,
                         eis.last().unwrap().index as i64,
                     ),
@@ -190,7 +190,7 @@ impl RhaiFilter {
                     state.first_index as i64,
                     state.count as i64,
                     state.rewrite_count as i64,
-                    new_item_queue as i64,
+                    new_item_queue.i() as i64,
                     *index as i64,
                 ),
             ),
@@ -203,7 +203,7 @@ impl RhaiFilter {
                     state.first_index as i64,
                     state.count as i64,
                     state.rewrite_count as i64,
-                    new_item_queue as i64,
+                    new_item_queue.i() as i64,
                 ),
             ),
             _ => Ok(0),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,25 +96,27 @@ impl GlobalStats {
     #[inline]
     pub fn add(&self, queue: pipe_log::LogQueue, count: usize) {
         match queue {
-            pipe_log::LogQueue::Append => {
+            pipe_log::LogQueue::DEFAULT => {
                 self.live_append_entries.fetch_add(count, Ordering::Relaxed);
             }
-            pipe_log::LogQueue::Rewrite => {
+            pipe_log::LogQueue::REWRITE => {
                 self.rewrite_entries.fetch_add(count, Ordering::Relaxed);
             }
+            _ => unreachable!(),
         }
     }
 
     #[inline]
     pub fn delete(&self, queue: pipe_log::LogQueue, count: usize) {
         match queue {
-            pipe_log::LogQueue::Append => {
+            pipe_log::LogQueue::DEFAULT => {
                 self.live_append_entries.fetch_sub(count, Ordering::Relaxed);
             }
-            pipe_log::LogQueue::Rewrite => {
+            pipe_log::LogQueue::REWRITE => {
                 self.deleted_rewrite_entries
                     .fetch_add(count, Ordering::Relaxed);
             }
+            _ => unreachable!(),
         }
     }
 
@@ -139,13 +141,14 @@ impl GlobalStats {
     #[inline]
     pub fn live_entries(&self, queue: pipe_log::LogQueue) -> usize {
         match queue {
-            pipe_log::LogQueue::Append => self.live_append_entries.load(Ordering::Relaxed),
-            pipe_log::LogQueue::Rewrite => {
+            pipe_log::LogQueue::DEFAULT => self.live_append_entries.load(Ordering::Relaxed),
+            pipe_log::LogQueue::REWRITE => {
                 let op = self.rewrite_entries.load(Ordering::Relaxed);
                 let dop = self.deleted_rewrite_entries.load(Ordering::Relaxed);
                 debug_assert!(op >= dop);
                 op.saturating_sub(dop)
             }
+            _ => unreachable!(),
         }
     }
 
@@ -153,10 +156,10 @@ impl GlobalStats {
     pub fn flush_metrics(&self) {
         metrics::LOG_ENTRY_COUNT
             .rewrite
-            .set(self.live_entries(pipe_log::LogQueue::Rewrite) as i64);
+            .set(self.live_entries(pipe_log::LogQueue::REWRITE) as i64);
         metrics::LOG_ENTRY_COUNT
             .append
-            .set(self.live_entries(pipe_log::LogQueue::Append) as i64);
+            .set(self.live_entries(pipe_log::LogQueue::DEFAULT) as i64);
     }
 }
 

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -983,7 +983,7 @@ mod tests {
         }
 
         let mut entry_indexes_with_file_id =
-            generate_entry_indexes_opt(7, 17, Some(FileId::new(LogQueue::Append, 7)));
+            generate_entry_indexes_opt(7, 17, Some(FileId::new(LogQueue::DEFAULT, 7)));
         let mut decoded = encode_and_decode(&mut entry_indexes_with_file_id);
         assert_ne!(entry_indexes_with_file_id, decoded.0);
         for i in decoded.0.iter_mut() {
@@ -1105,14 +1105,14 @@ mod tests {
             for compression_type in [CompressionType::Lz4, CompressionType::None] {
                 let mut batch = batch.clone();
                 batch.finish_populate(compression_type);
-                batch.finish_write(FileBlockHandle::dummy(LogQueue::Append));
+                batch.finish_write(FileBlockHandle::dummy(LogQueue::DEFAULT));
                 let mut encoded_batch = vec![];
                 batch.encode(&mut encoded_batch).unwrap();
                 let file_context =
-                    LogFileContext::new(FileId::dummy(LogQueue::Append), Version::default());
+                    LogFileContext::new(FileId::dummy(LogQueue::DEFAULT), Version::default());
                 let decoded_batch = LogItemBatch::decode(
                     &mut encoded_batch.as_slice(),
-                    FileBlockHandle::dummy(LogQueue::Append),
+                    FileBlockHandle::dummy(LogQueue::DEFAULT),
                     compression_type,
                     &file_context,
                 )
@@ -1134,11 +1134,11 @@ mod tests {
             // Test call protocol violation.
             assert!(catch_unwind_silent(|| batch.encoded_bytes()).is_err());
             assert!(catch_unwind_silent(
-                || batch.finish_write(FileBlockHandle::dummy(LogQueue::Append))
+                || batch.finish_write(FileBlockHandle::dummy(LogQueue::DEFAULT))
             )
             .is_err());
             let mocked_file_block_handle = FileBlockHandle {
-                id: FileId::new(LogQueue::Append, 12),
+                id: FileId::new(LogQueue::DEFAULT, 12),
                 len: 0,
                 offset: 0,
             };
@@ -1193,7 +1193,7 @@ mod tests {
                         &mut &encoded[offset..],
                         entries_handle,
                         compression_type,
-                        &LogFileContext::new(FileId::new(LogQueue::Append, u64::MAX), version),
+                        &LogFileContext::new(FileId::new(LogQueue::DEFAULT, u64::MAX), version),
                     )
                     .unwrap_err();
                 }
@@ -1278,7 +1278,7 @@ mod tests {
         let mut entries = Vec::new();
         let mut kvs = Vec::new();
         let data = vec![b'x'; 1024];
-        let file_id = FileId::dummy(LogQueue::Append);
+        let file_id = FileId::dummy(LogQueue::DEFAULT);
         let file_context = LogFileContext::new(file_id, Version::default());
 
         let mut batch1 = LogBatch::default();

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -82,12 +82,6 @@ impl FilesView {
         }
     }
 
-    /// Returns whether the view contains any file in Append queue.
-    #[inline]
-    pub fn is_empty(&self) -> bool {
-        self.id_by_channels.iter().any(|seq| seq.is_none())
-    }
-
     /// A simple view that contains default channel files with seqno no larger
     /// than `seq`.
     pub fn simple_view(seq: u64) -> Self {

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -14,11 +14,17 @@ use strum::EnumIter;
 use crate::Result;
 
 /// The type of log queue.
-#[repr(u8)]
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-pub enum LogQueue {
-    Append = 0,
-    Rewrite = 1,
+pub struct LogQueue(u8);
+
+impl LogQueue {
+    pub const REWRITE: LogQueue = LogQueue(0);
+    pub const DEFAULT: LogQueue = LogQueue(1);
+
+    #[inline]
+    pub fn i(&self) -> u8 {
+        self.0
+    }
 }
 
 /// Sequence number for log file. It is unique within a log queue.
@@ -48,8 +54,8 @@ impl FileId {
 impl std::cmp::Ord for FileId {
     fn cmp(&self, other: &Self) -> Ordering {
         match (self.queue, other.queue) {
-            (LogQueue::Append, LogQueue::Rewrite) => Ordering::Greater,
-            (LogQueue::Rewrite, LogQueue::Append) => Ordering::Less,
+            (LogQueue::DEFAULT, LogQueue::REWRITE) => Ordering::Greater,
+            (LogQueue::REWRITE, LogQueue::DEFAULT) => Ordering::Less,
             _ => self.seq.cmp(&other.seq),
         }
     }

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -154,7 +154,7 @@ fn test_pipe_log_listeners() {
     assert_eq!(hook.0[&LogQueue::DEFAULT].applys(), 32);
 
     engine.purge_expired_files().unwrap();
-    assert_eq!(hook.0[&LogQueue::DEFAULT].purged(), 13);
+    assert_eq!(hook.0[&LogQueue::DEFAULT].purged(), 14);
     assert_eq!(hook.0[&LogQueue::REWRITE].purged(), rewrite_files as u64);
 
     // Write region 3 without applying.
@@ -374,7 +374,8 @@ fn test_incomplete_purge() {
 
     {
         let _f = FailGuard::new("file_pipe_log::remove_file_skipped", "return");
-        append(&engine, rid, 0, 20, Some(&data));
+        append(&engine, rid, 0, 10, Some(&data));
+        append(&engine, rid, 10, 20, Some(&data));
         let append_first = engine.file_span(LogQueue::DEFAULT).0;
         engine.compact_to(rid, 18);
         engine.purge_expired_files().unwrap();
@@ -382,13 +383,15 @@ fn test_incomplete_purge() {
     }
 
     // Create a hole.
-    append(&engine, rid, 20, 40, Some(&data));
+    append(&engine, rid, 20, 30, Some(&data));
+    append(&engine, rid, 30, 40, Some(&data));
     let append_first = engine.file_span(LogQueue::DEFAULT).0;
     engine.compact_to(rid, 38);
     engine.purge_expired_files().unwrap();
     assert!(engine.file_span(LogQueue::DEFAULT).0 > append_first);
 
-    append(&engine, rid, 40, 60, Some(&data));
+    append(&engine, rid, 40, 50, Some(&data));
+    append(&engine, rid, 50, 60, Some(&data));
     let append_first = engine.file_span(LogQueue::DEFAULT).0;
     drop(engine);
 

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -150,7 +150,7 @@ fn test_file_rotate_error() {
     engine
         .write(&mut generate_batch(1, 3, 4, Some(&entry)), false)
         .unwrap();
-    assert_eq!(engine.file_span(LogQueue::Append).1, 1);
+    assert_eq!(engine.file_span(LogQueue::DEFAULT).1, 1);
     // The next write will be followed by a rotate.
     {
         // Fail to sync old log file.
@@ -159,7 +159,7 @@ fn test_file_rotate_error() {
             let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
         })
         .is_err());
-        assert_eq!(engine.file_span(LogQueue::Append).1, 1);
+        assert_eq!(engine.file_span(LogQueue::DEFAULT).1, 1);
     }
     {
         // Fail to create new log file.
@@ -168,7 +168,7 @@ fn test_file_rotate_error() {
             let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
         })
         .is_err());
-        assert_eq!(engine.file_span(LogQueue::Append).1, 1);
+        assert_eq!(engine.file_span(LogQueue::DEFAULT).1, 1);
     }
     {
         // Fail to write header of new log file.
@@ -177,7 +177,7 @@ fn test_file_rotate_error() {
             let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
         })
         .is_err());
-        assert_eq!(engine.file_span(LogQueue::Append).1, 1);
+        assert_eq!(engine.file_span(LogQueue::DEFAULT).1, 1);
     }
     {
         // Fail to sync new log file. The old log file is already sync-ed at this point.
@@ -186,7 +186,7 @@ fn test_file_rotate_error() {
             let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
         })
         .is_err());
-        assert_eq!(engine.file_span(LogQueue::Append).1, 1);
+        assert_eq!(engine.file_span(LogQueue::DEFAULT).1, 1);
     }
 
     // We can continue writing after the incidents.


### PR DESCRIPTION
Ref #258

- Add `LogQueue(u8)` to reference different write channels
- Introduce `FilesView` to filter log entries older than a specific timepoint (see comments for `history_files_view`)
- Use `LogKind` in places where channel details are irrelevant

Most of the code is doing basically the same thing but renamed.