### PR TITLE
Gate lz4-sys behind an optional lz4-compression feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,8 +38,10 @@ jobs:
         run: make clippy
         env:
           WITH_STABLE_TOOLCHAIN: 'force'
-      - name: Build (no default features)
-        run: cargo build --no-default-features --verbose
+      - name: Build and test (no default features)
+        run: |
+          cargo check --no-default-features --all-targets --verbose
+          cargo test --no-default-features --verbose
       - name: Run tests
         run: make test
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,6 +38,8 @@ jobs:
         run: make clippy
         env:
           WITH_STABLE_TOOLCHAIN: 'force'
+      - name: Build (no default features)
+        run: cargo build --no-default-features --verbose
       - name: Run tests
         run: make test
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * Add a new Prometheus metric `raft_engine_write_compression_ratio` to track compression ratio of write #358
+* Gate the `lz4-sys` C FFI dependency behind a new `lz4-compression` Cargo feature (on by default). Consumers who build with `default-features = false` and without `lz4-compression` get a fully pure-Rust build graph; `Config::sanitize` rejects a non-zero `batch-compression-threshold` in that configuration.
 
 ## [0.4.2] - 2024-04-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ log = { version = "0.4", features = [
   "max_level_trace",
   "release_max_level_debug",
 ] }
-lz4-sys = { version = "=1.9.5" }
+lz4-sys = { version = "=1.9.5", optional = true }
 memmap2 = { version = "0.9", optional = true }
 nix = "0.26"
 num-derive = "0.4"
@@ -79,13 +79,19 @@ tempfile = "3.6"
 toml = "0.8"
 
 [features]
-default = ["internals", "scripting"]
+default = ["internals", "scripting", "lz4-compression"]
 internals = []
 nightly = ["prometheus/nightly"]
 failpoints = ["fail/failpoints"]
 scripting = ["rhai"]
 swap = ["nightly", "memmap2"]
 std_fs = []
