### PR TITLE
Fix the compilation bug when `make` with `rustc xxx +nightly`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,9 @@ WITH_NIGHTLY_FEATURES = 1
 endif
 
 TOOLCHAIN_ARGS =
-ifeq ($(shell (rustc --version | grep -q nightly); echo $$?), 0)
 ifdef WITH_NIGHTLY_FEATURES
 # Force use nightly toolchain if we are building with nightly features.
 TOOLCHAIN_ARGS = +nightly
-endif
 else
 ifeq ($(WITH_STABLE_TOOLCHAIN), force)
 TOOLCHAIN_ARGS = +stable

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WITH_NIGHTLY_FEATURES = 1
 endif
 
 TOOLCHAIN_ARGS =
-ifeq ($(shell (rustc --version | grep -q nightly); echo $$?), 1)
+ifeq ($(shell (rustc --version | grep -q nightly); echo $$?), 0)
 ifdef WITH_NIGHTLY_FEATURES
 # Force use nightly toolchain if we are building with nightly features.
 TOOLCHAIN_ARGS = +nightly
@@ -24,7 +24,7 @@ TOOLCHAIN_ARGS = +stable
 endif
 endif
 
-.PHONY: format clippy test
+.PHONY: all
 
 all: format clippy test
 


### PR DESCRIPTION
## Description
Fix the bug when using nightly version `rustc 1.59.0-nightly (cfa4ac66c 2022-01-06)`, `make` do not compile the whole project with nightly features.

## Expectation with this PR
For example:
1. Default `make clippy`:
```
> make clippy
cargo +nightly clippy --all --all-features --all-targets -- -D clippy::all
```

2. `make clippy` with `auto`:
```
> make WITH_STABLE_TOOLCHAIN=auto clippy
cargo  clippy --all --features all_stable --all-targets -- -D clippy::all
```

3. `make clippy` with `force`:
```
> make WITH_STABLE_TOOLCHAIN=force clippy
cargo +stable clippy --all --features all_stable --all-targets -- -D clippy::all
```
