### PR TITLE
Optimize `fetch_entries_to` function to avoid stucking `write` too long.

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -334,14 +334,27 @@ where
         let _t = StopWatch::new(&*ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
         if let Some(memtable) = self.memtables.get(region_id) {
             let mut ents_idx: Vec<EntryIndex> = Vec::with_capacity((end - begin) as usize);
-            // Ensure that the corresponding memtable is locked with a read lock before
-            // completing the fetching of entries from the raft logs. This
-            // prevents the scenario where the index could become stale while
-            // being concurrently updated by the `rewrite` operation.
-            let immutable = memtable.read();
-            immutable.fetch_entries_to(begin, end, max_size, &mut ents_idx)?;
+            memtable.read().fetch_entries_to(begin, end, max_size, &mut ents_idx)?;
             for i in ents_idx.iter() {
-                vec.push(read_entry_from_file::<M, _>(self.pipe_log.as_ref(), i)?);
+                vec.push({
+                    match read_entry_from_file::<M, _>(self.pipe_log.as_ref(), i) {
+                        Ok(entry) => entry,
+                        Err(e) => {
+                            // The index is not found in the file, it means the entry is already
+                            // stale by `compact` or `rewrite`. Retry to read the entry from the memtable.
+                            let immutable = memtable.read();
+                            // Ensure that the corresponding memtable is locked with a read lock before
+                            // completing the fetching of entries from the raft logs. This
+                            // prevents the scenario where the index could become stale while
+                            // being concurrently updated by the `rewrite` operation.
+                            if let Some(idx) = immutable.get_entry(i.index) {
+                                read_entry_from_file::<M, _>(self.pipe_log.as_ref(), &idx)?
+                            } else {
+                                return Err(e);
+                            }
+                        }
+                    }
+                });
             }
             ENGINE_READ_ENTRY_COUNT_HISTOGRAM.observe(ents_idx.len() as f64);
             return Ok(ents_idx.len());
@@ -2246,6 +2259,14 @@ pub(crate) mod tests {
             old_perf_context.apply_duration,
             new_perf_context.apply_duration
         );
+
+        use rand::{thread_rng, Rng};
+        let huge_data: Vec<u8> = (0..3 * 1024 * 1024).map(|_| thread_rng().gen()).collect();
+        for i in 5..200 {
+            engine.append(rid, i, i + 1, Some(&huge_data));
+            let new_perf_context = get_perf_context();
+            println!("[i: {}] - the details of perf: {:?}", i, new_perf_context);
+        }
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2263,14 +2263,6 @@ pub(crate) mod tests {
             old_perf_context.apply_duration,
             new_perf_context.apply_duration
         );
-
-        use rand::{thread_rng, Rng};
-        let huge_data: Vec<u8> = (0..3 * 1024 * 1024).map(|_| thread_rng().gen()).collect();
-        for i in 5..200 {
-            engine.append(rid, i, i + 1, Some(&huge_data));
-            let new_perf_context = get_perf_context();
-            println!("[i: {}] - the details of perf: {:?}", i, new_perf_context);
-        }
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -334,18 +334,22 @@ where
         let _t = StopWatch::new(&*ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
         if let Some(memtable) = self.memtables.get(region_id) {
             let mut ents_idx: Vec<EntryIndex> = Vec::with_capacity((end - begin) as usize);
-            memtable.read().fetch_entries_to(begin, end, max_size, &mut ents_idx)?;
+            memtable
+                .read()
+                .fetch_entries_to(begin, end, max_size, &mut ents_idx)?;
             for i in ents_idx.iter() {
                 vec.push({
                     match read_entry_from_file::<M, _>(self.pipe_log.as_ref(), i) {
                         Ok(entry) => entry,
                         Err(e) => {
                             // The index is not found in the file, it means the entry is already
-                            // stale by `compact` or `rewrite`. Retry to read the entry from the memtable.
+                            // stale by `compact` or `rewrite`. Retry to read the entry from the
+                            // memtable.
                             let immutable = memtable.read();
-                            // Ensure that the corresponding memtable is locked with a read lock before
-                            // completing the fetching of entries from the raft logs. This
-                            // prevents the scenario where the index could become stale while
+                            // Ensure that the corresponding memtable is locked with a read lock
+                            // before completing the fetching of entries
+                            // from the raft logs. This prevents the
+                            // scenario where the index could become stale while
                             // being concurrently updated by the `rewrite` operation.
                             if let Some(idx) = immutable.get_entry(i.index) {
                                 read_entry_from_file::<M, _>(self.pipe_log.as_ref(), &idx)?


### PR DESCRIPTION
## Background
PR [#370](https://github.com/tikv/raft-engine/pull/370) fixed a panic issue caused by concurrent updates to `Memtable` followed by reads on stale indexes. However, we observed that this fix introduced performance regressions under concurrent read/write workloads.

## Issue
When `fetch_entries_to` retrieves a large batch of entries from disk, write operations are blocked until the read completes, delaying `Memtable` updates and degrading throughput.

## Solution
This PR optimizes `fetch_entries_to` to reduce contention and improve performance under mixed workloads.

## Results
| Branch | Status |
| --- | --- |
| [Master](https://github.com/tikv/raft-engine/commit/392f5e66f8286dc1b6d7cf69f2bc20ed72d40123) | ![image](https://github.com/user-attachments/assets/72b2e5b3-56a2-4938-aebd-15a3090b9e15) |
| This PR | ![image](https://github.com/user-attachments/assets/fff80c0b-a98e-4c9e-b902-86c31b9fa431) |