+# Optional LZ4 compression for log batches via the `lz4-sys` C FFI crate.
+# Default-on preserves historical behavior; disabling it removes the C
+# dependency entirely from the build graph. Callers who disable this
+# feature must set `compression_threshold = 0` in their `Config`, and
+# must not open existing data written with compression enabled.
+lz4-compression = ["dep:lz4-sys"]
 
 nightly_group = ["nightly", "swap"]
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Available Cargo features:
 - `internals`: Re-exports key components internal to Raft Engine. Enabled when building for docs.rs.
 - `failpoints`: Enables fail point testing powered by [tikv/fail-rs](https://github.com/tikv/fail-rs).
 - `swap`: Use `SwappyAllocator` to limit the memory usage of Raft Engine. The memory budget can be configured with "memory-limit". Depending on the `nightly` feature.
+- `lz4-compression` (default): Enables LZ4 compression for log batches via the [`lz4-sys`](https://crates.io/crates/lz4-sys) C FFI crate. Disabling this feature removes the C dependency entirely, producing a pure-Rust build graph. Consumers who disable the feature must set `batch-compression-threshold = 0` in their `Config` (`Config::sanitize` enforces this) and cannot read log files written by a build that had LZ4 compression active — those entries will surface an error on decode.
 
 See some basic use cases under the [examples](https://github.com/tikv/raft-engine/tree/master/examples) directory.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use log::{info, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::pipe_log::Version;
-use crate::{Result, util::ReadableSize};
+use crate::{util::ReadableSize, Result};
 
 const MIN_RECOVERY_READ_BLOCK_SIZE: usize = 512;
 const MIN_RECOVERY_THREADS: usize = 1;
@@ -57,6 +57,13 @@ pub struct Config {
     /// disables compression.
     ///
     /// Default: "8KB"
+    ///
+    /// Note: a non-zero threshold requires the `lz4-compression` Cargo
+    /// feature (on by default). Builds compiled with
+    /// `--no-default-features` and without `lz4-compression` must set
+    /// this to 0 or `Config::sanitize` will reject the configuration.
+    /// Such builds also cannot decode LZ4-compressed entries written by
+    /// other builds.
     pub batch_compression_threshold: ReadableSize,
     /// Acceleration factor for LZ4 compression. It can be fine tuned, with each
     /// successive value providing roughly +~3% to speed. The value will be
@@ -206,6 +213,12 @@ impl Config {
         if self.memory_limit.is_some() {
             warn!("memory-limit will be ignored because swap feature is disabled");
         }
+        #[cfg(not(feature = "lz4-compression"))]
+        if self.batch_compression_threshold.0 > 0 {
+            return Err(box_err!(
+                "batch-compression-threshold must be 0 when the `lz4-compression` Cargo feature is disabled"
+            ));
+        }
         Ok(())
     }
 
@@ -335,6 +348,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "lz4-compression"))]
+    fn test_sanitize_rejects_nonzero_threshold_without_lz4_feature() {
+        let mut cfg = Config::default();
+        cfg.batch_compression_threshold = ReadableSize::kb(8);
+        assert!(cfg.sanitize().is_err());
+        cfg.batch_compression_threshold = ReadableSize(0);
+        assert!(cfg.sanitize().is_ok());
+    }
+
+    #[test]
     fn test_backward_compactibility() {
         // Upgrade from older version.
         let old = r#"
@@ -343,11 +366,9 @@ mod tests {
         let mut load: Config = toml::from_str(old).unwrap();
         load.sanitize().unwrap();
         // Downgrade to older version.
-        assert!(
-            toml::to_string(&load)
-                .unwrap()
-                .contains("tolerate-corrupted-tail-records")
-        );
+        assert!(toml::to_string(&load)
+            .unwrap()
+            .contains("tolerate-corrupted-tail-records"));
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -219,6 +219,17 @@ pub fn unhash_u64(mut i: u64) -> u64 {
     i ^ (i >> 30) ^ (i >> 60)
 }
 
+/// LZ4 compression wrappers used by `LogBatch` encode/decode paths.
+///
+/// When the `lz4-compression` Cargo feature is enabled (the default),
+/// this module exposes real implementations that delegate to the
+/// `lz4-sys` C FFI crate. When the feature is disabled, this module is
+/// replaced by a stub (see below) that preserves the same public surface
+/// but returns clear errors on invocation — callers who disable the
+/// feature must ensure `compression_threshold = 0` in their `Config`
+/// and must not attempt to read on-disk data written by a build with
+/// the feature enabled.
+#[cfg(feature = "lz4-compression")]
 pub mod lz4 {
     use crate::{Error, Result};
     use std::ptr;
@@ -313,6 +324,40 @@ pub mod lz4 {
                 assert_eq!(res, vec[..uncompressed_len].to_owned());
             }
         }
+    }
+}
+
+/// Stub used when the `lz4-compression` Cargo feature is disabled.
+///
+/// Exposes the same public surface as the real `lz4` module so that
+/// call sites in `log_batch.rs` compile under both feature
+/// configurations without any `#[cfg]` plumbing of their own. Any
+/// actual invocation returns a clear error:
+///
+/// - `append_compress_block` is reached only when the caller has
+///   `compression_threshold > 0`; returns `Error::Other` telling the
+///   operator to set the threshold to 0 or rebuild with the feature.
+/// - `decompress_block` is reached only when reading a log entry whose
+///   header declares `CompressionType::Lz4`; returns `Error::Corruption`
+///   because, from the reader's perspective, the data cannot be
+///   interpreted by this build.
+#[cfg(not(feature = "lz4-compression"))]
+pub mod lz4 {
+    use crate::{Error, Result};
+
+    pub const DEFAULT_LZ4_COMPRESSION_LEVEL: usize = 1;
+
+    pub fn append_compress_block(_buf: &mut Vec<u8>, _skip: usize, _level: usize) -> Result<f64> {
+        Err(Error::Other(box_err!(
+            "lz4 compression requested but the `lz4-compression` Cargo feature is disabled; \
+             rebuild with `--features lz4-compression` or set `compression_threshold = 0` in Config"
+        )))
+    }
+
+    pub fn decompress_block(_src: &[u8]) -> Result<Vec<u8>> {
+        Err(Error::Corruption(
+            "encountered LZ4-compressed log entry but the `lz4-compression` Cargo feature is disabled".into(),
+        ))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -219,6 +219,11 @@ pub fn unhash_u64(mut i: u64) -> u64 {
     i ^ (i >> 30) ^ (i >> 60)
 }
 
+/// Default LZ4 acceleration factor exposed under both feature arms so
+/// that downstream call sites (and `Config::compression_level`) compile
+/// identically with or without the `lz4-compression` Cargo feature.
+pub const DEFAULT_LZ4_COMPRESSION_LEVEL: usize = 1;
+
 /// LZ4 compression wrappers used by `LogBatch` encode/decode paths.
 ///
 /// When the `lz4-compression` Cargo feature is enabled (the default),
@@ -234,7 +239,7 @@ pub mod lz4 {
     use crate::{Error, Result};
     use std::ptr;
 
-    pub const DEFAULT_LZ4_COMPRESSION_LEVEL: usize = 1;
+    pub use super::DEFAULT_LZ4_COMPRESSION_LEVEL;
 
     /// Compress content in `buf[skip..]`, and append output to `buf`.
     pub fn append_compress_block(buf: &mut Vec<u8>, skip: usize, level: usize) -> Result<f64> {
@@ -335,17 +340,19 @@ pub mod lz4 {
 /// actual invocation returns a clear error:
 ///
 /// - `append_compress_block` is reached only when the caller has
-///   `compression_threshold > 0`; returns `Error::Other` telling the
-///   operator to set the threshold to 0 or rebuild with the feature.
-/// - `decompress_block` is reached only when reading a log entry whose
-///   header declares `CompressionType::Lz4`; returns `Error::Corruption`
-///   because, from the reader's perspective, the data cannot be
-///   interpreted by this build.
+///   `compression_threshold > 0`; `Config::sanitize` already rejects
+///   that combination, so this path is defensive and returns
+///   `Error::Other` if ever reached.
+/// - `decompress_block` is reached when reading a log entry whose
+///   header declares `CompressionType::Lz4`. The data is not
+///   corrupt — this build simply cannot decode it — so the stub
+///   returns `Error::Other` naming the feature flag rather than
+///   `Error::Corruption`, which operators read as disk damage.
 #[cfg(not(feature = "lz4-compression"))]
 pub mod lz4 {
     use crate::{Error, Result};
 
-    pub const DEFAULT_LZ4_COMPRESSION_LEVEL: usize = 1;
+    pub use super::DEFAULT_LZ4_COMPRESSION_LEVEL;
 
     pub fn append_compress_block(_buf: &mut Vec<u8>, _skip: usize, _level: usize) -> Result<f64> {
         Err(Error::Other(box_err!(
@@ -355,9 +362,10 @@ pub mod lz4 {
     }
 
     pub fn decompress_block(_src: &[u8]) -> Result<Vec<u8>> {
-        Err(Error::Corruption(
-            "encountered LZ4-compressed log entry but the `lz4-compression` Cargo feature is disabled".into(),
-        ))
+        Err(Error::Other(box_err!(
+            "encountered LZ4-compressed log entry but the `lz4-compression` Cargo feature is disabled; \
+             rebuild with `--features lz4-compression` to read data written with compression enabled"
+        )))
     }
 }
 


### PR DESCRIPTION
## Summary

Make the `lz4-sys` C FFI crate optional behind a new `lz4-compression` Cargo feature (default-on). Consumers who build with `default-features = false` and without `lz4-compression` get a pure-Rust build graph with `lz4-sys` fully absent; existing consumers on defaults see zero behavior change.

## Motivation

Projects with a strict pure-Rust policy (no C dependencies in the build graph) currently cannot consume `raft-engine` at all because `lz4-sys = "=1.9.5"` is unconditional. Making the C dep opt-in-by-default removes that adoption blocker without affecting anyone who stays on defaults.

## Changes

- `Cargo.toml`: `lz4-sys` marked `optional = true`; new feature `lz4-compression = ["dep:lz4-sys"]`; `default = ["internals", "scripting", "lz4-compression"]` preserves existing BC.
- `src/util.rs`: `pub mod lz4` split into two `#[cfg]`-gated variants with identical public surface (`DEFAULT_LZ4_COMPRESSION_LEVEL`, `append_compress_block`, `decompress_block`). Real implementation behind `#[cfg(feature = "lz4-compression")]`. Stub under `#[cfg(not(...))]` returns `Error::Other` with a message naming the feature flag. Call sites in `src/log_batch.rs` compile unchanged under both arms.
- `src/config.rs`: `Config::sanitize` rejects `batch_compression_threshold > 0` when the feature is off, matching the existing reject patterns for `enable_log_recycle`/`prefill_for_recycle`. Rustdoc on `batch_compression_threshold` spells out the constraint. New unit test covers both reject and accept paths.
- `CHANGELOG.md` + `README.md`: entry under `[Unreleased]` and a line in the "Available Cargo features" list.
- `.github/workflows/rust.yml`: new `cargo build --no-default-features --verbose` step in the stable job to regression-guard the feature gate.

## Operator contract

Callers who disable the feature:

- MUST set `batch-compression-threshold = 0` in `Config` (enforced by `sanitize`).
- CANNOT decode log files written by a build that had LZ4 compression active — those entries surface `Error::Other` on read, naming the feature flag.

## Test plan

- [x] `cargo check --lib` passes (0 errors).
- [x] `cargo check --lib --no-default-features` passes (0 errors).
- [x] `cargo tree --no-default-features --edges no-dev | grep lz4` → empty.
- [x] `cargo tree --edges no-dev | grep lz4` → `lz4-sys v1.9.5` still present (defaults unchanged).
- [x] Build verification covered in CI by the new `--no-default-features` step.
- [x] Adversarial review by an outside Rust reviewer: two rounds (REVISE → APPROVE_WITH_NITS). Both rounds' feedback folded in.

## Pre-existing warning flagged in review

The new CI step will surface a pre-existing `warning: Patch cc v1.0.98 ... was not used in the crate graph.` This is the `[patch.crates-io] cc = { ... tag = "1.0.98" }` pin added for [rust-lang/cc-rs#984](https://github.com/rust-lang/cc-rs/issues/984), which no longer matches the resolved `cc 1.2.61` in the lockfile. The warning is orthogonal to this change and predates it — left as a follow-up since the original #984 workaround should be re-evaluated on its own merits rather than bundled into a feature-gate patch.

## Background

Part of the [humancto/mango](https://github.com/humancto/mango) project's adoption of `raft-engine` as its WAL. Tracking the fork's retirement against this upstream PR's merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional, default-enabled LZ4 compression feature that toggles native compression; builds without it remain usable but will error if compression is requested or compressed data is encountered.

* **Documentation**
  * Updated README and CHANGELOG with feature behavior, compatibility notes, and required configuration when disabling compression.

* **Chores**
  * CI now runs an additional build-and-test step with default features disabled.

* **Tests**
  * Added tests validating configuration rejection when compression is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->