### PR TITLE
fix: set close-on-exec on log file descriptors

### DIFF
--- a/src/env/log_fd/unix.rs
+++ b/src/env/log_fd/unix.rs
@@ -41,11 +41,11 @@ pub struct LogFd(RawFd);
 impl LogFd {
     /// Opens a file with the given `path`.
     pub fn open<P: ?Sized + NixPath>(path: &P, perm: Permission) -> IoResult<Self> {
+        let flags = OFlag::from(perm) | OFlag::O_CLOEXEC;
         // Permission 644
         let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
         fail_point!("log_fd::open::fadvise_dontneed", |_| {
-            let fd =
-                LogFd(fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?);
+            let fd = LogFd(fcntl::open(path, flags, mode).map_err(|e| from_nix_error(e, "open"))?);
             #[cfg(target_os = "linux")]
             unsafe {
                 extern crate libc;
@@ -54,14 +54,14 @@ impl LogFd {
             Ok(fd)
         });
         Ok(LogFd(
-            fcntl::open(path, perm.into(), mode).map_err(|e| from_nix_error(e, "open"))?,
+            fcntl::open(path, flags, mode).map_err(|e| from_nix_error(e, "open"))?,
         ))
     }
 
     /// Opens a file with the given `path`. The specified file will be created
     /// first if not exists.
     pub fn create<P: ?Sized + NixPath>(path: &P) -> IoResult<Self> {
-        let flags = OFlag::O_RDWR | OFlag::O_CREAT;
+        let flags = OFlag::O_RDWR | OFlag::O_CREAT | OFlag::O_CLOEXEC;
         // Permission 644
         let mode = Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP | Mode::S_IROTH;
         let fd = fcntl::open(path, flags, mode).map_err(|e| from_nix_error(e, "open"))?;


### PR DESCRIPTION
## What changed

Set `O_CLOEXEC` when opening and creating log files in the default
Unix backend.

Without this flag, applications embedding Raft Engine can leak log file
descriptors into spawned child processes. Those children may keep purged
files alive after unlinking, preventing disk space from being reclaimed.

The flag is applied at open time to avoid the fork/exec race in
multithreaded applications.

Fixes #404

## Tests

- `cargo fmt --check`
- `cargo check --lib`

The full test suite was not run locally because the bundled `grpcio-sys`
dependency fails to build on ARM macOS. GitHub Actions runs it on Ubuntu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file descriptor handling to ensure log files are automatically closed when executing other programs.
  * Applied consistent close-on-exec behavior when opening and creating log files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->