### PR TITLE
hide more file writing details from engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 * Add metadata deletion capability to `FileSystem` trait. Users can implement `exists_metadata` and `delete_metadata` to clean up obsolete metadata from older versions of Raft Engine.
 * Add `Engine::scan_messages` and `Engine::scan_raw_messages` for iterating over written key-values. 
 * Add `Engine::get` for getting raw value.
+* Move `sync` from `env::WriteExt` to `env::Handle`.
+* Deprecate `bytes_per_sync`.
 
 ### Behavior Changes
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,11 +49,12 @@ pub struct Config {
     ///
     /// Default: "8KB"
     pub batch_compression_threshold: ReadableSize,
+    /// Deprecated.
     /// Incrementally sync log files after specified bytes have been written.
     /// Setting it to zero disables incremental sync.
     ///
     /// Default: "4MB"
-    pub bytes_per_sync: ReadableSize,
+    pub bytes_per_sync: Option<ReadableSize>,
 
     /// Version of the log file.
     ///
@@ -101,7 +102,7 @@ impl Default for Config {
             recovery_read_block_size: ReadableSize::kb(16),
             recovery_threads: 4,
             batch_compression_threshold: ReadableSize::kb(8),
-            bytes_per_sync: ReadableSize::mb(4),
+            bytes_per_sync: None,
             format_version: Version::V1,
             target_file_size: ReadableSize::mb(128),
             purge_threshold: ReadableSize::gb(10),
@@ -132,8 +133,8 @@ impl Config {
                 self.target_file_size.0,
             )));
         }
