### PR TITLE
Update serde, so TiKV can update time crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,43 +15,9 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  nightly:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # tests with sanitizer on `ubuntu-latest` is supported by 
-        # self-defined `nihtly test` job, so we don't need to test it here.
-        os: [ macos-latest ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2026-01-30
-          override: true
-          components: rustfmt, clippy, rust-src
-      - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: ${{ matrix.os }}
-      - name: Cache dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
-      - name: Format
-        run: |
-          make format
-          git diff --exit-code
-      - name: Clippy
-        run: make clippy
-        env:
-          EXTRA_CARGO_ARGS: '--fix'
-      - name: Run tests
-        run: make test
-        env:
-          RUST_BACKTRACE: 1
-          EXTRA_CARGO_ARGS: '--verbose'
+  # The macOS nightly CI job was removed because grpc-io 0.13 fails with the
+  # macOS C++ toolchain. Without a committed Cargo.lock, we cannot pin
+  # grpc-io to 0.10 as a workaround.
   stable:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
           WITH_STABLE_TOOLCHAIN: 'force'
   coverage:
     runs-on: ubuntu-latest
-    needs: nightly
+    needs: stable
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,43 +15,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  nightly:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # tests with sanitizer on `ubuntu-latest` is supported by 
-        # self-defined `nihtly test` job, so we don't need to test it here.
-        os: [ macos-latest ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2026-01-30
-          override: true
-          components: rustfmt, clippy, rust-src
-      - uses: Swatinem/rust-cache@v1
-        with:
-          sharedKey: ${{ matrix.os }}
-      - name: Cache dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
-      - name: Format
-        run: |
-          make format
-          git diff --exit-code
-      - name: Clippy
-        run: make clippy
-        env:
-          EXTRA_CARGO_ARGS: '--fix'
-      - name: Run tests
-        run: make test
-        env:
-          RUST_BACKTRACE: 1
-          EXTRA_CARGO_ARGS: '--verbose'
   stable:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -83,7 +46,7 @@ jobs:
           WITH_STABLE_TOOLCHAIN: 'force'
   coverage:
     runs-on: ubuntu-latest
-    needs: nightly
+    needs: stable
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,9 +15,43 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # The macOS nightly CI job was removed because grpc-io 0.13 fails with the
-  # macOS C++ toolchain. Without a committed Cargo.lock, we cannot pin
-  # grpc-io to 0.10 as a workaround.
+  nightly:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # tests with sanitizer on `ubuntu-latest` is supported by 
+        # self-defined `nihtly test` job, so we don't need to test it here.
+        os: [ macos-latest ]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2026-01-30
+          override: true
+          components: rustfmt, clippy, rust-src
+      - uses: Swatinem/rust-cache@v1
+        with:
+          sharedKey: ${{ matrix.os }}
+      - name: Cache dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+      - name: Format
+        run: |
+          make format
+          git diff --exit-code
+      - name: Clippy
+        run: make clippy
+        env:
+          EXTRA_CARGO_ARGS: '--fix'
+      - name: Run tests
+        run: make test
+        env:
+          RUST_BACKTRACE: 1
+          EXTRA_CARGO_ARGS: '--verbose'
   stable:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -49,7 +83,7 @@ jobs:
           WITH_STABLE_TOOLCHAIN: 'force'
   coverage:
     runs-on: ubuntu-latest
-    needs: stable
+    needs: nightly
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2025-04-03
+          toolchain: nightly-2026-01-30
           override: true
           components: rustfmt, clippy, rust-src
       - uses: Swatinem/rust-cache@v1
@@ -92,7 +92,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2025-04-03
+          toolchain: nightly-2026-01-30
           override: true
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "raft-engine"
 version = "0.4.2"
 authors = ["The TiKV Project Developers"]
-edition = "2018"
+edition = "2024"
 rust-version = "1.85.0"
 description = "A persistent storage engine for Multi-Raft logs"
 readme = "README.md"
@@ -58,7 +58,7 @@ protobuf = "2"
 rayon = "1.5"
 rhai = { version = "1.7", features = ["sync"], optional = true }
 scopeguard = "1.1"
-serde = { version = "=1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ protobuf = "2"
 rayon = "1.5"
 rhai = { version = "1.7", features = ["sync"], optional = true }
 scopeguard = "1.1"
-serde = { version = "=1.0.194", features = ["derive"] }
+serde = { version = "=1.0", features = ["derive"] }
 serde_repr = "0.1"
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0"

--- a/examples/fork.rs
+++ b/examples/fork.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use raft_engine::env::DefaultFileSystem;
 use raft_engine::Config;
 use raft_engine::Engine;
+use raft_engine::env::DefaultFileSystem;
 
 fn main() {
     let mut args = std::env::args();

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::pipe_log::Version;
-use crate::{util::ReadableSize, Result};
+use crate::{Result, util::ReadableSize};
 
 const MIN_RECOVERY_READ_BLOCK_SIZE: usize = 512;
 const MIN_RECOVERY_THREADS: usize = 1;
@@ -343,9 +343,11 @@ mod tests {
         let mut load: Config = toml::from_str(old).unwrap();
         load.sanitize().unwrap();
         // Downgrade to older version.
-        assert!(toml::to_string(&load)
-            .unwrap()
-            .contains("tolerate-corrupted-tail-records"));
+        assert!(
+            toml::to_string(&load)
+                .unwrap()
+                .contains("tolerate-corrupted-tail-records")
+        );
     }
 
     #[test]

--- a/src/consistency.rs
+++ b/src/consistency.rs
@@ -2,10 +2,10 @@
 
 use hashbrown::HashMap;
 
+use crate::Result;
 use crate::file_pipe_log::ReplayMachine;
 use crate::log_batch::{LogItemBatch, LogItemContent};
 use crate::pipe_log::{FileId, LogQueue};
-use crate::Result;
 
 /// A `ConsistencyChecker` scans for log entry holes in a log queue. It will
 /// return a list of corrupted raft groups along with their last valid log

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1422,7 +1422,7 @@ pub(crate) mod tests {
         let empty_entry = Entry::new();
         assert_eq!(empty_entry.compute_size(), 0);
         log_batch
-            .add_entries::<Entry>(0, &[empty_entry.clone()])
+            .add_entries::<Entry>(0, std::slice::from_ref(&empty_entry))
             .unwrap();
         engine.write(&mut log_batch, false).unwrap();
         let empty_state = RaftLocalState::new();
@@ -1432,7 +1432,7 @@ pub(crate) mod tests {
             .unwrap();
         engine.write(&mut log_batch, false).unwrap();
         log_batch
-            .add_entries::<Entry>(2, &[empty_entry.clone()])
+            .add_entries::<Entry>(2, std::slice::from_ref(&empty_entry))
             .unwrap();
         log_batch
             .put_message(2, b"key".to_vec(), &empty_state)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,12 +3,12 @@
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::path::Path;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 use std::thread::{Builder as ThreadBuilder, JoinHandle};
 use std::time::{Duration, Instant};
 
 use log::{error, info};
-use protobuf::{parse_from_bytes, Message};
+use protobuf::{Message, parse_from_bytes};
 
 use crate::config::{Config, RecoveryMode};
 use crate::consistency::ConsistencyChecker;
@@ -22,7 +22,7 @@ use crate::metrics::*;
 use crate::pipe_log::{FileBlockHandle, FileId, LogQueue, PipeLog};
 use crate::purge::{PurgeHook, PurgeManager};
 use crate::write_barrier::{WriteBarrier, Writer};
-use crate::{perf_context, Error, GlobalStats, Result};
+use crate::{Error, GlobalStats, Result, perf_context};
 
 const METRICS_FLUSH_INTERVAL: Duration = Duration::from_secs(30);
 /// Max times for `write`.
@@ -106,11 +106,13 @@ where
         let memtables_clone = memtables.clone();
         let metrics_flusher = ThreadBuilder::new()
             .name("re-metrics".into())
-            .spawn(move || loop {
-                stats_clone.flush_metrics();
-                memtables_clone.flush_metrics();
-                if rx.recv_timeout(METRICS_FLUSH_INTERVAL).is_ok() {
-                    break;
+            .spawn(move || {
+                loop {
+                    stats_clone.flush_metrics();
+                    memtables_clone.flush_metrics();
+                    if rx.recv_timeout(METRICS_FLUSH_INTERVAL).is_ok() {
+                        break;
+                    }
                 }
             })?;
 
@@ -648,14 +650,14 @@ where
 pub(crate) mod tests {
     use super::*;
     use crate::env::{ObfuscatedFileSystem, Permission};
-    use crate::file_pipe_log::{parse_reserved_file_name, FileNameExt};
+    use crate::file_pipe_log::{FileNameExt, parse_reserved_file_name};
     use crate::log_batch::AtomicGroupBuilder;
     use crate::pipe_log::Version;
-    use crate::test_util::{generate_entries, PanicGuard};
+    use crate::test_util::{PanicGuard, generate_entries};
     use crate::util::ReadableSize;
     use kvproto::raft_serverpb::RaftLocalState;
     use raft::eraftpb::Entry;
-    use rand::{thread_rng, Rng};
+    use rand::{Rng, thread_rng};
     use std::collections::{BTreeSet, HashSet};
     use std::fs::OpenOptions;
     use std::path::PathBuf;
@@ -1231,9 +1233,11 @@ pub(crate) mod tests {
         // GC all log entries. Won't trigger purge because total size is not enough.
         let count = engine.compact_to(1, 100);
         assert_eq!(count, 100);
-        assert!(!engine
-            .purge_manager
-            .needs_rewrite_log_files(LogQueue::Append));
+        assert!(
+            !engine
+                .purge_manager
+                .needs_rewrite_log_files(LogQueue::Append)
+        );
 
         // Append more logs to make total size greater than `purge_threshold`.
         for index in 100..250 {
@@ -1243,9 +1247,11 @@ pub(crate) mod tests {
         // GC first 101 log entries.
         assert_eq!(engine.compact_to(1, 101), 1);
         // Needs to purge because the total size is greater than `purge_threshold`.
-        assert!(engine
-            .purge_manager
-            .needs_rewrite_log_files(LogQueue::Append));
+        assert!(
+            engine
+                .purge_manager
+                .needs_rewrite_log_files(LogQueue::Append)
+        );
 
         let old_min_file_seq = engine.file_span(LogQueue::Append).0;
         let will_force_compact = engine.purge_expired_files().unwrap();
@@ -1259,9 +1265,11 @@ pub(crate) mod tests {
 
         assert_eq!(engine.compact_to(1, 102), 1);
         // Needs to purge because the total size is greater than `purge_threshold`.
-        assert!(engine
-            .purge_manager
-            .needs_rewrite_log_files(LogQueue::Append));
+        assert!(
+            engine
+                .purge_manager
+                .needs_rewrite_log_files(LogQueue::Append)
+        );
         let will_force_compact = engine.purge_expired_files().unwrap();
         // The region needs to be force compacted because the threshold is reached.
         assert!(!will_force_compact.is_empty());
@@ -1350,9 +1358,11 @@ pub(crate) mod tests {
         engine.append(11, 1, 11, Some(&data));
 
         // The engine needs purge, and all old entries should be rewritten.
-        assert!(engine
-            .purge_manager
-            .needs_rewrite_log_files(LogQueue::Append));
+        assert!(
+            engine
+                .purge_manager
+                .needs_rewrite_log_files(LogQueue::Append)
+        );
         assert!(engine.purge_expired_files().unwrap().is_empty());
         assert!(engine.file_span(LogQueue::Append).0 > 1);
 
@@ -1386,9 +1396,11 @@ pub(crate) mod tests {
             }
         }
 
-        assert!(engine
-            .purge_manager
-            .needs_rewrite_log_files(LogQueue::Append));
+        assert!(
+            engine
+                .purge_manager
+                .needs_rewrite_log_files(LogQueue::Append)
+        );
         assert!(engine.purge_expired_files().unwrap().is_empty());
     }
 

--- a/src/env/log_fd/unix.rs
+++ b/src/env/log_fd/unix.rs
@@ -8,12 +8,12 @@ use log::error;
 use std::io::Result as IoResult;
 use std::os::unix::io::RawFd;
 
+use nix::NixPath;
 use nix::errno::Errno;
 use nix::fcntl::{self, OFlag};
 use nix::sys::stat::Mode;
 use nix::sys::uio::{pread, pwrite};
-use nix::unistd::{close, ftruncate, lseek, Whence};
-use nix::NixPath;
+use nix::unistd::{Whence, close, ftruncate, lseek};
 
 fn from_nix_error(e: nix::Error, custom: &'static str) -> std::io::Error {
     let kind = std::io::Error::from(e).kind();

--- a/src/env/obfuscated.rs
+++ b/src/env/obfuscated.rs
@@ -2,8 +2,8 @@
 
 use std::io::{Read, Result as IoResult, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::env::{DefaultFileSystem, FileSystem, Permission, WriteExt};
 

--- a/src/file_pipe_log/mod.rs
+++ b/src/file_pipe_log/mod.rs
@@ -10,7 +10,7 @@ mod pipe;
 mod pipe_builder;
 mod reader;
 
-pub use format::{parse_reserved_file_name, FileNameExt};
+pub use format::{FileNameExt, parse_reserved_file_name};
 pub use pipe::DualPipes as FilePipeLog;
 pub use pipe_builder::{
     DefaultMachineFactory, DualPipesBuilder as FilePipeLogBuilder, RecoveryConfig, ReplayMachine,
@@ -173,7 +173,7 @@ pub mod debug {
         use crate::env::DefaultFileSystem;
         use crate::log_batch::{Command, LogBatch};
         use crate::pipe_log::{FileBlockHandle, LogFileContext, LogQueue, Version};
-        use crate::test_util::{generate_entries, PanicGuard};
+        use crate::test_util::{PanicGuard, generate_entries};
         use raft::eraftpb::Entry;
 
         #[test]

--- a/src/file_pipe_log/pipe.rs
+++ b/src/file_pipe_log/pipe.rs
@@ -19,11 +19,11 @@ use crate::metrics::*;
 use crate::pipe_log::{
     FileBlockHandle, FileId, FileSeq, LogFileContext, LogQueue, PipeLog, ReactiveBytes,
 };
-use crate::{perf_context, Error, Result};
+use crate::{Error, Result, perf_context};
 
-use super::format::{build_reserved_file_name, FileNameExt, LogFileFormat};
+use super::format::{FileNameExt, LogFileFormat, build_reserved_file_name};
 use super::log_file::build_file_reader;
-use super::log_file::{build_file_writer, LogFileWriter};
+use super::log_file::{LogFileWriter, build_file_writer};
 
 pub type PathId = usize;
 pub type Paths = Vec<PathBuf>;
@@ -614,8 +614,10 @@ mod tests {
         // Only one thread can hold file lock
         let r2 = new_test_pipes(&cfg);
 
-        assert!(format!("{}", r2.err().unwrap())
-            .contains("maybe another instance is using this directory"));
+        assert!(
+            format!("{}", r2.err().unwrap())
+                .contains("maybe another instance is using this directory")
+        );
     }
 
     #[test]

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -240,9 +240,9 @@ impl<F: FileSystem> DualPipesBuilder<F> {
             self.scan_dir(&dir, lock)?;
         }
 
-        self.append_file_names.sort_by(|a, b| a.seq.cmp(&b.seq));
-        self.rewrite_file_names.sort_by(|a, b| a.seq.cmp(&b.seq));
-        self.recycled_file_names.sort_by(|a, b| a.seq.cmp(&b.seq));
+        self.append_file_names.sort_by_key(|a| a.seq);
+        self.rewrite_file_names.sort_by_key(|a| a.seq);
+        self.recycled_file_names.sort_by_key(|a| a.seq);
         Ok(())
     }
 

--- a/src/file_pipe_log/pipe_builder.rs
+++ b/src/file_pipe_log/pipe_builder.rs
@@ -17,17 +17,17 @@ use crate::config::{Config, RecoveryMode};
 use crate::env::{FileSystem, Handle, Permission};
 use crate::errors::is_no_space_err;
 use crate::event_listener::EventListener;
-use crate::log_batch::{LogItemBatch, LOG_BATCH_HEADER_LEN};
+use crate::log_batch::{LOG_BATCH_HEADER_LEN, LogItemBatch};
 use crate::pipe_log::{FileId, FileSeq, LogQueue};
 use crate::util::{Factory, ReadableSize};
 use crate::{Error, Result};
 
 use super::format::{
-    build_reserved_file_name, lock_file_path, parse_reserved_file_name, FileNameExt, LogFileFormat,
+    FileNameExt, LogFileFormat, build_reserved_file_name, lock_file_path, parse_reserved_file_name,
 };
 use super::log_file::build_file_reader;
 use super::pipe::{
-    find_available_dir, DualPipes, File, PathId, Paths, SinglePipe, DEFAULT_FIRST_FILE_SEQ,
+    DEFAULT_FIRST_FILE_SEQ, DualPipes, File, PathId, Paths, SinglePipe, find_available_dir,
 };
 use super::reader::LogItemBatchFileReader;
 

--- a/src/file_pipe_log/reader.rs
+++ b/src/file_pipe_log/reader.rs
@@ -1,12 +1,12 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
 use crate::env::FileSystem;
-use crate::log_batch::{LogBatch, LogItemBatch, LOG_BATCH_HEADER_LEN};
+use crate::log_batch::{LOG_BATCH_HEADER_LEN, LogBatch, LogItemBatch};
 use crate::pipe_log::{FileBlockHandle, FileId, LogFileContext};
 use crate::util::round_up;
 use crate::{Error, Result};
 
-use super::format::{is_zero_padded, LogFileFormat};
+use super::format::{LogFileFormat, is_zero_padded};
 use super::log_file::LogFileReader;
 
 /// A reusable reader over [`LogItemBatch`]s in a log file.

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use hashbrown::HashMap;
-use rhai::{Engine, Scope, AST};
-use scopeguard::{guard, ScopeGuard};
+use rhai::{AST, Engine, Scope};
+use scopeguard::{ScopeGuard, guard};
 
 use crate::env::FileSystem;
 use crate::file_pipe_log::debug::{build_file_reader, build_file_writer};

--- a/src/fork.rs
+++ b/src/fork.rs
@@ -9,11 +9,11 @@ use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::symlink_file as symlink;
 
+use crate::Engine;
 use crate::config::{Config, RecoveryMode};
 use crate::env::FileSystem;
 use crate::file_pipe_log::{FileNameExt, FilePipeLog, FilePipeLogBuilder};
 use crate::pipe_log::{FileId, LogQueue};
-use crate::Engine;
 
 /// Returned by `Engine::fork`.
 #[derive(Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,6 @@
 #![cfg_attr(feature = "nightly", feature(test))]
 #![cfg_attr(feature = "swap", feature(allocator_api))]
 #![cfg_attr(feature = "swap", feature(slice_ptr_get))]
-// Though the new nightly rust stablized this feature, keep it anyway
-// because some other project (like TiKV) is still using the old.
-#![cfg_attr(feature = "swap", feature(nonnull_slice_from_raw_parts))]
-#![cfg_attr(feature = "swap", feature(slice_ptr_len))]
 #![cfg_attr(feature = "swap", feature(alloc_layout_extra))]
 #![cfg_attr(all(test, feature = "swap"), feature(alloc_error_hook))]
 #![cfg_attr(all(test, feature = "swap"), feature(cfg_sanitize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub use config::{Config, RecoveryMode};
 pub use engine::Engine;
 pub use errors::{Error, Result};
 pub use log_batch::{Command, LogBatch, MessageExt};
-pub use metrics::{get_perf_context, set_perf_context, take_perf_context, PerfContext};
+pub use metrics::{PerfContext, get_perf_context, set_perf_context, take_perf_context};
 pub use pipe_log::Version;
 pub use util::ReadableSize;
 

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -3,8 +3,8 @@
 use std::fmt::Debug;
 use std::io::BufRead;
 use std::mem;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 use log::error;
@@ -17,7 +17,7 @@ use crate::memtable::EntryIndex;
 use crate::metrics::StopWatch;
 use crate::pipe_log::{FileBlockHandle, FileId, LogFileContext, ReactiveBytes};
 use crate::util::{crc32, lz4};
-use crate::{perf_context, Error, Result};
+use crate::{Error, Result, perf_context};
 
 pub(crate) const LOG_BATCH_HEADER_LEN: usize = 16;
 pub(crate) const LOG_BATCH_CHECKSUM_LEN: usize = 4;
@@ -1600,44 +1600,48 @@ mod tests {
 
         let mut copy = encoded.to_owned();
         copy.truncate(LOG_BATCH_HEADER_LEN - 1);
-        assert!(LogBatch::decode_header(&mut copy.as_slice())
-            .unwrap_err()
-            .to_string()
-            .contains("Log batch header too short"));
+        assert!(
+            LogBatch::decode_header(&mut copy.as_slice())
+                .unwrap_err()
+                .to_string()
+                .contains("Log batch header too short")
+        );
 
         let mut copy = encoded.to_owned();
         (&mut copy[LOG_BATCH_HEADER_LEN - 8..LOG_BATCH_HEADER_LEN])
             .write_u64::<BigEndian>(encoded.len() as u64 + 1)
             .unwrap();
-        assert!(LogBatch::decode_header(&mut copy.as_slice())
-            .unwrap_err()
-            .to_string()
-            .contains("Log item offset exceeds log batch length"));
+        assert!(
+            LogBatch::decode_header(&mut copy.as_slice())
+                .unwrap_err()
+                .to_string()
+                .contains("Log item offset exceeds log batch length")
+        );
 
         let mut copy = encoded.to_owned();
         (&mut copy[LOG_BATCH_HEADER_LEN - 8..LOG_BATCH_HEADER_LEN])
             .write_u64::<BigEndian>(LOG_BATCH_HEADER_LEN as u64 - 1)
             .unwrap();
-        assert!(LogBatch::decode_header(&mut copy.as_slice())
-            .unwrap_err()
-            .to_string()
-            .contains("Log item offset is smaller than log batch header length"));
+        assert!(
+            LogBatch::decode_header(&mut copy.as_slice())
+                .unwrap_err()
+                .to_string()
+                .contains("Log item offset is smaller than log batch header length")
+        );
     }
 
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_log_batch_add_entry_and_encode(b: &mut test::Bencher) {
-        use rand::{thread_rng, Rng};
+        use rand::{Rng, random};
         fn details(log_batch: &mut LogBatch, entries: &[Entry], regions: usize) {
             for _ in 0..regions {
-                log_batch
-                    .add_entries::<Entry>(thread_rng().gen(), entries)
-                    .unwrap();
+                log_batch.add_entries::<Entry>(random(), entries).unwrap();
             }
             log_batch.finish_populate(0, None).unwrap();
             let _ = log_batch.drain();
         }
-        let data: Vec<u8> = (0..128).map(|_| thread_rng().gen()).collect();
+        let data: Vec<u8> = (0..128).map(|_| random()).collect();
         let entries = generate_entries(1, 11, Some(&data));
         let mut log_batch = LogBatch::default();
         // warm up

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -1633,7 +1633,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_log_batch_add_entry_and_encode(b: &mut test::Bencher) {
-        use rand::{Rng, random};
+        use rand::random;
         fn details(log_batch: &mut LogBatch, entries: &[Entry], regions: usize) {
             for _ in 0..regions {
                 log_batch.add_entries::<Entry>(random(), entries).unwrap();

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -372,11 +372,11 @@ impl LogItemBatch {
         self.items
     }
 
-    pub fn iter(&self) -> std::slice::Iter<LogItem> {
+    pub fn iter(&self) -> std::slice::Iter<'_, LogItem> {
         self.items.iter()
     }
 
-    pub fn drain(&mut self) -> LogItemDrain {
+    pub fn drain(&mut self) -> LogItemDrain<'_> {
         self.item_size = 0;
         self.entries_size = 0;
         self.checksum = 0;
@@ -882,7 +882,7 @@ impl LogBatch {
     }
 
     /// Consumes log items into an iterator.
-    pub(crate) fn drain(&mut self) -> LogItemDrain {
+    pub(crate) fn drain(&mut self) -> LogItemDrain<'_> {
         debug_assert!(!matches!(self.buf_state, BufState::Incomplete));
 
         self.buf.shrink_to(MAX_LOG_BATCH_BUFFER_CAP);

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -19,7 +19,7 @@ use crate::log_batch::{
 };
 use crate::metrics::MEMORY_USAGE;
 use crate::pipe_log::{FileBlockHandle, FileId, FileSeq, LogQueue};
-use crate::util::{hash_u64, Factory};
+use crate::util::{Factory, hash_u64};
 use crate::{Error, GlobalStats, Result};
 
 #[cfg(feature = "swap")]
@@ -1855,21 +1855,27 @@ mod tests {
         memtable.consistency_check();
 
         let mut ents_idx = vec![];
-        assert!(memtable
-            .fetch_entry_indexes_before(2, &mut ents_idx)
-            .is_ok());
+        assert!(
+            memtable
+                .fetch_entry_indexes_before(2, &mut ents_idx)
+                .is_ok()
+        );
         assert_eq!(ents_idx.len(), 10);
         assert_eq!(ents_idx.last().unwrap().index, 19);
         ents_idx.clear();
-        assert!(memtable
-            .fetch_entry_indexes_before(1, &mut ents_idx)
-            .is_ok());
+        assert!(
+            memtable
+                .fetch_entry_indexes_before(1, &mut ents_idx)
+                .is_ok()
+        );
         assert!(ents_idx.is_empty());
 
         ents_idx.clear();
-        assert!(memtable
-            .fetch_rewritten_entry_indexes(&mut ents_idx)
-            .is_ok());
+        assert!(
+            memtable
+                .fetch_rewritten_entry_indexes(&mut ents_idx)
+                .is_ok()
+        );
         assert_eq!(ents_idx.len(), 10);
         assert_eq!(ents_idx.first().unwrap().index, 0);
         assert_eq!(ents_idx.last().unwrap().index, 9);

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -3,8 +3,8 @@
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
 use std::mem;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use fail::fail_point;
 use log::{info, warn};

--- a/src/swappy_allocator.rs
+++ b/src/swappy_allocator.rs
@@ -6,8 +6,8 @@ use std::alloc::{AllocError, Allocator, Global, Layout};
 use std::fs::{File, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::ptr::{self, NonNull};
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
 use std::vec::Vec;
 
 use log::{error, warn};
@@ -651,10 +651,12 @@ mod tests {
         {
             let mut vec: Vec<u8, _> = Vec::new_in(allocator.clone());
             global.set_err_mode(true);
-            assert!(catch_unwind_silent(|| {
-                vec.resize(16, 0);
-            })
-            .is_err());
+            assert!(
+                catch_unwind_silent(|| {
+                    vec.resize(16, 0);
+                })
+                .is_err()
+            );
             assert_eq!(allocator.memory_usage(), 0);
             global.set_err_mode(false);
             vec.resize(16, 0);
@@ -666,10 +668,12 @@ mod tests {
             vec.resize(16, 0);
             assert_eq!(allocator.memory_usage(), 16);
             global.set_err_mode(true);
-            assert!(catch_unwind_silent(|| {
-                vec.resize(32, 0);
-            })
-            .is_err());
+            assert!(
+                catch_unwind_silent(|| {
+                    vec.resize(32, 0);
+                })
+                .is_err()
+            );
             assert_eq!(allocator.memory_usage(), 16);
             global.set_err_mode(false);
             vec.resize(32, 0);
@@ -682,10 +686,12 @@ mod tests {
             assert_eq!(allocator.memory_usage(), 32);
             global.set_err_mode(true);
             vec.resize(16, 0);
-            assert!(catch_unwind_silent(|| {
-                vec.shrink_to_fit();
-            })
-            .is_err());
+            assert!(
+                catch_unwind_silent(|| {
+                    vec.shrink_to_fit();
+                })
+                .is_err()
+            );
             assert_eq!(allocator.memory_usage(), 32);
             global.set_err_mode(false);
             vec.shrink_to_fit();
@@ -1095,10 +1101,12 @@ mod tests {
             v.push_front(D(1, false));
             v.push_front(D(0, false));
 
-            assert!(catch_unwind_silent(|| {
-                v.drain(1..=4);
-            })
-            .is_err());
+            assert!(
+                catch_unwind_silent(|| {
+                    v.drain(1..=4);
+                })
+                .is_err()
+            );
 
             assert_eq!(unsafe { DROPS }, 4);
             assert_eq!(v.len(), 3);

--- a/src/swappy_allocator.rs
+++ b/src/swappy_allocator.rs
@@ -144,7 +144,7 @@ unsafe impl<A: Allocator + Send + Sync> Allocator for SwappyAllocator<A> {
             }
         }
         self.0.mem_usage.fetch_sub(layout.size(), Ordering::Relaxed);
-        self.0.mem_allocator.deallocate(ptr, layout)
+        unsafe { self.0.mem_allocator.deallocate(ptr, layout) }
     }
 
     #[inline]
@@ -187,12 +187,9 @@ unsafe impl<A: Allocator + Send + Sync> Allocator for SwappyAllocator<A> {
 
             Ok(new_ptr)
         } else {
-            self.0
-                .mem_allocator
-                .grow(ptr, old_layout, new_layout)
-                .inspect_err(|_| {
-                    self.0.mem_usage.fetch_sub(diff, Ordering::Relaxed);
-                })
+            unsafe { self.0.mem_allocator.grow(ptr, old_layout, new_layout) }.inspect_err(|_| {
+                self.0.mem_usage.fetch_sub(diff, Ordering::Relaxed);
+            })
         }
     }
 
@@ -203,8 +200,8 @@ unsafe impl<A: Allocator + Send + Sync> Allocator for SwappyAllocator<A> {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        let ptr = self.grow(ptr, old_layout, new_layout)?;
-        ptr.as_non_null_ptr().as_ptr().write_bytes(0, ptr.len());
+        let ptr = unsafe { self.grow(ptr, old_layout, new_layout)? };
+        unsafe { ptr.as_non_null_ptr().as_ptr().write_bytes(0, ptr.len()) };
         Ok(ptr)
     }
 
@@ -243,19 +240,16 @@ unsafe impl<A: Allocator + Send + Sync> Allocator for SwappyAllocator<A> {
             } else {
                 // The new layout should still be mapped to disk. Reuse old pointer.
                 Ok(NonNull::slice_from_raw_parts(
-                    NonNull::new_unchecked(ptr.as_ptr()),
+                    unsafe { NonNull::new_unchecked(ptr.as_ptr()) },
                     new_layout.size(),
                 ))
             }
         } else {
-            self.0
-                .mem_allocator
-                .shrink(ptr, old_layout, new_layout)
-                .inspect(|_| {
-                    self.0
-                        .mem_usage
-                        .fetch_sub(old_layout.size() - new_layout.size(), Ordering::Relaxed);
-                })
+            unsafe { self.0.mem_allocator.shrink(ptr, old_layout, new_layout) }.inspect(|_| {
+                self.0
+                    .mem_usage
+                    .fetch_sub(old_layout.size() - new_layout.size(), Ordering::Relaxed);
+            })
         }
     }
 }

--- a/src/swappy_allocator.rs
+++ b/src/swappy_allocator.rs
@@ -402,7 +402,7 @@ mod tests {
         }
         unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
             self.dealloc.fetch_add(1, Ordering::Relaxed);
-            std::alloc::Global.deallocate(ptr, layout)
+            unsafe { std::alloc::Global.deallocate(ptr, layout) }
         }
         unsafe fn grow(
             &self,
@@ -414,7 +414,7 @@ mod tests {
             if self.err_mode.load(Ordering::Relaxed) {
                 Err(AllocError)
             } else {
-                std::alloc::Global.grow(ptr, old_layout, new_layout)
+                unsafe { std::alloc::Global.grow(ptr, old_layout, new_layout) }
             }
         }
         unsafe fn shrink(
@@ -427,7 +427,7 @@ mod tests {
             if self.err_mode.load(Ordering::Relaxed) {
                 Err(AllocError)
             } else {
-                std::alloc::Global.shrink(ptr, old_layout, new_layout)
+                unsafe { std::alloc::Global.shrink(ptr, old_layout, new_layout) }
             }
         }
     }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,6 +1,9 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use std::panic::{self, AssertUnwindSafe};
+use std::{
+    panic::{self, AssertUnwindSafe},
+    sync::Arc,
+};
 
 use raft::eraftpb::Entry;
 
@@ -63,22 +66,18 @@ where
 }
 
 pub struct PanicGuard {
-    prev_hook: *mut (dyn Fn(&panic::PanicHookInfo<'_>) + Sync + Send + 'static),
+    prev_hook: Arc<dyn Fn(&panic::PanicHookInfo<'_>) + Sync + Send + 'static>,
 }
-
-struct PointerHolder<T: ?Sized>(*mut T);
-
-unsafe impl<T: Send + ?Sized> Send for PointerHolder<T> {}
-unsafe impl<T: Sync + ?Sized> Sync for PointerHolder<T> {}
 
 impl PanicGuard {
     pub fn with_prompt(s: String) -> Self {
-        let prev_hook = Box::into_raw(panic::take_hook());
-        let sendable_prev_hook = PointerHolder(prev_hook);
+        let prev_hook: Arc<dyn Fn(&panic::PanicHookInfo<'_>) + Sync + Send + 'static> =
+            Arc::from(panic::take_hook());
+        let prev_hook_for_hook = Arc::clone(&prev_hook);
         // FIXME: Use thread local hook.
         panic::set_hook(Box::new(move |info| {
             eprintln!("{s}");
-            unsafe { (*sendable_prev_hook.0)(info) };
+            prev_hook_for_hook(info);
         }));
         PanicGuard { prev_hook }
     }
@@ -88,9 +87,8 @@ impl Drop for PanicGuard {
     fn drop(&mut self) {
         if !std::thread::panicking() {
             let _ = panic::take_hook();
-            unsafe {
-                panic::set_hook(Box::from_raw(self.prev_hook));
-            }
+            let prev_hook = Arc::clone(&self.prev_hook);
+            panic::set_hook(Box::new(move |info| prev_hook(info)));
         }
     }
 }

--- a/tests/benches/bench_recovery.rs
+++ b/tests/benches/bench_recovery.rs
@@ -118,7 +118,7 @@ fn dir_size(path: &str) -> ReadableSize {
 
 fn bench_recovery(c: &mut Criterion) {
     // prepare input
-    let cfgs = vec![
+    let cfgs = [
         (
             "default".to_owned(),
             Config {

--- a/tests/benches/bench_recovery.rs
+++ b/tests/benches/bench_recovery.rs
@@ -1,6 +1,6 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use criterion::{criterion_group, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion, criterion_group};
 use raft::eraftpb::Entry;
 use raft_engine::ReadableSize;
 use raft_engine::{Config as EngineConfig, Engine, LogBatch, MessageExt, Result};
@@ -44,7 +44,9 @@ impl Default for Config {
 
 impl fmt::Display for Config {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} [region-count: {}][batch-size: {}][item-size: {}][entry-size: {}][batch-compression-threshold: {}]",
+        write!(
+            f,
+            "{} [region-count: {}][batch-size: {}][item-size: {}][entry-size: {}][batch-compression-threshold: {}]",
             self.total_size,
             self.region_count,
             self.batch_size,

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -724,14 +724,16 @@ fn test_recycle_with_stale_logbatch_at_tail() {
     // Causing the final log file is a recycled file, containing rewritten
     // LogBatchs and end with stale LogBatchs, `Engine::open(...)` should
     // `panic` when recovering the relate `Memtable`.
-    assert!(catch_unwind_silent(|| {
-        let cfg_v2 = Config {
-            format_version: Version::V2,
-            ..cfg_err
-        };
-        Engine::open(cfg_v2)
-    })
-    .is_err());
+    assert!(
+        catch_unwind_silent(|| {
+            let cfg_v2 = Config {
+                format_version: Version::V2,
+                ..cfg_err
+            };
+            Engine::open(cfg_v2)
+        })
+        .is_err()
+    );
 }
 
 #[test]

--- a/tests/failpoints/test_io_error.rs
+++ b/tests/failpoints/test_io_error.rs
@@ -105,10 +105,12 @@ fn test_file_write_error() {
         engine
             .write(&mut generate_batch(1, 2, 3, Some(&entry)), false)
             .unwrap();
-        assert!(catch_unwind_silent(|| {
-            let _ = engine.write(&mut generate_batch(1, 3, 4, Some(&entry)), true);
-        })
-        .is_err());
+        assert!(
+            catch_unwind_silent(|| {
+                let _ = engine.write(&mut generate_batch(1, 3, 4, Some(&entry)), true);
+            })
+            .is_err()
+        );
     }
 
     // Internal states are consistent after panics. But outstanding writes are not
@@ -155,10 +157,12 @@ fn test_file_rotate_error(restart_after_failure: bool) {
     {
         // Fail to sync old log file.
         let _f = FailGuard::new("log_fd::sync::err", "return");
-        assert!(catch_unwind_silent(|| {
-            let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
-        })
-        .is_err());
+        assert!(
+            catch_unwind_silent(|| {
+                let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
+            })
+            .is_err()
+        );
     }
     if restart_after_failure {
         drop(engine);
@@ -168,9 +172,11 @@ fn test_file_rotate_error(restart_after_failure: bool) {
     {
         // Fail to create new log file.
         let _f = FailGuard::new("default_fs::create::err", "return");
-        assert!(engine
-            .write(&mut generate_batch(1, 4, 5, Some(&entry)), false)
-            .is_err());
+        assert!(
+            engine
+                .write(&mut generate_batch(1, 4, 5, Some(&entry)), false)
+                .is_err()
+        );
     }
     if restart_after_failure {
         drop(engine);
@@ -180,9 +186,11 @@ fn test_file_rotate_error(restart_after_failure: bool) {
     {
         // Fail to write header of new log file.
         let _f = FailGuard::new("log_file::write::err", "1*off->return");
-        assert!(engine
-            .write(&mut generate_batch(1, 4, 5, Some(&entry)), false)
-            .is_err());
+        assert!(
+            engine
+                .write(&mut generate_batch(1, 4, 5, Some(&entry)), false)
+                .is_err()
+        );
     }
     if restart_after_failure {
         drop(engine);
@@ -201,10 +209,12 @@ fn test_file_rotate_error(restart_after_failure: bool) {
         // If the engine restarted, the write does not require sync will succeed.
         // Fail to sync new log file. The old log file is already sync-ed at this point.
         let _f = FailGuard::new("log_fd::sync::err", "return");
-        assert!(catch_unwind_silent(|| {
-            let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
-        })
-        .is_err());
+        assert!(
+            catch_unwind_silent(|| {
+                let _ = engine.write(&mut generate_batch(1, 4, 5, Some(&entry)), false);
+            })
+            .is_err()
+        );
         assert_eq!(engine.file_span(LogQueue::Append).1, 1);
     }
 
@@ -372,12 +382,14 @@ fn test_non_atomic_write_error() {
         let engine = Engine::open_with_file_system(cfg.clone(), fs.clone()).unwrap();
         let _f1 = FailGuard::new("log_file::write::err", "return");
         let _f2 = FailGuard::new("log_file::seek::err", "return");
-        assert!(catch_unwind_silent(|| {
-            engine
-                .write(&mut generate_batch(rid, 6, 7, Some(&entry)), true)
-                .unwrap_err();
-        })
-        .is_err());
+        assert!(
+            catch_unwind_silent(|| {
+                engine
+                    .write(&mut generate_batch(rid, 6, 7, Some(&entry)), true)
+                    .unwrap_err();
+            })
+            .is_err()
+        );
     }
     {
         let engine = Engine::open_with_file_system(cfg, fs).unwrap();
@@ -572,9 +584,11 @@ fn test_no_space_write_error() {
             };
             let engine = Engine::open(cfg_err).unwrap();
             let _f = FailGuard::new("log_fd::write::no_space_err", "return");
-            assert!(engine
-                .write(&mut generate_batch(2, 11, 21, Some(&entry)), true)
-                .is_err());
+            assert!(
+                engine
+                    .write(&mut generate_batch(2, 11, 21, Some(&entry)), true)
+                    .is_err()
+            );
             assert_eq!(
                 0,
                 engine
@@ -588,9 +602,11 @@ fn test_no_space_write_error() {
             let _f1 = FailGuard::new("log_fd::write::no_space_err", "2*return->off");
             let _f2 = FailGuard::new("file_pipe_log::force_choose_dir", "return");
             // The first write should fail, because all dirs run out of space for writing.
-            assert!(engine
-                .write(&mut generate_batch(2, 11, 21, Some(&entry)), true)
-                .is_err());
+            assert!(
+                engine
+                    .write(&mut generate_batch(2, 11, 21, Some(&entry)), true)
+                    .is_err()
+            );
             assert_eq!(
                 0,
                 engine
@@ -643,9 +659,11 @@ fn test_no_space_write_error() {
                 "log_fd::write::no_space_err",
                 "1*return->1*off->1*return->1*off",
             );
-            assert!(engine
-                .write(&mut generate_batch(7, 11, 21, Some(&entry)), true)
-                .is_err());
+            assert!(
+                engine
+                    .write(&mut generate_batch(7, 11, 21, Some(&entry)), true)
+                    .is_err()
+            );
             assert_eq!(
                 0,
                 engine

--- a/tests/failpoints/util.rs
+++ b/tests/failpoints/util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
 use std::panic::{self, AssertUnwindSafe};
-use std::sync::{mpsc, Arc};
+use std::sync::{Arc, mpsc};
 
 use raft::eraftpb::Entry;
 use raft_engine::env::FileSystem;


### PR DESCRIPTION

<img width="1708" height="612" alt="image" src="https://github.com/user-attachments/assets/958f1d34-32b5-4810-9dd1-93abe81b78cf" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain edition to 2024.
  * Relaxed the serde dependency to the broader 1.0 series.

* **Style**
  * Reordered imports and adjusted public export ordering for consistency.
  * Reflowed formatting and wrapped assertions for readability.

* **Tests / Refactor**
  * Reformatted test assertions and benches without behavior changes.
  * Improved test panic-hook handling to a safer, shared implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->