### PR TITLE
rewrite: optimize the interval of `sync` when rewriting memtables.

### DIFF
--- a/src/purge.rs
+++ b/src/purge.rs
@@ -27,7 +27,6 @@ const REWRITE_RATIO: f64 = 0.7;
 const MAX_REWRITE_ENTRIES_PER_REGION: usize = 32;
 const MAX_COUNT_BEFORE_FORCE_REWRITE: u32 = 9;
 
-#[inline]
 fn max_batch_bytes() -> usize {
     fail_point!("max_rewrite_batch_bytes", |s| s
         .unwrap()


### PR DESCRIPTION
In a cloud environment, refraining from unscheduling sync operations when rewriting memtables might result in an accumulation of unsynced bytes in the buffer. This accumulation has the potential to impede the foreground write progress during sync.

This pull request introduces periodic sync operations when the amount of stashed unsynced bytes exceeds a predefined threshold. This optimization aims to address the issue and enhance performance.