### PR TITLE
Expose the setting of the maximum size of `prefill-for-recycle` to users

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -184,6 +184,13 @@ impl Config {
         if self.memory_limit.is_some() {
             warn!("memory-limit will be ignored because swap feature is disabled");
         }
+        #[cfg(test)]
+        {
+            self.purge_threshold = ReadableSize(std::cmp::min(
+                self.purge_threshold.0,
+                ReadableSize::gb(12).0,
+            ));
+        }
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use log::warn;
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::pipe_log::Version;
@@ -193,7 +193,7 @@ impl Config {
             self.prefill_limit = None;
         }
         if self.prefill_for_recycle && self.prefill_limit.is_none() {
-            warn!("prefill-limit will be calibrated to purge-threshold");
+            info!("prefill-limit will be calibrated to purge-threshold");
             self.prefill_limit = Some(self.purge_threshold);
         }
         #[cfg(not(feature = "swap"))]

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -476,13 +476,12 @@ impl<F: FileSystem> DualPipesBuilder<F> {
 
     fn initialize_files(&mut self) -> Result<()> {
         let target_file_size = self.cfg.target_file_size.0 as usize;
-        let mut target = if self.cfg.prefill_for_recycle {
+        let mut target = std::cmp::min(
+            self.cfg.prefill_capacity(),
             self.cfg
                 .recycle_capacity()
-                .saturating_sub(self.append_files.len())
-        } else {
-            0
-        };
+                .saturating_sub(self.append_files.len()),
+        );
         let to_create = target.saturating_sub(self.recycled_files.len());
         if to_create > 0 {
             let now = Instant::now();

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -2,7 +2,6 @@
 
 //! Helper types to recover in-memory states from log files.
 
-use std::cmp;
 use std::fs::{self, File as StdFile};
 use std::io::Write;
 use std::marker::PhantomData;
@@ -32,8 +31,8 @@ use super::pipe::{
 };
 use super::reader::LogItemBatchFileReader;
 
+/// Maximum size for the buffer for prefilling.
 const PREFILL_BUFFER_SIZE: usize = ReadableSize::mb(16).0 as usize;
-const MAX_PREFILL_SIZE: usize = ReadableSize::gb(12).0 as usize;
 
 /// `ReplayMachine` is a type of deterministic state machine that obeys
 /// associative law.
@@ -484,7 +483,6 @@ impl<F: FileSystem> DualPipesBuilder<F> {
         } else {
             0
         };
-        target = cmp::min(target, MAX_PREFILL_SIZE / target_file_size);
         let to_create = target.saturating_sub(self.recycled_files.len());
         if to_create > 0 {
             let now = Instant::now();


### PR DESCRIPTION
## Description
This pr is used to unleash the limitation of `prefill-for-recycle`, used to adaptive to the requirement of large threshold.

Related issue: https://github.com/tikv/tikv/issues/14468.