### PR TITLE
fix panic when reusing a was-empty batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
 * Avoid leaving fractured write after failure by reseeking the file writer. Panic if the reseek fails as well.
+* Fix panic when an empty batch is written to engine and then reused.
 
 ### New Features
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1397,6 +1397,34 @@ mod tests {
         );
     }
 
+    #[ignore]
+    #[test]
+    fn test_empty_batch() {
+        let dir = tempfile::Builder::new()
+            .prefix("test_empty_batch")
+            .tempdir()
+            .unwrap();
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            ..Default::default()
+        };
+        let engine =
+            RaftLogEngine::open_with_file_system(cfg, Arc::new(ObfuscatedFileSystem::default()))
+                .unwrap();
+        let data = vec![b'x'; 16];
+        let cases = [[false, false], [false, true], [true, true]];
+        for (i, writes) in cases.iter().enumerate() {
+            let rid = i as u64;
+            let mut batch = LogBatch::default();
+            for &has_data in writes {
+                if has_data {
+                    batch.put(rid, b"key".to_vec(), data.clone());
+                }
+                engine.write(&mut batch, true).unwrap();
+            }
+        }
+    }
+
     #[test]
     fn test_dirty_recovery() {
         let dir = tempfile::Builder::new()

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -141,7 +141,6 @@ where
         }
         let start = Instant::now();
         let len = log_batch.finish_populate(self.cfg.batch_compression_threshold.0 as usize)?;
-        debug_assert!(!log_batch.is_empty());
         debug_assert!(len > 0);
         let block_handle = {
             let mut writer = Writer::new(log_batch, sync);


### PR DESCRIPTION
Close #266

An empty batch went through `finish_populate` but not `drain` (in memtable apply block). This will break internal state machine and panic.