### PR TITLE
detect entries block corruption of tail record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * Fix data loss caused by aborted rewrite operation. Downgrading to an earlier version without the fix may produce phantom Raft Groups or keys, i.e. never written but appear in queries.
+* Fix a potential bug that an un-persisted log batch is mistakenly recovered and causes checksum mismatch error when being read later.
 
 ### New Features
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ endif
 
 BIN_PATH = $(CURDIR)/bin
 CARGO_TARGET_DIR ?= $(CURDIR)/target/
+export RUST_LOG=info
 
 .PHONY: clean format clippy test
 .PHONY: ctl

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -156,9 +156,8 @@ pub mod debug {
 
         fn find_next_readable_file(&mut self) -> Result<()> {
             while let Some((file_id, path)) = self.files.pop_front() {
-                let mut reader = build_file_reader(self.system.as_ref(), &path)?;
-                let format = reader.parse_format()?;
-                self.batch_reader.open(file_id, format, reader)?;
+                let reader = build_file_reader(self.system.as_ref(), &path)?;
+                self.batch_reader.open(file_id, reader)?;
                 if let Some(b) = self.batch_reader.next()? {
                     self.items.extend(b.into_items());
                     break;

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -13,7 +13,7 @@ use super::log_file::LogFileReader;
 pub(super) struct LogItemBatchFileReader<F: FileSystem> {
     file_id: Option<FileId>,
     format: Option<LogFileFormat>,
-    reader: Option<LogFileReader<F>>,
+    pub(crate) reader: Option<LogFileReader<F>>,
     size: usize,
 
     buffer: Vec<u8>,

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -44,12 +44,8 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
     }
 
     /// Opens a file that can be accessed through the given reader.
-    pub fn open(
-        &mut self,
-        file_id: FileId,
-        format: LogFileFormat,
-        reader: LogFileReader<F>,
-    ) -> Result<()> {
+    pub fn open(&mut self, file_id: FileId, mut reader: LogFileReader<F>) -> Result<LogFileFormat> {
+        let format = reader.parse_format()?;
         self.valid_offset = LogFileFormat::encoded_len(format.version);
         self.file_id = Some(file_id);
         self.format = Some(format);
@@ -57,7 +53,7 @@ impl<F: FileSystem> LogItemBatchFileReader<F> {
         self.reader = Some(reader);
         self.buffer.clear();
         self.buffer_offset = 0;
-        Ok(())
+        Ok(format)
     }
 
     /// Closes any ongoing file access.

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -327,6 +327,13 @@ impl LogItem {
         })
     }
 
+    pub fn entry_index(&self) -> Option<EntryIndex> {
+        match &self.content {
+            LogItemContent::EntryIndexes(entry_indexes) => entry_indexes.0.first().cloned(),
+            _ => None,
+        }
+    }
+
     fn approximate_size(&self) -> usize {
         match &self.content {
             LogItemContent::EntryIndexes(entry_indexes) => {

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -813,6 +813,14 @@ impl LogBatch {
             if corrupted_items() {
                 self.buf[footer_roffset] += 1;
             }
+            let corrupted_entries = || {
+                fail::fail_point!("log_batch::corrupted_entries", |_| true);
+                false
+            };
+            if corrupted_entries() {
+                assert!(footer_roffset > LOG_BATCH_HEADER_LEN);
+                self.buf[footer_roffset - 1] += 1;
+            }
         }
 
         self.buf_state = BufState::Encoded(header_offset, footer_roffset - LOG_BATCH_HEADER_LEN);

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -327,13 +327,6 @@ impl LogItem {
         })
     }
 
-    pub fn entry_index(&self) -> Option<EntryIndex> {
-        match &self.content {
-            LogItemContent::EntryIndexes(entry_indexes) => entry_indexes.0.first().cloned(),
-            _ => None,
-        }
-    }
-
     fn approximate_size(&self) -> usize {
         match &self.content {
             LogItemContent::EntryIndexes(entry_indexes) => {
@@ -550,6 +543,16 @@ impl LogItemBatch {
 
     pub fn approximate_size(&self) -> usize {
         8 /*count*/ + self.item_size + LOG_BATCH_CHECKSUM_LEN
+    }
+
+    /// Returns the first [`EntryIndex`] appeared in this batch.
+    pub fn entry_index(&self) -> Option<EntryIndex> {
+        for item in &self.items {
+            if let LogItemContent::EntryIndexes(entry_indexes) = &item.content {
+                return entry_indexes.0.first().cloned();
+            }
+        }
+        None
     }
 }
 

--- a/tests/failpoints/mod.rs
+++ b/tests/failpoints/mod.rs
@@ -11,6 +11,11 @@ use fail::FailGuard;
 use raft_engine::*;
 use util::*;
 
+#[ctor::ctor]
+fn init() {
+    env_logger::init();
+}
+
 #[test]
 fn test_log_batch_full() {
     let _f = FailGuard::new("log_batch::1kb_entries_size_per_batch", "return");

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -422,6 +422,24 @@ fn test_tail_corruption() {
         let engine = Engine::open_with_file_system(cfg, fs.clone()).unwrap();
         assert_eq!(engine.first_index(rid), None);
     }
+    // Tail entries block is corrupted.
+    {
+        let dir = tempfile::Builder::new()
+            .prefix("test_tail_corruption_1_1")
+            .tempdir()
+            .unwrap();
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            ..Default::default()
+        };
+        let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
+        let _f = FailGuard::new("log_batch::corrupted_entries", "return");
+        append(&engine, rid, 1, 5, Some(&data));
+        drop(engine);
+        let engine = Engine::open_with_file_system(cfg, fs.clone()).unwrap();
+        assert_eq!(engine.first_index(rid), None);
+    }
     // Header is corrupted.
     {
         let _f = FailGuard::new("log_file_header::corrupted", "return");

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -440,6 +440,24 @@ fn test_tail_corruption() {
         let engine = Engine::open_with_file_system(cfg, fs.clone()).unwrap();
         assert_eq!(engine.first_index(rid), None);
     }
+    // Repeat with absolute consistency.
+    {
+        let dir = tempfile::Builder::new()
+            .prefix("test_tail_corruption_1_2")
+            .tempdir()
+            .unwrap();
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            format_version: Version::V2,
+            recovery_mode: RecoveryMode::AbsoluteConsistency,
+            ..Default::default()
+        };
+        let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
+        let _f = FailGuard::new("log_batch::corrupted_entries", "return");
+        append(&engine, rid, 1, 5, Some(&data));
+        drop(engine);
+        assert!(Engine::open_with_file_system(cfg, fs.clone()).is_err());
+    }
     // Header is corrupted.
     {
         let _f = FailGuard::new("log_file_header::corrupted", "return");


### PR DESCRIPTION
There're three blocks in a batch: header, entries and footer. During recovery, we only read and verify the header and footer to reduce I/O overhead. But it's possible that only entries block is corrupted while header and footer are not.

Only one type of this corruption can be tolerated: fsync hasn't properly synchronized the entries block before the shutdown. In this PR we detect it by verify entries block of the tail record. The added overhead should be negligible.