### PR TITLE
PoC bytes_per_sync

### DIFF
--- a/src/purge.rs
+++ b/src/purge.rs
@@ -380,7 +380,7 @@ where
                     )?;
                     current_size = 0;
                     previous_size = 0;
-                    self.rewrite_impl(&mut log_batch, rewrite, false)?;
+                    self.rewrite_impl(&mut log_batch, rewrite, true)?;
                 }
             }
             log_batch.add_raw_entries(region_id, current_entry_indexes, current_entries)?;

--- a/stress/src/main.rs
+++ b/stress/src/main.rs
@@ -284,17 +284,17 @@ impl Default for TestArgs {
 
 impl TestArgs {
     fn validate(&self) -> Result<(), String> {
-        if self.regions < self.write_threads {
-            return Err("Write thread count must be smaller than region count.".to_owned());
-        }
-        if self.regions < self.read_threads {
-            return Err("Read thread count must be smaller than region count.".to_owned());
-        }
-        if self.write_region_count > self.regions / self.write_threads {
-            return Err(
-                "Write region count must be smaller than region-count / write-threads.".to_owned(),
-            );
-        }
+        // if self.regions < self.write_threads {
+        //     return Err("Write thread count must be smaller than region
+        // count.".to_owned()); }
+        // if self.regions < self.read_threads {
+        //     return Err("Read thread count must be smaller than region
+        // count.".to_owned()); }
+        // if self.write_region_count > self.regions / self.write_threads {
+        //     return Err(
+        //         "Write region count must be smaller than region-count /
+        // write-threads.".to_owned(),     );
+        // }
         Ok(())
     }
 }
@@ -418,9 +418,8 @@ fn spawn_write(
             }
             while !shutdown.load(Ordering::Relaxed) {
                 // TODO(tabokie): scattering regions in one batch
-                let mut rid = thread_rng().gen_range(0..(args.regions / args.write_threads))
-                    * args.write_threads
-                    + index;
+                // let mut rid = thread_rng().gen_range(0..(args.regions / args.write_threads))
+                let mut rid = thread_rng().gen_range(0..args.regions) * args.write_threads + index;
                 for _ in 0..args.write_region_count {
                     let first = engine.first_index(rid).unwrap_or(0);
                     let last = engine.last_index(rid).unwrap_or(0);
@@ -472,9 +471,8 @@ fn spawn_read(
                 None
             };
             while !shutdown.load(Ordering::Relaxed) {
-                let rid = thread_rng().gen_range(0..(args.regions / args.read_threads))
-                    * args.read_threads
-                    + index;
+                // let rid = thread_rng().gen_range(0..(args.regions / args.read_threads))
+                let rid = thread_rng().gen_range(0..args.regions) * args.read_threads + index;
                 let mut start = Instant::now();
                 if let (Some(i), Some(last)) = (min_interval, summary.last) {
                     wait_til(&mut start, last + i);


### PR DESCRIPTION
Did tests on a EC2 instance with two EBS GP3 disks:
* /data1 101G Default IOPS Default Throughputs
* /data2 100G High IOPS (16k) High Throughputs (1000MB/s)

Baseline rewrite max (us): the max latency in micro-seconds of the baseline raft engine append with rewrite.
Baseline no-rewrite max (us): the max latency in micro-seconds of the baseline raft engine append without rewrite.
PoC rewrite max (us): the max latency in micro-seconds of the PoC raft engine append with rewrite.

| GP3 | Max Latency | Bandwidth |
|--------|--------|--------|
| /data1 | <img width="678" alt="image" src="https://github.com/tikv/raft-engine/assets/2150711/b200ca12-8811-48ec-a1b5-d8557503e440"> | <img width="679" alt="image" src="https://github.com/tikv/raft-engine/assets/2150711/34b8be7c-2e8b-4b10-bf5a-6344239d4d40"> |
| /data2 | <img width="679" alt="image" src="https://github.com/tikv/raft-engine/assets/2150711/571d9c08-6603-41f5-8520-edeba6815b92"> | <img width="678" alt="image" src="https://github.com/tikv/raft-engine/assets/2150711/65fb5ff9-1ab7-48b0-a7ea-76009d5d7ccf"> | 
