### PR TITLE
build on windows system.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ kvproto = { git = "https://github.com/pingcap/kvproto.git", default-features = f
 raft = { git = "https://github.com/tikv/raft-rs", branch = "master", default-features = false, features = ["protobuf-codec"] }
 rand = "0.8"
 rand_distr = "0.4"
-tempfile = "3.1"
+tempfile = "3.6"
 toml = "0.7"
 
 [features]
@@ -87,6 +87,7 @@ swap = [
   "nightly",
   "memmap2",
 ]
+std_fs = []
 
 nightly_group = ["nightly", "swap"]
 
@@ -94,6 +95,8 @@ nightly_group = ["nightly", "swap"]
 raft-proto = { git = "https://github.com/tikv/raft-rs", branch = "master" }
 protobuf = { git = "https://github.com/pingcap/rust-protobuf", branch = "v2.8" }
 protobuf-codegen = { git = "https://github.com/pingcap/rust-protobuf", branch = "v2.8" }
+# TODO: Use official grpc-rs once https://github.com/tikv/grpc-rs/pull/622 is merged.
+grpcio = { git = "https://github.com/tabokie/grpc-rs", branch = "v0.10.x-win" }
 
 [workspace]
 members = ["stress", "ctl"]

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,8 @@ else
 test_matrix: test
 	cargo ${TOOLCHAIN_ARGS} test --all ${EXTRA_CARGO_ARGS} -- --nocapture
 	cargo ${TOOLCHAIN_ARGS} test --test failpoints --features failpoints ${EXTRA_CARGO_ARGS} -- --test-threads 1 --nocapture
+	cargo ${TOOLCHAIN_ARGS} test --all --features nightly_group,std_fs ${EXTRA_CARGO_ARGS} -- --nocapture
+	cargo ${TOOLCHAIN_ARGS} test --test failpoints --features nightly_group,std_fs,failpoints ${EXTRA_CARGO_ARGS} -- --test-threads 1 --nocapture
 endif
 
 ## Build raft-engine-ctl.

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -1,211 +1,13 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
-use std::os::unix::io::RawFd;
+use std::io::{Error, ErrorKind, Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::sync::Arc;
 
 use fail::fail_point;
-use log::error;
-use nix::errno::Errno;
-use nix::fcntl::{self, OFlag};
-use nix::sys::stat::Mode;
-use nix::sys::uio::{pread, pwrite};
-use nix::unistd::{close, ftruncate, lseek, Whence};
-use nix::NixPath;
 
+use crate::env::log_fd::LogFd;
 use crate::env::{FileSystem, Handle, Permission, WriteExt};
-
-fn from_nix_error(e: nix::Error, custom: &'static str) -> std::io::Error {
-    let kind = std::io::Error::from(e).kind();
-    std::io::Error::new(kind, custom)
-}
-
-impl From<Permission> for OFlag {
-    fn from(value: Permission) -> OFlag {
-        match value {
-            Permission::ReadOnly => OFlag::O_RDONLY,
-            Permission::ReadWrite => OFlag::O_RDWR,
-        }
-    }
-}
-
-/// A RAII-style low-level file. Errors occurred during automatic resource
-/// release are logged and ignored.
-///
-/// A [`LogFd`] is essentially a thin wrapper around [`RawFd`]. It's only
-/// supported on *Unix*, and primarily optimized for *Linux*.
-///
-/// All [`LogFd`] instances are opened with read and write permission.
-pub struct LogFd(RawFd);
-
-impl LogFd {
-    /// Opens a file with the given `path`.
-    pub fn open<P: ?Sized + NixPath>(path: &P, perm: Permission) -> IoResult<Self> {
-        fail_point!("log_fd::open::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        // Permission 644
-        let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
-        fail_point!("log_fd::open::fadvise_dontneed", |_| {
-            let fd =
-                LogFd(fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?);
-            #[cfg(target_os = "linux")]
-            unsafe {
-                extern crate libc;
-                libc::posix_fadvise64(fd.0, 0, fd.file_size()? as i64, libc::POSIX_FADV_DONTNEED);
-            }
-            Ok(fd)
-        });
-        Ok(LogFd(
-            fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?,
-        ))
-    }
-
-    /// Opens a file with the given `path`. The specified file will be created
-    /// first if not exists.
-    pub fn create<P: ?Sized + NixPath>(path: &P) -> IoResult<Self> {
-        fail_point!("log_fd::create::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        let flags = OFlag::O_RDWR | OFlag::O_CREAT;
-        // Permission 644
-        let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
-        let fd = fcntl::open(path, flags, mode).map_err(|e| from_nix_error(e, "open"))?;
-        Ok(LogFd(fd))
-    }
-
-    /// Closes the file.
-    pub fn close(&self) -> IoResult<()> {
-        fail_point!("log_fd::close::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        close(self.0).map_err(|e| from_nix_error(e, "close"))
-    }
-
-    /// Reads some bytes starting at `offset` from this file into the specified
-    /// buffer. Returns how many bytes were read.
-    pub fn read(&self, mut offset: usize, buf: &mut [u8]) -> IoResult<usize> {
-        let mut readed = 0;
-        while readed < buf.len() {
-            fail_point!("log_fd::read::err", |_| {
-                Err(from_nix_error(nix::Error::EINVAL, "fp"))
-            });
-            let bytes = match pread(self.0, &mut buf[readed..], offset as i64) {
-                Ok(bytes) => bytes,
-                Err(e) if e == Errno::EINTR => continue,
-                Err(e) => return Err(from_nix_error(e, "pread")),
-            };
-            // EOF
-            if bytes == 0 {
-                break;
-            }
-            readed += bytes;
-            offset += bytes;
-        }
-        Ok(readed)
-    }
-
-    /// Writes some bytes to this file starting at `offset`. Returns how many
-    /// bytes were written.
-    pub fn write(&self, mut offset: usize, content: &[u8]) -> IoResult<usize> {
-        fail_point!("log_fd::write::zero", |_| { Ok(0) });
-        fail_point!("log_fd::write::no_space_err", |_| {
-            Err(from_nix_error(nix::Error::ENOSPC, "nospace"))
-        });
-        let mut written = 0;
-        while written < content.len() {
-            let bytes = match pwrite(self.0, &content[written..], offset as i64) {
-                Ok(bytes) => bytes,
-                Err(e) if e == Errno::EINTR => continue,
-                Err(e) if e == Errno::ENOSPC => return Err(from_nix_error(e, "nospace")),
-                Err(e) => return Err(from_nix_error(e, "pwrite")),
-            };
-            if bytes == 0 {
-                break;
-            }
-            written += bytes;
-            offset += bytes;
-        }
-        fail_point!("log_fd::write::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        Ok(written)
-    }
-
-    /// Truncates all data after `offset`.
-    pub fn truncate(&self, offset: usize) -> IoResult<()> {
-        fail_point!("log_fd::truncate::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        ftruncate(self.0, offset as i64).map_err(|e| from_nix_error(e, "ftruncate"))
-    }
-
-    /// Attempts to allocate space for `size` bytes starting at `offset`.
-    #[allow(unused_variables)]
-    pub fn allocate(&self, offset: usize, size: usize) -> IoResult<()> {
-        fail_point!("log_fd::allocate::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        #[cfg(target_os = "linux")]
-        {
-            if let Err(e) = fcntl::fallocate(
-                self.0,
-                fcntl::FallocateFlags::empty(),
-                offset as i64,
-                size as i64,
-            ) {
-                if e != nix::Error::EOPNOTSUPP {
-                    return Err(from_nix_error(e, "fallocate"));
-                }
-            }
-        }
-        Ok(())
-    }
-}
-
-impl Handle for LogFd {
-    #[inline]
-    fn truncate(&self, offset: usize) -> IoResult<()> {
-        fail_point!("log_fd::truncate::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        ftruncate(self.0, offset as i64).map_err(|e| from_nix_error(e, "ftruncate"))
-    }
-
-    #[inline]
-    fn file_size(&self) -> IoResult<usize> {
-        fail_point!("log_fd::file_size::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        lseek(self.0, 0, Whence::SeekEnd)
-            .map(|n| n as usize)
-            .map_err(|e| from_nix_error(e, "lseek"))
-    }
-
-    #[inline]
-    fn sync(&self) -> IoResult<()> {
-        fail_point!("log_fd::sync::err", |_| {
-            Err(from_nix_error(nix::Error::EINVAL, "fp"))
-        });
-        #[cfg(target_os = "linux")]
-        {
-            nix::unistd::fdatasync(self.0).map_err(|e| from_nix_error(e, "fdatasync"))
-        }
-        #[cfg(not(target_os = "linux"))]
-        {
-            nix::unistd::fsync(self.0).map_err(|e| from_nix_error(e, "fsync"))
-        }
-    }
-}
-
-impl Drop for LogFd {
-    fn drop(&mut self) {
-        if let Err(e) = self.close() {
-            error!("error while closing file: {e}");
-        }
-    }
-}
 
 /// A low-level file adapted for standard interfaces including [`Seek`],
 /// [`Write`] and [`Read`].
@@ -226,7 +28,14 @@ impl LogFile {
 
 impl Write for LogFile {
     fn write(&mut self, buf: &[u8]) -> IoResult<usize> {
+        fail_point!("log_file::write::zero", |_| { Ok(0) });
+
         let len = self.inner.write(self.offset, buf)?;
+
+        fail_point!("log_file::write::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         self.offset += len;
         Ok(len)
     }
@@ -238,6 +47,10 @@ impl Write for LogFile {
 
 impl Read for LogFile {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        fail_point!("log_file::read::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         let len = self.inner.read(self.offset, buf)?;
         self.offset += len;
         Ok(len)
@@ -260,12 +73,20 @@ impl Seek for LogFile {
 
 impl WriteExt for LogFile {
     fn truncate(&mut self, offset: usize) -> IoResult<()> {
+        fail_point!("log_file::truncate::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         self.inner.truncate(offset)?;
         self.offset = offset;
         Ok(())
     }
 
     fn allocate(&mut self, offset: usize, size: usize) -> IoResult<()> {
+        fail_point!("log_file::allocate::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         self.inner.allocate(offset, size)
     }
 }
@@ -278,10 +99,18 @@ impl FileSystem for DefaultFileSystem {
     type Writer = LogFile;
 
     fn create<P: AsRef<Path>>(&self, path: P) -> IoResult<Self::Handle> {
+        fail_point!("default_fs::create::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         LogFd::create(path.as_ref())
     }
 
     fn open<P: AsRef<Path>>(&self, path: P, perm: Permission) -> IoResult<Self::Handle> {
+        fail_point!("default_fs::open::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
         LogFd::open(path.as_ref(), perm)
     }
 

--- a/src/env/log_fd.rs
+++ b/src/env/log_fd.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
+#[cfg(not(any(windows, feature = "std_fs")))]
+mod unix;
+#[cfg(not(any(windows, feature = "std_fs")))]
+pub use unix::LogFd;
+
+#[cfg(any(windows, feature = "std_fs"))]
+mod plain;
+#[cfg(any(windows, feature = "std_fs"))]
+pub use plain::LogFd;

--- a/src/env/log_fd/plain.rs
+++ b/src/env/log_fd/plain.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
+use crate::env::{Handle, Permission};
+
+use fail::fail_point;
+use parking_lot::RwLock;
+
+use std::fs::{File, OpenOptions};
+use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
+use std::path::Path;
+use std::sync::Arc;
+
+pub struct LogFd(Arc<RwLock<File>>);
+
+impl LogFd {
+    pub fn open<P: AsRef<Path>>(path: P, _: Permission) -> Result<Self> {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path)
+            .map(|x| Self(Arc::new(RwLock::new(x))))
+    }
+
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self> {
+        OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .map(|x| Self(Arc::new(RwLock::new(x))))
+    }
+
+    pub fn read(&self, offset: usize, buf: &mut [u8]) -> Result<usize> {
+        let mut file = self.0.write();
+        let _ = file.seek(SeekFrom::Start(offset as u64))?;
+        file.read(buf)
+    }
+
+    pub fn write(&self, offset: usize, content: &[u8]) -> Result<usize> {
+        fail_point!("log_fd::write::no_space_err", |_| {
+            Err(Error::new(ErrorKind::Other, "nospace"))
+        });
+
+        let mut file = self.0.write();
+        let _ = file.seek(SeekFrom::Start(offset as u64))?;
+        file.write(content)
+    }
+
+    pub fn truncate(&self, offset: usize) -> Result<()> {
+        let file = self.0.write();
+        file.set_len(offset as u64)
+    }
+
+    pub fn allocate(&self, _offset: usize, _size: usize) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl Handle for LogFd {
+    fn truncate(&self, offset: usize) -> Result<()> {
+        self.truncate(offset)
+    }
+
+    fn file_size(&self) -> Result<usize> {
+        fail_point!("log_fd::file_size::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
+        let file = self.0.read();
+        file.metadata().map(|x| x.len() as usize)
+    }
+
+    fn sync(&self) -> Result<()> {
+        fail_point!("log_fd::sync::err", |_| {
+            Err(Error::new(ErrorKind::InvalidInput, "fp"))
+        });
+
+        let file = self.0.write();
+        file.sync_all()
+    }
+}

--- a/src/env/log_fd/unix.rs
+++ b/src/env/log_fd/unix.rs
@@ -1,0 +1,185 @@
+// Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
+
+use crate::env::{Handle, Permission};
+
+use fail::fail_point;
+use log::error;
+
+use std::io::Result as IoResult;
+use std::os::unix::io::RawFd;
+
+use nix::errno::Errno;
+use nix::fcntl::{self, OFlag};
+use nix::sys::stat::Mode;
+use nix::sys::uio::{pread, pwrite};
+use nix::unistd::{close, ftruncate, lseek, Whence};
+use nix::NixPath;
+
+fn from_nix_error(e: nix::Error, custom: &'static str) -> std::io::Error {
+    let kind = std::io::Error::from(e).kind();
+    std::io::Error::new(kind, custom)
+}
+
+impl From<Permission> for OFlag {
+    fn from(value: Permission) -> OFlag {
+        match value {
+            Permission::ReadOnly => OFlag::O_RDONLY,
+            Permission::ReadWrite => OFlag::O_RDWR,
+        }
+    }
+}
+
+/// A RAII-style low-level file. Errors occurred during automatic resource
+/// release are logged and ignored.
+///
+/// A [`LogFd`] is essentially a thin wrapper around [`RawFd`]. It's only
+/// supported on *Unix*, and primarily optimized for *Linux*.
+///
+/// All [`LogFd`] instances are opened with read and write permission.
+pub struct LogFd(RawFd);
+
+impl LogFd {
+    /// Opens a file with the given `path`.
+    pub fn open<P: ?Sized + NixPath>(path: &P, perm: Permission) -> IoResult<Self> {
+        // Permission 644
+        let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
+        fail_point!("log_fd::open::fadvise_dontneed", |_| {
+            let fd =
+                LogFd(fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?);
+            #[cfg(target_os = "linux")]
+            unsafe {
+                extern crate libc;
+                libc::posix_fadvise64(fd.0, 0, fd.file_size()? as i64, libc::POSIX_FADV_DONTNEED);
+            }
+            Ok(fd)
+        });
+        Ok(LogFd(
+            fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?,
+        ))
+    }
+
+    /// Opens a file with the given `path`. The specified file will be created
+    /// first if not exists.
+    pub fn create<P: ?Sized + NixPath>(path: &P) -> IoResult<Self> {
+        let flags = OFlag::O_RDWR | OFlag::O_CREAT;
+        // Permission 644
+        let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
+        let fd = fcntl::open(path, flags, mode).map_err(|e| from_nix_error(e, "open"))?;
+        Ok(LogFd(fd))
+    }
+
+    /// Closes the file.
+    pub fn close(&self) -> IoResult<()> {
+        fail_point!("log_fd::close::err", |_| {
+            Err(from_nix_error(nix::Error::EINVAL, "fp"))
+        });
+        close(self.0).map_err(|e| from_nix_error(e, "close"))
+    }
+
+    /// Reads some bytes starting at `offset` from this file into the specified
+    /// buffer. Returns how many bytes were read.
+    pub fn read(&self, mut offset: usize, buf: &mut [u8]) -> IoResult<usize> {
+        let mut readed = 0;
+        while readed < buf.len() {
+            let bytes = match pread(self.0, &mut buf[readed..], offset as i64) {
+                Ok(bytes) => bytes,
+                Err(e) if e == Errno::EINTR => continue,
+                Err(e) => return Err(from_nix_error(e, "pread")),
+            };
+            // EOF
+            if bytes == 0 {
+                break;
+            }
+            readed += bytes;
+            offset += bytes;
+        }
+        Ok(readed)
+    }
+
+    /// Writes some bytes to this file starting at `offset`. Returns how many
+    /// bytes were written.
+    pub fn write(&self, mut offset: usize, content: &[u8]) -> IoResult<usize> {
+        fail_point!("log_fd::write::no_space_err", |_| {
+            Err(from_nix_error(nix::Error::ENOSPC, "nospace"))
+        });
+        let mut written = 0;
+        while written < content.len() {
+            let bytes = match pwrite(self.0, &content[written..], offset as i64) {
+                Ok(bytes) => bytes,
+                Err(e) if e == Errno::EINTR => continue,
+                Err(e) if e == Errno::ENOSPC => return Err(from_nix_error(e, "nospace")),
+                Err(e) => return Err(from_nix_error(e, "pwrite")),
+            };
+            if bytes == 0 {
+                break;
+            }
+            written += bytes;
+            offset += bytes;
+        }
+        Ok(written)
+    }
+
+    /// Truncates all data after `offset`.
+    pub fn truncate(&self, offset: usize) -> IoResult<()> {
+        ftruncate(self.0, offset as i64).map_err(|e| from_nix_error(e, "ftruncate"))
+    }
+
+    /// Attempts to allocate space for `size` bytes starting at `offset`.
+    #[allow(unused_variables)]
+    pub fn allocate(&self, offset: usize, size: usize) -> IoResult<()> {
+        #[cfg(target_os = "linux")]
+        {
+            if let Err(e) = fcntl::fallocate(
+                self.0,
+                fcntl::FallocateFlags::empty(),
+                offset as i64,
+                size as i64,
+            ) {
+                if e != nix::Error::EOPNOTSUPP {
+                    return Err(from_nix_error(e, "fallocate"));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Handle for LogFd {
+    #[inline]
+    fn truncate(&self, offset: usize) -> IoResult<()> {
+        self.truncate(offset)
+    }
+
+    #[inline]
+    fn file_size(&self) -> IoResult<usize> {
+        fail_point!("log_fd::file_size::err", |_| {
+            Err(from_nix_error(nix::Error::EINVAL, "fp"))
+        });
+        lseek(self.0, 0, Whence::SeekEnd)
+            .map(|n| n as usize)
+            .map_err(|e| from_nix_error(e, "lseek"))
+    }
+
+    #[inline]
+    fn sync(&self) -> IoResult<()> {
+        fail_point!("log_fd::sync::err", |_| {
+            Err(from_nix_error(nix::Error::EINVAL, "fp"))
+        });
+        #[cfg(target_os = "linux")]
+        {
+            nix::unistd::fdatasync(self.0).map_err(|e| from_nix_error(e, "fdatasync"))
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            nix::unistd::fsync(self.0).map_err(|e| from_nix_error(e, "fsync"))
+        }
+    }
+}
+
+impl Drop for LogFd {
+    fn drop(&mut self) {
+        if let Err(e) = self.close() {
+            error!("error while closing file: {e}");
+        }
+    }
+}

--- a/src/env/mod.rs
+++ b/src/env/mod.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 mod default;
+mod log_fd;
 mod obfuscated;
 
 pub use default::DefaultFileSystem;

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -175,6 +175,10 @@ impl<F: FileSystem> SinglePipe<F> {
     /// filesystem.
     fn sync_dir(&self, path_id: PathId) -> Result<()> {
         debug_assert!(!self.paths.is_empty());
+
+        // Skip syncing directory in Windows. Refer to badger's discussion for more
+        // detail: https://github.com/dgraph-io/badger/issues/699
+        #[cfg(not(windows))]
         std::fs::File::open(PathBuf::from(&self.paths[path_id])).and_then(|d| d.sync_all())?;
         Ok(())
     }

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -1,9 +1,13 @@
 // Copyright (c) 2023-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::fs::{copy, create_dir_all};
-use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::sync::Arc;
+
+#[cfg(not(windows))]
+use std::os::unix::fs::symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_file as symlink;
 
 use crate::config::{Config, RecoveryMode};
 use crate::env::FileSystem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(feature = "swap", feature(allocator_api))]
 #![cfg_attr(feature = "swap", feature(slice_ptr_get))]
+// Though the new nightly rust stablized this feature, keep it anyway
+// because some other project (like TiKV) is still using the old.
 #![cfg_attr(feature = "swap", feature(nonnull_slice_from_raw_parts))]
 #![cfg_attr(feature = "swap", feature(slice_ptr_len))]
 #![cfg_attr(feature = "swap", feature(alloc_layout_extra))]

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -792,7 +792,7 @@ fn test_partial_rewrite_rewrite() {
     }
 
     {
-        let _f = FailGuard::new("log_fd::write::err", "10*off->return->off");
+        let _f = FailGuard::new("log_file::write::err", "10*off->return->off");
         assert!(
             catch_unwind_silent(|| engine.purge_manager().must_rewrite_rewrite_queue()).is_err()
         );
@@ -830,7 +830,7 @@ fn test_partial_rewrite_rewrite_online() {
     assert_eq!(engine.file_span(LogQueue::Append).0, old_active_file + 1);
 
     {
-        let _f = FailGuard::new("log_fd::write::err", "10*off->return->off");
+        let _f = FailGuard::new("log_file::write::err", "10*off->return->off");
         assert!(
             catch_unwind_silent(|| engine.purge_manager().must_rewrite_rewrite_queue()).is_err()
         );
@@ -897,13 +897,13 @@ fn test_split_rewrite_batch_imp(regions: u64, region_size: u64, split_size: u64,
         let count = AtomicU64::new(0);
         fail::cfg_callback("atomic_group::begin", move || {
             if count.fetch_add(1, Ordering::Relaxed) + 1 == i {
-                fail::cfg("log_fd::write::err", "return").unwrap();
+                fail::cfg("log_file::write::err", "return").unwrap();
             }
         })
         .unwrap();
         let r = catch_unwind_silent(|| engine.purge_manager().must_rewrite_rewrite_queue());
         fail::remove("atomic_group::begin");
-        fail::remove("log_fd::write::err");
+        fail::remove("log_file::write::err");
         if r.is_ok() {
             break;
         }
@@ -917,13 +917,13 @@ fn test_split_rewrite_batch_imp(regions: u64, region_size: u64, split_size: u64,
         let count = AtomicU64::new(0);
         fail::cfg_callback("atomic_group::add", move || {
             if count.fetch_add(1, Ordering::Relaxed) + 1 == i {
-                fail::cfg("log_fd::write::err", "return").unwrap();
+                fail::cfg("log_file::write::err", "return").unwrap();
             }
         })
         .unwrap();
         let r = catch_unwind_silent(|| engine.purge_manager().must_rewrite_rewrite_queue());
         fail::remove("atomic_group::add");
-        fail::remove("log_fd::write::err");
+        fail::remove("log_file::write::err");
         if r.is_ok() {
             break;
         }


### PR DESCRIPTION
Let cargo build pass under windows system:
1. use windows os specific symlink API in `fork.rs`
2. use different `LogFd` implementations in each os. Guarded (or choosen) by feature flags
    - for non-linux or non-unix system, use the plain `std::fs` APIs instead
    - for linux and unix system, still use the `nix` raw bindings