### PR TITLE
use option<> for purge_threshold and recovery_threads

### DIFF
--- a/examples/append_compact_purge.rs
+++ b/examples/append_compact_purge.rs
@@ -24,7 +24,7 @@ fn main() {
 
     let config = Config {
         dir: "append-compact-purge-data".to_owned(),
-        purge_threshold: ReadableSize::gb(2),
+        purge_threshold: Some(ReadableSize::gb(2)),
         batch_compression_threshold: ReadableSize::kb(0),
         ..Default::default()
     };

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1192,7 +1192,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize::kb(5),
-            purge_threshold: ReadableSize::kb(150),
+            purge_threshold: Some(ReadableSize::kb(150)),
             ..Default::default()
         };
 
@@ -1253,7 +1253,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize::kb(1),
-            purge_threshold: ReadableSize::kb(10),
+            purge_threshold: Some(ReadableSize::kb(10)),
             ..Default::default()
         };
 
@@ -1309,7 +1309,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize::kb(5),
-            purge_threshold: ReadableSize::kb(80),
+            purge_threshold: Some(ReadableSize::kb(80)),
             ..Default::default()
         };
         let engine =
@@ -1580,7 +1580,7 @@ pub(crate) mod tests {
             let cfg_v1 = Config {
                 dir: dir.path().to_str().unwrap().to_owned(),
                 target_file_size: ReadableSize(1),
-                purge_threshold: ReadableSize(1),
+                purge_threshold: Some(ReadableSize(1)),
                 format_version: Version::V1,
                 enable_log_recycle: false,
                 ..Default::default()
@@ -1589,7 +1589,7 @@ pub(crate) mod tests {
             let cfg_v2 = Config {
                 dir: dir.path().to_str().unwrap().to_owned(),
                 target_file_size: ReadableSize(1),
-                purge_threshold: ReadableSize(1),
+                purge_threshold: Some(ReadableSize(1)),
                 format_version: Version::V2,
                 enable_log_recycle: false,
                 ..Default::default()
@@ -1606,7 +1606,7 @@ pub(crate) mod tests {
             let cfg_v1 = Config {
                 dir: dir.path().to_str().unwrap().to_owned(),
                 target_file_size: ReadableSize(1),
-                purge_threshold: ReadableSize(1),
+                purge_threshold: Some(ReadableSize(1)),
                 format_version: Version::V1,
                 enable_log_recycle: false,
                 ..Default::default()
@@ -1615,7 +1615,7 @@ pub(crate) mod tests {
             let cfg_v2 = Config {
                 dir: dir.path().to_str().unwrap().to_owned(),
                 target_file_size: ReadableSize(1),
-                purge_threshold: ReadableSize(1),
+                purge_threshold: Some(ReadableSize(1)),
                 format_version: Version::V2,
                 enable_log_recycle: true,
                 prefill_for_recycle: true,
@@ -2098,7 +2098,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(1),
+            purge_threshold: Some(ReadableSize(1)),
             enable_log_recycle: false,
             ..Default::default()
         };
@@ -2153,7 +2153,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(100),
+            purge_threshold: Some(ReadableSize(100)),
             format_version: Version::V2,
             enable_log_recycle: true,
             prefill_for_recycle: true,
@@ -2245,7 +2245,7 @@ pub(crate) mod tests {
         let cfg_v1 = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(1024),
+            purge_threshold: Some(ReadableSize(1024)),
             format_version: Version::V1,
             enable_log_recycle: false,
             ..Default::default()
@@ -2253,7 +2253,7 @@ pub(crate) mod tests {
         let cfg_v2 = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(15),
+            purge_threshold: Some(ReadableSize(15)),
             format_version: Version::V2,
             enable_log_recycle: true,
             ..Default::default()
@@ -2344,7 +2344,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: path.to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(80), // common size of capacity
+            purge_threshold: Some(ReadableSize(80)), // common size of capacity
             enable_log_recycle: true,
             prefill_for_recycle: true,
             ..Default::default()
@@ -2370,7 +2370,7 @@ pub(crate) mod tests {
         // will be cleared.
         let cfg_v2 = Config {
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(50),
+            purge_threshold: Some(ReadableSize(50)),
             ..cfg
         };
         let engine =
@@ -2393,7 +2393,7 @@ pub(crate) mod tests {
         // cleared.
         let cfg_v3 = Config {
             target_file_size: ReadableSize::kb(2),
-            purge_threshold: ReadableSize::kb(100),
+            purge_threshold: Some(ReadableSize::kb(100)),
             enable_log_recycle: false,
             prefill_for_recycle: false,
             ..cfg_v2
@@ -2411,7 +2411,7 @@ pub(crate) mod tests {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             // Make sure each file gets replayed individually.
-            recovery_threads: 100,
+            recovery_threads: Some(100),
             ..Default::default()
         };
         let fs = Arc::new(ObfuscatedFileSystem::default());
@@ -2672,7 +2672,7 @@ pub(crate) mod tests {
         let cfg_2 = Config {
             enable_log_recycle: true,
             prefill_for_recycle: true,
-            purge_threshold: ReadableSize(40),
+            purge_threshold: Some(ReadableSize(40)),
             ..cfg
         };
         let engine =
@@ -2719,7 +2719,7 @@ pub(crate) mod tests {
         let cfg_3 = Config {
             enable_log_recycle: false,
             prefill_for_recycle: false,
-            purge_threshold: ReadableSize(40),
+            purge_threshold: Some(ReadableSize(40)),
             ..cfg_2
         };
         let engine = RaftLogEngine::open_with_file_system(cfg_3, file_system.clone()).unwrap();

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -691,7 +691,7 @@ mod tests {
             dir: path.to_owned(),
             target_file_size: ReadableSize(1),
             // super large capacity for recycling
-            purge_threshold: ReadableSize::mb(100),
+            purge_threshold: Some(ReadableSize::mb(100)),
             enable_log_recycle: true,
             format_version: Version::V2,
             ..Default::default()

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -287,7 +287,7 @@ impl<F: FileSystem> DualPipesBuilder<F> {
             return Ok((machine_factory.new_target(), machine_factory.new_target()));
         }
         let threads = std::cmp::min(
-            self.cfg.recovery_threads,
+            self.cfg.recovery_threads(),
             self.append_files.len() + self.rewrite_files.len(),
         );
         let pool = rayon::ThreadPoolBuilder::new()

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -175,7 +175,7 @@ where
 
         let total_size = self.pipe_log.total_size(queue);
         match queue {
-            LogQueue::Append => total_size > self.cfg.purge_threshold.0 as usize,
+            LogQueue::Append => total_size > self.cfg.purge_threshold().0 as usize,
             LogQueue::Rewrite => {
                 let compacted_rewrites_ratio = self.global_stats.deleted_rewrite_entries() as f64
                     / self.global_stats.rewrite_entries() as f64;

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -584,7 +584,7 @@ fn main() {
     // Raft Engine configurations
     config.dir = opts.path;
     config.target_file_size = ReadableSize::from_str(&opts.target_file_size).unwrap();
-    config.purge_threshold = ReadableSize::from_str(&opts.purge_threshold).unwrap();
+    config.purge_threshold = Some(ReadableSize::from_str(&opts.purge_threshold).unwrap());
     config.purge_rewrite_threshold =
         Some(ReadableSize::from_str(&opts.purge_rewrite_threshold).unwrap());
     config.purge_rewrite_garbage_ratio = opts.purge_rewrite_garbage_ratio;

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -103,7 +103,7 @@ fn test_pipe_log_listeners() {
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(128),
-        purge_threshold: ReadableSize::kb(512),
+        purge_threshold: Some(ReadableSize::kb(512)),
         batch_compression_threshold: ReadableSize::kb(0),
         ..Default::default()
     };
@@ -365,7 +365,7 @@ fn test_incomplete_purge() {
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize(1),
-        purge_threshold: ReadableSize(1),
+        purge_threshold: Some(ReadableSize(1)),
         ..Default::default()
     };
     let rid = 1;
@@ -463,7 +463,7 @@ fn test_tail_corruption() {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(1),
+            purge_threshold: Some(ReadableSize(1)),
             ..Default::default()
         };
         let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
@@ -517,7 +517,7 @@ fn test_tail_corruption() {
         let cfg = Config {
             dir: dir.path().to_str().unwrap().to_owned(),
             target_file_size: ReadableSize(1),
-            purge_threshold: ReadableSize(1),
+            purge_threshold: Some(ReadableSize(1)),
             format_version: Version::V2,
             ..Default::default()
         };
@@ -610,7 +610,7 @@ fn test_recycle_with_stale_logbatch_at_tail() {
     let cfg_err = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
-        purge_threshold: ReadableSize::kb(4),
+        purge_threshold: Some(ReadableSize::kb(4)),
         enable_log_recycle: true,
         format_version: Version::V1,
         ..Default::default()
@@ -662,7 +662,7 @@ fn test_build_engine_with_multi_datalayout() {
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
-        purge_threshold: ReadableSize::kb(4),
+        purge_threshold: Some(ReadableSize::kb(4)),
         recovery_mode: RecoveryMode::AbsoluteConsistency,
         ..Default::default()
     };
@@ -696,7 +696,7 @@ fn test_build_engine_with_datalayout_abnormal() {
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(2),
-        purge_threshold: ReadableSize::kb(4),
+        purge_threshold: Some(ReadableSize::kb(4)),
         recovery_mode: RecoveryMode::AbsoluteConsistency,
         format_version: Version::V2,
         ..Default::default()
@@ -736,7 +736,7 @@ fn test_partial_rewrite_rewrite() {
     let _f = FailGuard::new("max_rewrite_batch_bytes", "return(1)");
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
-        recovery_threads: 1,
+        recovery_threads: Some(1),
         ..Default::default()
     };
     let engine = Engine::open(cfg.clone()).unwrap();
@@ -986,7 +986,7 @@ fn test_build_engine_with_recycling_and_multi_dirs() {
         dir: dir.path().to_str().unwrap().to_owned(),
         spill_dir: Some(spill_dir.path().to_str().unwrap().to_owned()),
         target_file_size: ReadableSize::kb(1),
-        purge_threshold: ReadableSize::kb(20),
+        purge_threshold: Some(ReadableSize::kb(20)),
         enable_log_recycle: true,
         prefill_for_recycle: true,
         ..Default::default()

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -449,7 +449,7 @@ fn test_start_with_recycled_file_allocate_error() {
     let cfg = Config {
         dir: dir.path().to_str().unwrap().to_owned(),
         target_file_size: ReadableSize::kb(1),
-        purge_threshold: ReadableSize::kb(10), // capacity is 12
+        purge_threshold: Some(ReadableSize::kb(10)), // capacity is 12
         enable_log_recycle: true,
         prefill_for_recycle: true,
         ..Default::default()


### PR DESCRIPTION
This is to make it possible for the caller to dynamically choose the default value under different situations like single rocksdb or multi-rocksdb.