### PR TITLE
memtable: Shrink sparse raft-engine memtable entry index buffers more proactively after compaction. 

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -2616,7 +2616,7 @@ pub(crate) mod tests {
             assert!(data.remove(&rid), "{}", rid);
             assert_eq!(engine.get(rid, &key).unwrap(), value);
         }
-        assert!(data.is_empty(), "data loss {:?}", data);
+        assert!(data.is_empty(), "data loss {data:?}");
     }
 
     #[test]

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -111,7 +111,7 @@ impl<F: FileSystem> LogFileWriter<F> {
             self.writer
                 .seek(SeekFrom::Start(self.written as u64))
                 .unwrap_or_else(|e| {
-                    panic!("failed to reseek after write failure: {}", e);
+                    panic!("failed to reseek after write failure: {e}");
                 });
         })?;
         self.written = new_written;

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1741,7 +1741,7 @@ mod tests {
         let capacity_before = memtable.entry_indexes.capacity();
         assert_eq!(capacity_before, CAPACITY_SHRINK_THRESHOLD);
 
-        assert_eq!(memtable.compact_to(next - 40), (next - 40) as u64);
+        assert_eq!(memtable.compact_to(next - 40), next - 40);
         assert_eq!(memtable.entry_indexes.len(), 40);
         assert_eq!(memtable.entry_indexes.capacity(), capacity_before);
         memtable.consistency_check();

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -66,8 +66,12 @@ mod swap_conditional_imports {
 
 use swap_conditional_imports::*;
 
-/// Attempt to shrink entry container if its capacity reaches the threshold.
-const CAPACITY_SHRINK_THRESHOLD: usize = 1024 - 1;
+/// Consider shrinking entry container once it grows past this size.
+const CAPACITY_SHRINK_THRESHOLD: usize = 128 - 1;
+/// Shrink only when live entries use at most half of the allocated slots.
+const CAPACITY_SHRINK_UTILIZATION_FACTOR: usize = 2;
+/// Skip tiny reallocations that would recover very little memory.
+const CAPACITY_SHRINK_MIN_RECLAIM: usize = 64 - 1;
 const CAPACITY_INIT: usize = 32 - 1;
 /// Number of hash table to store [`MemTable`].
 const MEMTABLE_SLOT_COUNT: usize = 128;
@@ -620,9 +624,19 @@ impl<A: AllocatorTrait> MemTable<A> {
 
     #[inline]
     fn maybe_shrink_entry_indexes(&mut self) {
-        if self.entry_indexes.capacity() >= CAPACITY_SHRINK_THRESHOLD {
-            self.entry_indexes.shrink_to_fit();
+        let len = self.entry_indexes.len();
+        let capacity = self.entry_indexes.capacity();
+        let target = std::cmp::max(len.saturating_add(CAPACITY_INIT), CAPACITY_INIT);
+        if capacity < CAPACITY_SHRINK_THRESHOLD
+            || len.saturating_mul(CAPACITY_SHRINK_UTILIZATION_FACTOR) > capacity
+            || capacity <= target.saturating_add(CAPACITY_SHRINK_MIN_RECLAIM)
+        {
+            return;
         }
+
+        // Keep one initial-sized window of slack so a freshly compacted table
+        // does not immediately regrow on the next small append burst.
+        self.entry_indexes.shrink_to(target);
     }
 
     /// Pulls all entries between log index `begin` and `end` to the given
@@ -1663,6 +1677,106 @@ mod tests {
         assert_eq!(memtable.entries_size(), 5);
         assert_eq!(memtable.first_index().unwrap(), 20);
         assert_eq!(memtable.last_index().unwrap(), 24);
+        memtable.consistency_check();
+    }
+
+    #[test]
+    fn test_memtable_compact_shrinks_sparse_entry_indexes() {
+        let region_id = 8;
+        let mut memtable = MemTable::new(region_id, Arc::new(GlobalStats::default()));
+
+        memtable.append(generate_entry_indexes(
+            0,
+            600,
+            FileId::new(LogQueue::Append, 1),
+        ));
+        let capacity_before = memtable.entry_indexes.capacity();
+        assert!(capacity_before >= CAPACITY_SHRINK_THRESHOLD);
+
+        assert_eq!(memtable.compact_to(584), 584);
+        assert_eq!(memtable.entry_indexes.len(), 16);
+        assert_eq!(memtable.first_index().unwrap(), 584);
+
+        let capacity_after = memtable.entry_indexes.capacity();
+        assert!(capacity_after < capacity_before);
+        assert!(capacity_after >= memtable.entry_indexes.len());
+        assert!(capacity_after >= memtable.entry_indexes.len().saturating_add(CAPACITY_INIT));
+        memtable.consistency_check();
+    }
+
+    #[test]
+    fn test_memtable_compact_keeps_busy_entry_indexes_capacity() {
+        let region_id = 8;
+        let mut memtable = MemTable::new(region_id, Arc::new(GlobalStats::default()));
+
+        memtable.append(generate_entry_indexes(
+            0,
+            600,
+            FileId::new(LogQueue::Append, 1),
+        ));
+        let capacity_before = memtable.entry_indexes.capacity();
+        assert!(capacity_before >= CAPACITY_SHRINK_THRESHOLD);
+
+        assert_eq!(memtable.compact_to(80), 80);
+        assert_eq!(memtable.entry_indexes.len(), 520);
+        assert_eq!(memtable.entry_indexes.capacity(), capacity_before);
+        memtable.consistency_check();
+    }
+
+    #[test]
+    fn test_memtable_compact_keeps_capacity_when_reclaim_is_too_small() {
+        let region_id = 8;
+        let mut memtable = MemTable::new(region_id, Arc::new(GlobalStats::default()));
+        let mut next = 0;
+
+        while memtable.entry_indexes.capacity() < CAPACITY_SHRINK_THRESHOLD {
+            memtable.append(generate_entry_indexes(
+                next,
+                next + 1,
+                FileId::new(LogQueue::Append, 1),
+            ));
+            next += 1;
+        }
+
+        let capacity_before = memtable.entry_indexes.capacity();
+        assert_eq!(capacity_before, CAPACITY_SHRINK_THRESHOLD);
+
+        assert_eq!(memtable.compact_to(next - 40), (next - 40) as u64);
+        assert_eq!(memtable.entry_indexes.len(), 40);
+        assert_eq!(memtable.entry_indexes.capacity(), capacity_before);
+        memtable.consistency_check();
+    }
+
+    #[test]
+    fn test_memtable_append_after_compact_shrink_keeps_span_consistent() {
+        let region_id = 8;
+        let mut memtable = MemTable::new(region_id, Arc::new(GlobalStats::default()));
+
+        memtable.append(generate_entry_indexes(
+            0,
+            600,
+            FileId::new(LogQueue::Append, 1),
+        ));
+        assert_eq!(memtable.compact_to(584), 584);
+        let capacity_after_compact = memtable.entry_indexes.capacity();
+
+        memtable.append(generate_entry_indexes(
+            600,
+            620,
+            FileId::new(LogQueue::Append, 2),
+        ));
+
+        let mut ents_idx = vec![];
+        memtable
+            .fetch_entries_to(584, 620, None, &mut ents_idx)
+            .unwrap();
+        assert_eq!(memtable.first_index(), Some(584));
+        assert_eq!(memtable.last_index(), Some(619));
+        assert_eq!(ents_idx.len(), 36);
+        assert_eq!(ents_idx[0].index, 584);
+        assert_eq!(ents_idx.last().unwrap().index, 619);
+        assert_eq!(memtable.global_stats.live_entries(LogQueue::Append), 36);
+        assert!(memtable.entry_indexes.capacity() >= capacity_after_compact);
         memtable.consistency_check();
     }
 

--- a/src/memtable.rs
+++ b/src/memtable.rs
@@ -1729,7 +1729,13 @@ mod tests {
         let mut memtable = MemTable::new(region_id, Arc::new(GlobalStats::default()));
         let mut next = 0;
 
-        while memtable.entry_indexes.capacity() < CAPACITY_SHRINK_THRESHOLD {
+        while memtable.entry_indexes.capacity() < CAPACITY_SHRINK_THRESHOLD
+            || memtable.entry_indexes.len()
+                <= memtable
+                    .entry_indexes
+                    .capacity()
+                    .saturating_sub(CAPACITY_INIT + CAPACITY_SHRINK_MIN_RECLAIM)
+        {
             memtable.append(generate_entry_indexes(
                 next,
                 next + 1,
@@ -1739,10 +1745,14 @@ mod tests {
         }
 
         let capacity_before = memtable.entry_indexes.capacity();
-        assert_eq!(capacity_before, CAPACITY_SHRINK_THRESHOLD);
+        let retained = capacity_before - (CAPACITY_INIT + CAPACITY_SHRINK_MIN_RECLAIM);
+        assert!(capacity_before >= CAPACITY_SHRINK_THRESHOLD);
+        assert!(retained > 0);
+        assert!(retained < memtable.entry_indexes.len());
 
-        assert_eq!(memtable.compact_to(next - 40), next - 40);
-        assert_eq!(memtable.entry_indexes.len(), 40);
+        let compact_to = next - retained as u64;
+        assert_eq!(memtable.compact_to(compact_to), compact_to);
+        assert_eq!(memtable.entry_indexes.len(), retained);
         assert_eq!(memtable.entry_indexes.capacity(), capacity_before);
         memtable.consistency_check();
     }


### PR DESCRIPTION
## Problem

Close https://github.com/tikv/tikv/issues/19544

`raft-engine` memtable memory can grow slowly over time even when workload and region count stay relatively stable.

A notable source is `MemTable::entry_indexes`: after entries are compacted away, the underlying deque may continue to retain a large amount of spare capacity. The previous shrink policy only triggered once capacity grew beyond `1023`, and when triggered it used `shrink_to_fit()`, which was coarse and could still leave room for improvement in long-running stable clusters.

## Solution

This PR makes entry index shrinking more proactive, but keeps it conservative enough to avoid unnecessary capacity churn.

The new policy still only runs after `compact_to()`, and shrinks `entry_indexes` only when all of the following are true:
- the buffer has grown past a minimum capacity threshold;
- live entries occupy at most 50% of the allocated slots;
- shrinking would reclaim a meaningful amount of memory.

Instead of shrinking all the way down to `len`, the new logic keeps a small headroom window (`len + CAPACITY_INIT`) so a freshly compacted memtable does not immediately regrow on the next small append burst.

In short, this change targets long-lived sparse memtables while avoiding a simple “lower the threshold and always shrink harder” strategy.

## Why this should not introduce a meaningful performance regression

The new logic does not run on the append hot path. It is only evaluated after `compact_to()`, and the fast path is just a few integer checks.

Actual reallocations become possible earlier than before, but only for clearly sparse memtables. The added utilization gate, minimum reclaim gate, and retained headroom together are intended to avoid frequent shrink/regrow oscillation.

This means the tradeoff is:
- slightly more compact-side realloc opportunities in sparse cases;
- noticeably better reclamation of long-lived unused entry index capacity.

Given that the logic stays off the append hot path and avoids `shrink_to_fit()` churn, the risk of a meaningful performance regression is low.

## Validation

Added targeted regression tests in `src/memtable.rs`:

1. `test_memtable_compact_shrinks_sparse_entry_indexes`
- Verifies that a sparse memtable actually shrinks after compaction.
- Also verifies the new policy keeps headroom instead of shrinking all the way to `len`.

2. `test_memtable_compact_keeps_busy_entry_indexes_capacity`
- Verifies that a still-busy memtable does not shrink just because compaction happened.

3. `test_memtable_compact_keeps_capacity_when_reclaim_is_too_small`
- Verifies that the deque is not shrunk when the reclaimable space is too small to justify a reallocation.

4. `test_memtable_append_after_compact_shrink_keeps_span_consistent`
- Verifies span, fetch, and live entry accounting remain correct after a shrink followed by new appends.

Build validation:
- `cargo +nightly-2025-04-03 fmt --all --check`
- `cargo +nightly-2025-04-03 check --lib`
- `cargo +nightly-2025-04-03 check --lib --no-default-features --features internals`

Note: full `cargo test` is currently blocked in this environment by the existing Darwin/arm64 `grpcio-sys` toolchain issue rather than by this patch itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revised container shrinking to use utilization-aware capacity planning, making memory reclamation more aggressive while preserving a slack window to avoid frequent resizes.

* **Tests**
  * Added tests for sparse-shrink, high-utilization (no shrink), minimal-reclaim (skip shrink), and post-shrink correctness with subsequent appends.

* **Style**
  * Minor diagnostic message formatting tweaks for clearer error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->