### PR TITLE
Disable `enable-log-recycle` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 ### Behavior Changes
 
 * Change format version to 2 from 1 by default.
-* Enable log recycling by default.
+* Disable log recycling by default.
 
 ## [0.2.0] - 2022-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Raft Engine Change Log
 
+## [Unreleased]
+
+### Behavior Changes
+
+* Disable log recycling by default.
+
 ## [0.3.0] - 2022-09-14
 
 ### Bug Fixes
@@ -26,7 +32,7 @@
 ### Behavior Changes
 
 * Change format version to 2 from 1 by default.
-* Disable log recycling by default.
+* Enable log recycling by default.
 
 ## [0.2.0] - 2022-05-25
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,7 +89,7 @@ pub struct Config {
     /// If `true`, logically purged log files will be reserved for recycling.
     /// Only available for `format_version` 2 and above.
     ///
-    /// Default: true
+    /// Default: false
     pub enable_log_recycle: bool,
 }
 
@@ -109,7 +109,7 @@ impl Default for Config {
             purge_rewrite_threshold: None,
             purge_rewrite_garbage_ratio: 0.6,
             memory_limit: None,
-            enable_log_recycle: true,
+            enable_log_recycle: false,
         };
         // Test-specific configurations.
         #[cfg(test)]


### PR DESCRIPTION
### Description
Disable `enable-log-recycle` in raft-engine by default.

When opening `log recycling`,
> We observe on physical disk, overwriting existing log files will generate unnecessary read I/Os, and even though the fdatasync latency is reduced, the duration sum of fdatasync and pwrite has increased.

So, we disable it by default.

Signed-off-by: Lucasliang <nkcs_lykx@hotmail.com>