### PR TITLE
fix data loss after partial rewrite-rewrite

### DIFF
--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -76,11 +76,17 @@ impl<F: FileSystem> LogFileWriter<F> {
 
     pub fn close(&mut self) -> Result<()> {
         // Necessary to truncate extra zeros from fallocate().
-        self.truncate()?;
+        self.truncate(None)?;
         self.sync()
     }
 
-    pub fn truncate(&mut self) -> Result<()> {
+    pub fn truncate(&mut self, offset: Option<usize>) -> Result<()> {
+        if let Some(offset) = offset {
+            if offset < self.written {
+                self.writer.seek(SeekFrom::Start(offset as u64))?;
+                self.written = offset;
+            }
+        }
         if self.written < self.capacity {
             fail_point!("file_pipe_log::log_file_writer::skip_truncate", |_| {
                 Ok(())

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -335,8 +335,8 @@ impl<F: FileSystem> DualPipesBuilder<F> {
                                 if recovery_mode == RecoveryMode::TolerateTailCorruption
                                     && is_last_file =>
                             {
-                                warn!(
-                                    "The last log file is corrupted but ignored: {:?}:{}, {}",
+                                info!(
+                                    "Log file is truncated at tail: {:?}:{}, {}",
                                     queue, f.seq, e
                                 );
                                 f.handle.truncate(reader.valid_offset())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub mod internals {
     pub use crate::file_pipe_log::*;
     pub use crate::memtable::*;
     pub use crate::pipe_log::*;
+    pub use crate::purge::*;
     #[cfg(feature = "swap")]
     pub use crate::swappy_allocator::*;
     pub use crate::write_barrier::*;

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -160,6 +160,11 @@ where
     }
 }
 
+pub struct PipeSnapshot {
+    pub file_id: FileId,
+    pub offset: usize,
+}
+
 /// A `PipeLog` serves reads and writes over multiple queues of log files.
 ///
 /// # Safety
@@ -216,4 +221,9 @@ pub trait PipeLog: Sized {
     ///
     /// Returns the number of deleted files.
     fn purge_to(&self, file_id: FileId) -> Result<usize>;
+
+    fn snapshot(&self, queue: LogQueue) -> PipeSnapshot;
+    /// Deletes all log files not visible in `snapshot`. This call should be
+    /// retriable on I/O error.
+    fn restore(&self, snapshot: PipeSnapshot) -> Result<()>;
 }

--- a/src/pipe_log.rs
+++ b/src/pipe_log.rs
@@ -160,11 +160,6 @@ where
     }
 }
 
-pub struct PipeSnapshot {
-    pub file_id: FileId,
-    pub offset: usize,
-}
-
 /// A `PipeLog` serves reads and writes over multiple queues of log files.
 ///
 /// # Safety
@@ -222,8 +217,7 @@ pub trait PipeLog: Sized {
     /// Returns the number of deleted files.
     fn purge_to(&self, file_id: FileId) -> Result<usize>;
 
-    fn snapshot(&self, queue: LogQueue) -> PipeSnapshot;
-    /// Deletes all log files not visible in `snapshot`. This call should be
+    /// Deletes all log files larger than `file_id`. This call should be
     /// retriable on I/O error.
-    fn restore(&self, snapshot: PipeSnapshot) -> Result<()>;
+    fn truncate(&self, file_id: FileId) -> Result<()>;
 }


### PR DESCRIPTION
Fix #288 by adding a file marker during rewrite.

A more elegant fix would be https://github.com/tikv/raft-engine/issues/252, but that requires some radical architectural changes.

Signed-off-by: tabokie <xy.tao@outlook.com>