### PR TITLE
Relax serde version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ protobuf = "2"
 rayon = "1.5"
 rhai = { version = "1.7", features = ["sync"], optional = true }
 scopeguard = "1.1"
-serde = { version = "=1.0.194", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_repr = "0.1"
 strum = { version = "0.26.2", features = ["derive"] }
 thiserror = "1.0"


### PR DESCRIPTION
This relaxes the serde dependency from an exact pin (=1.0.194) to a compatible requirement ("1") to avoid version selection conflicts in downstream workspaces (e.g. when other deps require newer serde via time 0.3.47 / serde_core 1.0.220).

No code changes beyond Cargo.toml dependency requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated serde dependency version constraint to use flexible versioning for improved dependency resolution and cross-environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->