### PR TITLE
clean up file collection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,8 @@ impl Default for Config {
         #[cfg(test)]
         {
             cfg.memory_limit = Some(ReadableSize(0));
+            cfg.format_version = Version::V2;
+            cfg.enable_log_recycle = true;
         }
         cfg
     }
@@ -148,18 +150,11 @@ impl Config {
             );
             self.recovery_threads = MIN_RECOVERY_THREADS;
         }
-        if self.enable_log_recycle {
-            if !self.format_version.has_log_signing() {
-                return Err(box_err!(
-                    "format version {} doesn't support log recycle, use 2 or above",
-                    self.format_version
-                ));
-            }
-            if self.purge_threshold.0 / self.target_file_size.0 >= std::u32::MAX as u64 {
-                return Err(box_err!(
-                    "File count exceed u32::MAX, calculated by `purge-threshold / target-file-size`"
-                ));
-            }
+        if self.enable_log_recycle && !self.format_version.has_log_signing() {
+            return Err(box_err!(
+                "format version {} doesn't support log recycle, use 2 or above",
+                self.format_version
+            ));
         }
         #[cfg(not(feature = "swap"))]
         if self.memory_limit.is_some() {
@@ -177,7 +172,11 @@ impl Config {
             return 0;
         }
         if self.enable_log_recycle && self.purge_threshold.0 >= self.target_file_size.0 {
-            (self.purge_threshold.0 / self.target_file_size.0) as usize
+            // This is required to squeeze file signature into an u32.
+            std::cmp::min(
+                (self.purge_threshold.0 / self.target_file_size.0) as usize,
+                u32::MAX as usize,
+            )
         } else {
             0
         }
@@ -213,7 +212,6 @@ mod tests {
         assert_eq!(load.target_file_size, ReadableSize::mb(1));
         assert_eq!(load.purge_threshold, ReadableSize::mb(3));
         assert_eq!(load.format_version, Version::V1);
-        assert!(!load.enable_log_recycle);
     }
 
     #[test]
@@ -246,20 +244,12 @@ mod tests {
         assert_eq!(soft_sanitized.format_version, Version::V2);
         assert!(soft_sanitized.enable_log_recycle);
 
-        let format_error = r#"
+        let recycle_error = r#"
             enable-log-recycle = true
+            format-version = 1
         "#;
-        let mut cfg_load: Config = toml::from_str(format_error).unwrap();
+        let mut cfg_load: Config = toml::from_str(recycle_error).unwrap();
         assert!(cfg_load.sanitize().is_err());
-
-        let file_count_error = r#"
-            target-file-size = "1B"
-            purge-threshold = "4GB"
-            format-version = 2
-            enable-log-recycle = true
-        "#;
-        let mut file_count_load: Config = toml::from_str(file_count_error).unwrap();
-        assert!(file_count_load.sanitize().is_err());
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2170,6 +2170,7 @@ mod tests {
             target_file_size: ReadableSize(1),
             purge_threshold: ReadableSize(1024),
             format_version: Version::V1,
+            enable_log_recycle: false,
             ..Default::default()
         };
         let cfg_v2 = Config {

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -33,7 +33,8 @@ struct FileCollection<F: FileSystem> {
     first_seq_in_use: FileSeq,
     fds: VecDeque<FileWithFormat<F>>,
     /// A hint to control the amount of stale files.
-    /// Unless `active_len() > capacity`, `len() <= capacity`.
+    /// `fds.len()` should be no larger than `capacity` unless it is full of
+    /// active files.
     capacity: usize,
 }
 


### PR DESCRIPTION
* Putting mutable operations into methods
* Clean up tests
* Log recycling doesn't affect `purge_to` return value any more
* Disallow reading stale files via pipe_log
* Enable recycling for tests

Signed-off-by: tabokie <xy.tao@outlook.com>