### PR TITLE
fix data loss caused by atomic group being partially purged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Disable log recycling by default.
 * `LogBatch::put` returns a `Result<()>` instead of `()`. It errs when the key is reserved for internal use.
 * Possible to specify a permission in `FileSystem::open`.
+* Prometheus counter `raft_engine_log_file_count` no longer includes retired log files that are stashed for recycling. Those files are now tracked by a new counter `raft_engine_recycled_file_count`.
 
 ### Bug Fixes
 
@@ -14,7 +15,7 @@
 
 ### New Features
 
-* Support preparing prefilled logs to enable log recycling when start-up.
+* Support preparing prefilled logs to enable log recycling when start-up. The amount of logs to prepare is controlled by `Config::prefill_limit`.
 * Add a new configuration `spill-dir` to allow automatic placement of logs into an auxiliary directory when `dir` is full.
 * Add a new method `Engine::fork` to duplicate an `Engine` to a new place, with a few disk file copies.
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2417,6 +2417,7 @@ pub(crate) mod tests {
             dir: dir.path().to_str().unwrap().to_owned(),
             // Make sure each file gets replayed individually.
             recovery_threads: 100,
+            target_file_size: ReadableSize(1),
             ..Default::default()
         };
         let fs = Arc::new(ObfuscatedFileSystem::default());
@@ -2550,7 +2551,7 @@ pub(crate) mod tests {
             assert!(data.remove(&rid), "{}", rid);
             assert_eq!(engine.get(rid, &key).unwrap(), value);
         }
-        assert!(data.is_empty());
+        assert!(data.is_empty(), "data loss {:?}", data);
     }
 
     #[test]

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -167,6 +167,22 @@ where
         .unwrap();
     }
 
+    pub fn must_purge_all_stale(&self) {
+        let _lk = self.force_rewrite_candidates.try_lock().unwrap();
+        self.pipe_log.rotate(LogQueue::Rewrite).unwrap();
+        self.rescan_memtables_and_purge_stale_files(
+            LogQueue::Rewrite,
+            self.pipe_log.file_span(LogQueue::Rewrite).1,
+        )
+        .unwrap();
+        self.pipe_log.rotate(LogQueue::Append).unwrap();
+        self.rescan_memtables_and_purge_stale_files(
+            LogQueue::Append,
+            self.pipe_log.file_span(LogQueue::Append).1,
+        )
+        .unwrap();
+    }
+
     pub(crate) fn needs_rewrite_log_files(&self, queue: LogQueue) -> bool {
         let (first_file, active_file) = self.pipe_log.file_span(queue);
         if active_file == first_file {


### PR DESCRIPTION
Close #315

Record the start and end position of an atomic group in memtable.