-        if self.bytes_per_sync.0 == 0 {
-            self.bytes_per_sync = ReadableSize(u64::MAX);
+        if self.bytes_per_sync.is_some() {
+            warn!("bytes-per-sync has been deprecated.");
         }
         let min_recovery_read_block_size = ReadableSize(MIN_RECOVERY_READ_BLOCK_SIZE as u64);
         if self.recovery_read_block_size < min_recovery_read_block_size {
@@ -208,7 +209,7 @@ mod tests {
         let load: Config = toml::from_str(custom).unwrap();
         assert_eq!(load.dir, "custom_dir");
         assert_eq!(load.recovery_mode, RecoveryMode::TolerateTailCorruption);
-        assert_eq!(load.bytes_per_sync, ReadableSize::kb(2));
+        assert_eq!(load.bytes_per_sync, Some(ReadableSize::kb(2)));
         assert_eq!(load.target_file_size, ReadableSize::mb(1));
         assert_eq!(load.purge_threshold, ReadableSize::mb(3));
         assert_eq!(load.format_version, Version::V1);
@@ -226,7 +227,6 @@ mod tests {
         let soft_error = r#"
             recovery-read-block-size = "1KB"
             recovery-threads = 0
-            bytes-per-sync = "0KB"
             target-file-size = "5000MB"
             format-version = 2
             enable-log-recycle = true
@@ -236,7 +236,6 @@ mod tests {
         soft_sanitized.sanitize().unwrap();
         assert!(soft_sanitized.recovery_read_block_size.0 >= MIN_RECOVERY_READ_BLOCK_SIZE as u64);
         assert!(soft_sanitized.recovery_threads >= MIN_RECOVERY_THREADS);
-        assert_eq!(soft_sanitized.bytes_per_sync.0, u64::MAX);
         assert_eq!(
             soft_sanitized.purge_rewrite_threshold.unwrap(),
             soft_sanitized.target_file_size

--- a/src/config.rs
+++ b/src/config.rs
@@ -204,14 +204,16 @@ mod tests {
             target-file-size = "1MB"
             purge-threshold = "3MB"
             format-version = 1
+            enable-log-recycle = false
         "#;
-        let load: Config = toml::from_str(custom).unwrap();
+        let mut load: Config = toml::from_str(custom).unwrap();
         assert_eq!(load.dir, "custom_dir");
         assert_eq!(load.recovery_mode, RecoveryMode::TolerateTailCorruption);
         assert_eq!(load.bytes_per_sync, Some(ReadableSize::kb(2)));
         assert_eq!(load.target_file_size, ReadableSize::mb(1));
         assert_eq!(load.purge_threshold, ReadableSize::mb(3));
         assert_eq!(load.format_version, Version::V1);
+        load.sanitize().unwrap();
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -165,7 +165,9 @@ where
                 }
                 perf_context!(log_write_duration).observe_since(now);
                 if sync {
-                    self.pipe_log.sync(LogQueue::Append)?
+                    // As per trait protocol, this error should be retriable. But we panic anyway to
+                    // save the trouble of propagating it to other group members.
+                    self.pipe_log.sync(LogQueue::Append).expect("pipe::sync()");
                 }
                 // Pass the perf context diff to all the writers.
                 let diff = get_perf_context();

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -155,7 +155,7 @@ where
                     let res = if !log_batch.is_empty() {
                         log_batch.prepare_write(&file_context)?;
                         self.pipe_log
-                            .append(LogQueue::Append, log_batch.encoded_bytes())
+                            .append(LogQueue::Append, &mut log_batch.encoded_bytes())
                     } else {
                         // TODO(tabokie): use Option<FileBlockHandle> instead.
                         Ok(FileBlockHandle {

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -147,15 +147,12 @@ where
             if let Some(mut group) = self.write_barrier.enter(&mut writer) {
                 let now = Instant::now();
                 let _t = StopWatch::new_with(&*ENGINE_WRITE_LEADER_DURATION_HISTOGRAM, now);
-                let file_context = self.pipe_log.fetch_active_file(LogQueue::Append);
                 for writer in group.iter_mut() {
                     writer.entered_time = Some(now);
                     sync |= writer.sync;
                     let log_batch = writer.mut_payload();
                     let res = if !log_batch.is_empty() {
-                        log_batch.prepare_write(&file_context)?;
-                        self.pipe_log
-                            .append(LogQueue::Append, &mut log_batch.encoded_bytes())
+                        self.pipe_log.append(LogQueue::Append, log_batch)
                     } else {
                         // TODO(tabokie): use Option<FileBlockHandle> instead.
                         Ok(FileBlockHandle {
@@ -166,9 +163,6 @@ where
                     };
                     writer.set_output(res);
                 }
-                debug_assert!(
-                    file_context.id == self.pipe_log.fetch_active_file(LogQueue::Append).id
-                );
                 perf_context!(log_write_duration).observe_since(now);
                 if let Err(e) = self.pipe_log.maybe_sync(LogQueue::Append, sync) {
                     panic!(

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -56,11 +56,12 @@ pub trait Handle {
 
     /// Returns the current size of this file.
     fn file_size(&self) -> Result<usize>;
+
+    fn sync(&self) -> Result<()>;
 }
 
 /// WriteExt is writer extension api
 pub trait WriteExt {
     fn truncate(&mut self, offset: usize) -> Result<()>;
-    fn sync(&mut self) -> Result<()>;
     fn allocate(&mut self, offset: usize, size: usize) -> Result<()>;
 }

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -57,10 +57,6 @@ impl WriteExt for ObfuscatedWriter {
         self.0.truncate(offset)
     }
 
-    fn sync(&mut self) -> IoResult<()> {
-        self.0.sync()
-    }
-
     fn allocate(&mut self, offset: usize, size: usize) -> IoResult<()> {
         self.0.allocate(offset, size)
     }

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -11,7 +11,7 @@ use protobuf::Message;
 use crate::codec::{self, NumberEncoder};
 use crate::memtable::EntryIndex;
 use crate::metrics::StopWatch;
-use crate::pipe_log::{FileBlockHandle, FileId, LogFileContext};
+use crate::pipe_log::{FileBlockHandle, FileId, LogFileContext, ReactiveBytes};
 use crate::util::{crc32, lz4};
 use crate::{perf_context, Error, Result};
 
@@ -899,6 +899,13 @@ impl LogBatch {
         } else {
             Ok(Vec::new())
         }
+    }
+}
+
+impl ReactiveBytes for LogBatch {
+    fn as_bytes(&mut self, ctx: &LogFileContext) -> &[u8] {
+        self.prepare_write(ctx).unwrap();
+        self.encoded_bytes()
     }
 }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -721,16 +721,12 @@ impl<A: AllocatorTrait> MemTable<A> {
         }
     }
 
-    /// Returns the number of entries smaller than or equal to `gate`.
-    pub fn entries_count_before(&self, mut gate: FileId) -> usize {
-        gate.seq += 1;
-        let idx = self
-            .entry_indexes
-            .binary_search_by_key(&gate, |ei| ei.entries.unwrap().id);
-        match idx {
-            Ok(idx) => idx,
-            Err(idx) => idx,
-        }
+    #[inline]
+    pub fn has_at_least_some_entries_before(&self, gate: FileId, count: usize) -> bool {
+        debug_assert!(count > 0);
+        self.entry_indexes
+            .get(count - 1)
+            .map_or(false, |ei| ei.entries.unwrap().id.seq <= gate.seq)
     }
 
     /// Returns the region ID.

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -161,6 +161,13 @@ where
 }
 
 /// A `PipeLog` serves reads and writes over multiple queues of log files.
+///
+/// # Safety
+///
+/// The pipe will panic if it encounters an unrecoverable failure. Otherwise the
+/// operations on it should be atomic, i.e. failed operation will not affect
+/// other ones, and user can still use it afterwards without breaking
+/// consistency.
 pub trait PipeLog: Sized {
     /// Reads some bytes from the specified position.
     fn read_bytes(&self, handle: FileBlockHandle) -> Result<Vec<u8>>;
@@ -173,12 +180,11 @@ pub trait PipeLog: Sized {
         bytes: &mut T,
     ) -> Result<FileBlockHandle>;
 
-    /// Hints it to synchronize buffered writes. The synchronization is
-    /// mandotory when `sync` is true.
+    /// Synchronize buffered writes.
     ///
     /// This operation might incurs a great latency overhead. It's advised to
     /// call it once every batch of writes.
-    fn maybe_sync(&self, queue: LogQueue, sync: bool) -> Result<()>;
+    fn sync(&self, queue: LogQueue) -> Result<()>;
 
     /// Returns the smallest and largest file sequence number, still in use,
     /// of the specified log queue.

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -167,8 +167,6 @@ pub trait PipeLog: Sized {
 
     /// Appends some bytes to the specified log queue. Returns file position of
     /// the written bytes.
-    ///
-    /// The result of `fetch_active_file` will not be affected by this method.
     fn append<T: ReactiveBytes + ?Sized>(
         &self,
         queue: LogQueue,
@@ -212,8 +210,4 @@ pub trait PipeLog: Sized {
     ///
     /// Returns the number of deleted files.
     fn purge_to(&self, file_id: FileId) -> Result<usize>;
-
-    /// Returns [`LogFileContext`] of the active file in the specific
-    /// log queue.
-    fn fetch_active_file(&self, queue: LogQueue) -> LogFileContext;
 }

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -180,7 +180,7 @@ pub trait PipeLog: Sized {
         bytes: &mut T,
     ) -> Result<FileBlockHandle>;
 
-    /// Synchronize buffered writes.
+    /// Synchronizes all buffered writes.
     ///
     /// This operation might incurs a great latency overhead. It's advised to
     /// call it once every batch of writes.

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -351,11 +351,7 @@ where
         if len == 0 {
             return self.pipe_log.maybe_sync(LogQueue::Rewrite, sync);
         }
-        let file_context = self.pipe_log.fetch_active_file(LogQueue::Rewrite);
-        log_batch.prepare_write(&file_context)?;
-        let file_handle = self
-            .pipe_log
-            .append(LogQueue::Rewrite, &mut log_batch.encoded_bytes())?;
+        let file_handle = self.pipe_log.append(LogQueue::Rewrite, log_batch)?;
         self.pipe_log.maybe_sync(LogQueue::Rewrite, sync)?;
         log_batch.finish_write(file_handle);
         self.memtables.apply_rewrite_writes(

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -359,13 +359,11 @@ where
         rewrite_watermark: Option<FileSeq>,
         sync: bool,
     ) -> Result<()> {
-        let len = log_batch.finish_populate(self.cfg.batch_compression_threshold.0 as usize)?;
-        if len == 0 {
-            if sync {
-                self.pipe_log.sync(LogQueue::Rewrite)?
-            }
-            return Ok(());
+        if log_batch.is_empty() {
+            debug_assert!(sync);
+            return self.pipe_log.sync(LogQueue::Rewrite);
         }
+        log_batch.finish_populate(self.cfg.batch_compression_threshold.0 as usize)?;
         let file_handle = self.pipe_log.append(LogQueue::Rewrite, log_batch)?;
         if sync {
             self.pipe_log.sync(LogQueue::Rewrite)?

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -355,7 +355,7 @@ where
         log_batch.prepare_write(&file_context)?;
         let file_handle = self
             .pipe_log
-            .append(LogQueue::Rewrite, log_batch.encoded_bytes())?;
+            .append(LogQueue::Rewrite, &mut log_batch.encoded_bytes())?;
         self.pipe_log.maybe_sync(LogQueue::Rewrite, sync)?;
         log_batch.finish_write(file_handle);
         self.memtables.apply_rewrite_writes(

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -127,7 +127,7 @@ fn test_pipe_log_listeners() {
         assert_eq!(hook.0[&LogQueue::Append].appends(), i);
         assert_eq!(hook.0[&LogQueue::Append].applys(), i);
     }
-    assert_eq!(hook.0[&LogQueue::Append].files(), 11);
+    assert_eq!(hook.0[&LogQueue::Append].files(), 10);
 
     engine.purge_expired_files().unwrap();
     assert_eq!(hook.0[&LogQueue::Append].purged(), 8);
@@ -154,7 +154,7 @@ fn test_pipe_log_listeners() {
     assert_eq!(hook.0[&LogQueue::Append].applys(), 32);
 
     engine.purge_expired_files().unwrap();
-    assert_eq!(hook.0[&LogQueue::Append].purged(), 13);
+    assert_eq!(hook.0[&LogQueue::Append].purged(), 14);
     assert_eq!(hook.0[&LogQueue::Rewrite].purged(), rewrite_files as u64);
 
     // Write region 3 without applying.

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -148,6 +148,9 @@ fn test_file_rotate_error() {
     engine
         .write(&mut generate_batch(1, 3, 4, Some(&entry)), false)
         .unwrap();
+    engine
+        .write(&mut generate_batch(1, 4, 5, Some(&entry)), false)
+        .unwrap();
     assert_eq!(engine.file_span(LogQueue::Append).1, 1);
     // The next write will be followed by a rotate.
     {

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -84,7 +84,6 @@ fn test_file_write_error() {
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1024),
         target_file_size: ReadableSize::kb(1024),
         ..Default::default()
     };
@@ -133,7 +132,6 @@ fn test_file_rotate_error() {
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1024),
         target_file_size: ReadableSize::kb(4),
         ..Default::default()
     };
@@ -209,7 +207,6 @@ fn test_concurrent_write_error() {
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1024),
         target_file_size: ReadableSize::kb(1024),
         ..Default::default()
     };
@@ -295,7 +292,6 @@ fn test_non_atomic_write_error() {
         .unwrap();
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        bytes_per_sync: ReadableSize::kb(1024),
         target_file_size: ReadableSize::kb(1024),
         ..Default::default()
     };


### PR DESCRIPTION
This is a preparing work for #258.

Changes:
- Move `fsync` to file handle instead of writer, so that we can call it concurrently in the future. In doing so, we have to remove the sync offset tracking and deprecate `bytes_per_sync` support
- Move `prepare_write` into pipe_log. Introduce a trait `ReactiveBytes` for this purpose.
- Rotate the file during write instead of doing it every write group, the timing is also delayed to the next write after exceeding limit (instead of the write that exceeds the limit).
- Differentiate two types of I/O errors: unrecoverable error from fsync, and retriable error from pwrite. Only bubble error for the latter case, panic early for unrecoverable ones.
- Also refactor the purge code, fix two cases where force-compact is not triggered